### PR TITLE
Refactored language picker to a more usable pattern than "skipping to the next"

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -52,9 +52,6 @@
             <md-menu-content flex layout-padding width="6">
                 <md-list>
                   <md-list-item>
-                    <b translate>Language</b> <md-button class="md-secondary" aria-label="Change Language" md-prevent-menu-close ng-click="ul.selectNextLanguage()">{{ul.getLanguage()}}</md-button>
-                  </md-list-item>
-                  <md-list-item>
                     <md-button aria-label="Import Account" ng-click="ul.importAccount()"><translate>Import Account</translate></md-button>
                     <md-button aria-label="Create Account" ng-click="ul.createAccount()"><translate>Create Account</translate></md-button>
                   </md-list-item>
@@ -126,7 +123,16 @@
                </md-list>
            </md-menu-content>
          </md-menu>
-
+         <md-menu>
+           <md-button aria-label="Language" ng-click="$mdMenu.open()">
+             <md-icon md-font-library="material-icons">language</md-icon>
+           </md-button>
+           <md-menu-content flex layout-padding width="4">
+             <md-menu-item ng-repeat="(key,item) in ul.getLanguages()">
+               <md-button ng-class="{'md-primary': key===ul.language}" ng-click="ul.selectLanguage(key)">{{item}}</md-button>
+             </md-menu-item>
+           </md-menu-content>
+         </md-menu>
          <md-menu>
            <md-button aria-label="Application State" ng-click="ul.openMenu($mdOpenMenu, $event)">
              <md-icon md-font-library="material-icons">power_settings_new</md-icon>

--- a/client/app/src/accounts/AccountController.js
+++ b/client/app/src/accounts/AccountController.js
@@ -158,7 +158,6 @@
     self.vote  = vote;
     self.addDelegate = addDelegate;
     self.showAccountMenu  = showAccountMenu;
-    self.selectNextLanguage = selectNextLanguage;
     self.currency = storageService.get("currency") || {name:"btc",symbol:"Ƀ"};
     self.switchNetwork = networkService.switchNetwork;
     self.network = networkService.getNetwork();
@@ -246,6 +245,18 @@
           .hideDelay(5000)
       );
     }
+
+    self.getLanguages = function() {
+      return languages;
+    };
+
+    self.selectLanguage= function(which) {
+      if (typeof(languages[which]) !== 'undefined') {
+        self.language = which;
+        storageService.set("language",self.language);
+        gettextCatalog.setCurrentLanguage(self.language);
+      }
+    };
 
     function selectNextLanguage(){
       var lkeys=Object.keys(languages);


### PR DESCRIPTION
Hello, 

I've noticed that the current version of the wallet just cycles through all possible languages.

I think the approach proposed in this pull request is a bit better in term of User Experience.

As you can see in the screenshot below, I've created a new menu which opens the all available languages in a Dropdown. Current active language is highlighted. (English in the screenshot)
![image](https://user-images.githubusercontent.com/200523/26977878-bb8b2a8e-4d29-11e7-85bf-c0e4a2ecda89.png)

Cheers :)
