### PR TITLE
Plugin Loader

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -1001,6 +1001,7 @@
   <script src="src/accounts/AccountService.js"></script>
   <script src="src/accounts/AccountController.js"></script>
   <script src="src/network/NetworkService.js"></script>
+  <script src="src/plugin/pluginLoader.js"></script>
   <script src="src/changer/ChangerService.js"></script>
   <script src="src/ledger/LedgerService.js"></script>
   <script src="src/directives.js"></script>

--- a/client/app/src/accounts/AccountController.js
+++ b/client/app/src/accounts/AccountController.js
@@ -3,6 +3,7 @@
     .module('arkclient')
     .controller('AccountController', [
       'accountService',
+      'pluginLoader',
       'networkService',
       'storageService',
       'changerService',
@@ -90,7 +91,7 @@
    * @param avatarsService
    * @constructor
    */
-  function AccountController(accountService, networkService, storageService, changerService, ledgerService, $mdToast, $mdSidenav, $mdBottomSheet, $timeout, $interval, $log, $mdDialog, $scope, $mdMedia, gettextCatalog, $mdTheming, $mdThemingProvider) {
+  function AccountController(accountService, pluginLoader, networkService, storageService, changerService, ledgerService, $mdToast, $mdSidenav, $mdBottomSheet, $timeout, $interval, $log, $mdDialog, $scope, $mdMedia, gettextCatalog, $mdTheming, $mdThemingProvider) {
     var self = this;
 
     var languages = {
@@ -112,6 +113,7 @@
       id: gettextCatalog.getString("Indonesian"),
       ru: gettextCatalog.getString("Russian")
     };
+    pluginLoader.triggerEvent("onStart");
 
 
     gettextCatalog.debug = false;
@@ -778,7 +780,7 @@
     function selectAccount(account) {
       var currentaddress = account.address;
       self.selected = accountService.getAccount(currentaddress);
-
+      pluginLoader.triggerEvent("onSelectAccount", self.selected);
       self.showPublicKey = false;
 
       loadSignedMessages();

--- a/client/app/src/plugin/pluginLoader.js
+++ b/client/app/src/plugin/pluginLoader.js
@@ -1,0 +1,71 @@
+(function() {
+  'use strict';
+
+  angular.module('arkclient')
+    .service('pluginLoader', ['accountService', PluginLoader]);
+
+  /**
+   * pluginLoader
+   * @constructor
+   */
+  function PluginLoader(accountService) {
+
+    var self = this;
+    var fs = require('fs')
+    var plugins = getDirectories("./plugins")
+    
+    self.plugincontent = {}
+    
+    //load all plugin configurations
+    plugins.forEach(function(element) {
+        var conf = JSON.parse(readFile("./plugins/"+element+"/plugin.conf"));
+        self.plugincontent[element] = conf;
+    }, this);
+    
+    //on event
+    self.triggerEvent = function(eventname)
+    {
+        //parse arguments and prepare for sending
+        var sendargs = "";
+        for(var arg = 1; arg < arguments.length; ++ arg)
+        {
+            if(sendargs != "")
+            {
+                sendargs = sendargs +","+ JSON.stringify(arguments[arg]);
+            }
+            else
+            {
+                sendargs = JSON.stringify(arguments[arg]);
+            }
+        }
+        //make callback function available for plugin
+        function triggerEvent(eventname)
+        {
+            if(eventname == "getLocalAccount")
+            {
+                return accountService.getAccount(arguments[1]);
+            }
+        }
+        //iterate over all plugins
+        plugins.forEach(function(element) {
+            //if plugin has event defined in configuration
+            if(self.plugincontent[element]["events"][eventname])
+            {
+                //read its javascript file
+                var js = readFile("./plugins/"+element+"/plugin.js");
+                //run the js file and call the function with the prepared parameters
+                eval(js+";"+self.plugincontent[element]["events"][eventname]+"("+sendargs+")");
+            }
+        }, this);
+        
+    }
+    //helper functions for os operations
+    function getDirectories(path) {
+        return fs.readdirSync(path).filter(function (file) {
+            return fs.statSync(path+'/'+file).isDirectory();
+        });}
+    function readFile(filename) {
+        var data = fs.readFileSync(filename, 'utf8');
+        return data;}
+}
+})();

--- a/sampleplugin/plugin.conf
+++ b/sampleplugin/plugin.conf
@@ -1,0 +1,6 @@
+{
+"events" : {
+    "onStart":"onStart",
+    "onSelectAccount": "onSelectAccount"
+    } 
+}

--- a/sampleplugin/plugin.js
+++ b/sampleplugin/plugin.js
@@ -1,0 +1,11 @@
+alert("always called");
+function onStart()
+{
+    alert("Wallet started");
+}
+function onSelectAccount(account)
+{
+    alert(account.address + " selected");
+    var localaccount = triggerEvent("getLocalAccount", account.address);
+    alert("the balance is: "+localaccount.balance);
+}


### PR DESCRIPTION
Just developed a small plugin loader. Its event driven, meaning the wallet calls an event (which we need to define in the code where we want to trigger it) and the plugins may decide to implement a function for handling this event. The other way around its possible to call defined functions which are capsulated in an own scope.
To create a plugin just create a new folder in the "plugins" directory, call it however you want. In that directory create 2 files (plugin.conf and plugin.js). in the conf file you can define eventhandlers which will be handled in the plugin.js file. An example can be viewed in the sampleplugin folder. you may want to copy the whole sampleplugin directory to the plugins folder and see it in action.

Indeed there are still some improvements possible. one thing would be to do the function calling asynchronous. the other one would be the extension/adding of events and callback functions to create a bigger using range. But this ones I will do on a additional commit and/or Pull Request.

Note that the plugins will be loaded at start, so to add a plugin you need to restart the application.

May resolving #202 and #180 