### PR TITLE
Sending ARK to yourself now shows up as grey, not red

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -509,10 +509,16 @@
                     <td md-cell><a href="" ng-click="ul.openExplorer('/tx/'+it.id)">{{it.id | smallId}}</a></td>
                     <td md-cell>{{it.confirmations}}</td>
                     <td md-cell>{{it.date | date: 'short'}}</td>
-                    <td ng-if="it.total>=0" md-cell>
+                    <td ng-if="it.recipientId==it.senderId && it.type!=3" md-cell>
+                      <md-button disabled md-colors="{'background' : 'default-grey-200' }">{{it.humanTotal}}</md-button>
+                    </td>
+                    <td ng-if="it.type==3" md-cell>
+                      <md-button disabled md-colors="{'background' : 'default-red-200' }">{{it.humanTotal}}</md-button>
+                    </td>
+                    <td ng-if="it.total>=0 && it.recipientId!=it.senderId" md-cell>
                       <md-button disabled md-colors="{'background' : 'default-green-200' }">+{{it.humanTotal}}</md-button>
                     </td>
-                    <td ng-if="it.total<0" md-cell>
+                    <td ng-if="it.total<0 && it.recipientId!=it.senderId" md-cell>
                       <md-button disabled md-colors="{'background' : 'default-red-200' }">{{it.humanTotal}}</md-button>
                     </td>
                     <td md-cell><a href="" ng-click="ul.gotoAddress(it.senderId)">{{it.senderId | accountlabel}}</a></td>

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -510,7 +510,7 @@
                     <td md-cell>{{it.confirmations}}</td>
                     <td md-cell>{{it.date | date: 'short'}}</td>
                     <td ng-if="it.recipientId==it.senderId && it.type!=3" md-cell>
-                      <md-button disabled md-colors="{'background' : 'default-grey-200' }">{{it.humanTotal}}</md-button>
+                      <md-button disabled md-colors="{'background' : 'default-grey-200' }">{{it.total/100000000 + ' + ' + it.amount/100000000}}</md-button>
                     </td>
                     <td ng-if="it.type==3" md-cell>
                       <md-button disabled md-colors="{'background' : 'default-red-200' }">{{it.humanTotal}}</md-button>


### PR DESCRIPTION
Fix for #61. Sending ARK to yourself now shows up as grey instead of red.
Also fix for #259. Total now shows amount sent and amount received (ex. "-1.1 + 1") so that you can see how much you sent and got back.