### PR TITLE
Added Pagination to Transaction List

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -444,7 +444,7 @@
                       </tr>
                     </thead>
                     <tbody md-body style="white-space:nowrap;">
-                      <tr md-row md-select="transaction" md-select-id="id" md-auto-select ng-repeat="it in ul.selected.transactions | orderBy: query.order">
+                      <tr md-row md-select="transaction" md-select-id="id" md-auto-select ng-repeat="it in ul.selected.transactions | orderBy: query.order | limitTo: query.limit : (query.page -1) * query.limit">
                         <td md-cell><a href="" ng-click="ul.openExplorer('/tx/'+it.id)">{{it.id | smallId}}</a></td>
                         <td md-cell>{{it.confirmations}}</td>
                         <td md-cell>{{it.date | date: 'short'}}</td>
@@ -457,8 +457,9 @@
                       </tr>
                     </tbody>
                   </table>
+                  <md-table-pagination ng-init="query.limit=10; query.page=1" md-limit="query.limit"md-limit-options="[10, 25, 50]" md-page="query.page" md-total="{{ul.selected.transactions.length}}" md-page-select="true"></md-table-pagination>
                 </md-table-container>
-            </md-tab>
+              </md-tab>
 
           <md-tab>
             <md-tab-label>


### PR DESCRIPTION
just another small one which solves #49 and also may do a temporary tricky fix to #101 because the scrollbar is'nt so much down in default.
@fix @Doweig the API-Limit is set to 50 Transactions per Request. It may be useful to increase it a bit. If the Limit will be increased, the pagination is definetly a bit more usefull ;-) 

Screenshot:
![pagination_transaction](https://user-images.githubusercontent.com/29228937/28073788-1ddec4de-6657-11e7-8eb3-aee033310b0d.png)
