### PR TITLE
Horizontal Scrollbar in Transactions list now visible w/o scrolling down

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -434,8 +434,8 @@
         </md-list>
       </md-sidenav>
 
-      <md-content flex id="content">
-        <md-card>
+      <md-content flex layout="column" id="content">
+        <md-card flex="none">
           <div class="share" ng-if="ul.selected.virtual">
             <md-button md-no-ink ng-click="ul.sendArk(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">send</md-icon>
@@ -481,7 +481,7 @@
         </md-card>
 
 
-        <md-tabs md-dynamic-height>
+        <md-tabs flex="100">
           <md-tab label="{{'Transactions'|translate}}">
 
             <md-table-container flex="100">


### PR DESCRIPTION
Fix for #204. The horizontal scrollbar at the bottom of the transactions list is now always visible when the main window is not wide enough. 