### PR TITLE
Delegate username case sensitivity

### DIFF
--- a/client/app/src/accounts/AccountService.js
+++ b/client/app/src/accounts/AccountService.js
@@ -302,6 +302,7 @@
         deferred.reject("No Username");
         return deferred.promise;
       }
+      username = username.toLowerCase();
       networkService.getFromPeer("/api/delegates/get/?username="+username).then(function (resp) {
         if(resp && resp.success && resp.delegate){
           storageService.set("delegate-"+resp.delegate.address,resp.delegate);


### PR DESCRIPTION
Some delegates like to advertise their username with uppercases and therefore it is not accepted. This will fix it.