### PR TITLE
Remove deprecated 'electron-prebuilt'

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "~0.5.0",
-    "electron-prebuilt": "^1.4.13",
     "electron-rebuild": "^1.5.11"
   },
   "build": {


### PR DESCRIPTION
Fixes macOS build issues.
# 
macOS >= 10.12.0 would not ```npm run start``` after ```npm install```.
Throwing error: 
```bash
> ArkClient@1.3.0 start /Users/.../github/ark-desktop
> electron main.js

App threw an error during load
Error: Module version mismatch. Expected 50, got 53.
    at Error (native)
    at process.module.(anonymous function) [as dlopen] (ELECTRON_ASAR.js:173:20)
    at Object.Module._extensions..node (module.js:583:18)
    at Object.module.(anonymous function) [as .node] (ELECTRON_ASAR.js:173:20)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/.../github/ark-desktop/node_modules/node-hid/nodehid.js:9:15)
```
# 

After removing deprecated dependency,  
```npm run start``` launches ark-desktop as expected.

# 

# Reference
Empy package:
https://www.npmjs.com/package/electron-prebuilt

"The `electron` package name on npm"
https://github.com/electron-userland/electron-prebuilt/issues/160

"deprecation: electron-prebuilt has been renamed to electron"
https://github.com/egoist/vuepack/issues/51

