### PR TITLE
remove about application menu item

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,8 +25,6 @@ function createWindow () {
     {
       label: "Application",
       submenu: [
-        { label: "About Application", selector: "orderFrontStandardAboutPanel:" },
-        { type: "separator" },
         { label: "Disable screenshot protection (unsafe)", click: function() { mainWindow.setContentProtection(false) }},
         { type: "separator" },
         { label: "Minimize", click: function() { mainWindow.minimize(); }},


### PR DESCRIPTION
Removes the non-functional "About Application" menu item.

https://github.com/ArkEcosystem/ark-desktop/issues/81

![screenshot from 2017-06-02 00 13 30](https://cloud.githubusercontent.com/assets/211871/26715349/40708a9c-472a-11e7-8f1d-40653bc73f6f.png)
