### PR TITLE
Network Management Improvements

### DIFF
--- a/client/app/src/accounts/AccountController.js
+++ b/client/app/src/accounts/AccountController.js
@@ -1109,30 +1109,49 @@
       var networks=networkService.getNetworks();
 
       function save() {
-        $mdDialog.hide();
+        //these are not needed as the createNetwork now rerender automatically
+        //$mdDialog.hide();
         for(var network in $scope.send.networks){
           networkService.setNetwork(network, $scope.send.networks[network]);
         }
-        window.location.reload();
+        //window.location.reload();
       };
 
       function cancel() {
         $mdDialog.hide();
       };
 
+      function refreshTabs()
+      {
+          //reload networks
+          networks=networkService.getNetworks();
+          //add it back to the scope
+          $scope.send.networkKeys = Object.keys(networks);
+          $scope.send.networks = networks;
+          //tell angular that the list changed
+          $scope.$apply();
+      }
+
       function createNetwork() {
         networkService.createNetwork($scope.send.createnetwork).then(
           function(network){
-
+            refreshTabs();
           },
           formatAndToastError
         );
       };
 
+      function removeNetwork(network)
+      {
+        networkService.removeNetwork(network);
+        refreshTabs();
+      }
+
       $scope.send = {
         networkKeys: Object.keys(networks),
         networks: networks,
         createNetwork: createNetwork,
+        removeNetwork: removeNetwork,
         cancel: cancel,
         save: save
       };

--- a/client/app/src/accounts/view/manageNetwork.html
+++ b/client/app/src/accounts/view/manageNetwork.html
@@ -41,7 +41,7 @@
             <label translate>Explorer</label>
             <input ng-model="send.networks[network].explorer" type="text" ng-required="false">
           </md-input-container>
-          <!-- <md-button class="md-primary md-raised" ng-click="removeTab( tab )" ng-disabled="tabs.length <= 1">Remove Tab</md-button> -->
+          <md-button class="md-primary md-raised" ng-click="send.removeNetwork(network)" ng-disabled="network =='mainnet' || network == 'testnet'"><translate>Remove</translate></md-button>
         </div>
       </md-tab>
 


### PR DESCRIPTION
I've improved the "Manage Networks" functions.
If you add a new network, you don't need to re-render the full page, instead it is now adding just a new tab without even reload the modal. 
Also #126 is implemented. You now have the possibility to delete your own added networks. here is also no re-rendering needed as it updates "live"