### PR TITLE
Possible comparison bug?

### DIFF
--- a/client/app/src/shapeshift/lib/shapeshift-api.js
+++ b/client/app/src/shapeshift/lib/shapeshift-api.js
@@ -277,9 +277,9 @@ var ShapeShift = (function() {
     function CancelPendingValidate(data, ss) {
         if(typeof(data) === 'object') return data;
         if(data.address === undefined) throw new Error('no address given');
-        if(typeof(data) === 'String') {
+        if(typeof(data) === 'string') {
             var address = data;
-            data = { address : address }
+            data = { address : address };
         }
         if(ss.apiKey) data.apiKey = ss.apiPubKey;
         return data;


### PR DESCRIPTION
According to docs: The typeof operator returns type information as a string. There are six possible values that typeof returns: "number," "string," "boolean," "object," "function," and "undefined.".
In the code - the comparission is done with 'String'  not 'string'. If data is object, new String('123'), then already first if gets executed, as typeof returns 'object'