### PR TITLE
Remove X from home screen

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -163,9 +163,6 @@
                <md-button class="share" md-no-ink ng-click="ul.refreshAccountBalances()" aria-label="Refresh balances">
                  <md-icon md-font-library="material-icons">cached</md-icon>
                </md-button>
-               <md-button class="share" md-no-ink ng-click="ul.selected=ul.accounts[0]" aria-label="Switch off dashboard">
-                 <md-icon md-font-library="material-icons">close</md-icon>
-               </md-button>
              </md-toolbar>
              <md-list md-no-ink>
                <md-list-item ng-click="ul.selectAccount(it)" ng-repeat="it in ul.myAccounts() track by $index">


### PR DESCRIPTION
The "X" in the home screen was misleading as clicking it brought you to the first account listed instead of actually removing anything.
