### PR TITLE
fixing typo in deb synopsis and improving documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ If you login to your account (with your passphrase)
 
 Second signature supported. Multisignature accounts not yet supported.
 
-## Screenshot
-Soon
+## Screenshots
+![linux](http://i.imgur.com/P9TTXyY.png)
+![linux](http://i.imgur.com/CQ4ms4H.png)
 
 ## From code
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "iconUrl": "https://ark.io/i/mediakit/icon_1.png"
     },
     "linux": {
-      "synopsis": "A Lite Arl Client to securely connect to the Ark network and manage your Ark assets.",
+      "synopsis": "A Lite Client used to securely connect to the Ark network and manage your Ark assets.",
       "description": ""
     }
   }


### PR DESCRIPTION
Fixes a typo in the Linux deb synopsis. Screenshots adding some eye-candy.