### PR TITLE
Acccount currency balance will now have comma separators

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -20,14 +20,14 @@
     body {
       background-color: #000
     }
-    
+
     html {
       border-radius: 10px;
     }
     /**
          * Hide when Angular is not yet loaded and initialized
          */
-    
+
     [ng\:cloak],
     [ng-cloak],
     [data-ng-cloak],
@@ -271,7 +271,7 @@
       <md-toolbar layout="row" md-scroll-shrink>
         <div class="md-toolbar-tools">
           <h2>
-            <translate>My Accounts</translate> {{ul.network.symbol}}{{ul.myAccountsBalance()}} / {{ul.currency.symbol}}{{(ul.myAccountsBalance()*(ul.connectedPeer.market.price[ul.currency.name] || 0)).toFixed(2)}}
+            <translate>My Accounts</translate> {{ul.network.symbol}}{{ul.myAccountsBalance()}} / {{ul.currency.symbol}}{{ul.myAccountsCurrencyBalance()}}
           </h2>
           <span flex></span>
           <md-button class="share" md-no-ink ng-click="ul.refreshAccountBalances()" aria-label="Refresh balances">

--- a/client/app/src/accounts/AccountController.js
+++ b/client/app/src/accounts/AccountController.js
@@ -392,7 +392,7 @@
     self.getMarketInfo(self.selectedCoin);
 
     var setExchangBuyExpirationProgress = function(timestamp){
-      
+
     }
 
     self.buy = function() {
@@ -424,7 +424,7 @@
                   self.exchangeHistory = changerService.getHistory();
                 },
                 function(data) {
-    
+
                 },
                 function(data) {
                   if (data.payee && self.exchangeBuy.payee != data.payee) {
@@ -435,14 +435,14 @@
                   }
                 }
               );
-    
+
             }, function(error) {
               formatAndToastError(error, 10000);
               self.exchangeBuy = null;
             });
             }
           )
-          
+
       });
 
     };
@@ -512,7 +512,7 @@
                 completeExchangeSell(timestamp);
               }
             )
-            
+
           },
           function(error) {
             formatAndToastError(error, 10000)
@@ -591,6 +591,14 @@
       return (self.myAccounts().reduce(function(memo, acc) {
         return memo + parseInt(acc.balance);
       }, 0) / 100000000).toFixed(2);
+    }
+
+    //(ul.myAccountsBalance()*(ul.connectedPeer.market.price[ul.currency.name] || 0)).toFixed(2)}}
+    self.myAccountsCurrencyBalance = function() {
+        var currencyBalance = self.myAccountsBalance()*self.connectedPeer.market.price[self.currency.name];
+        currencyBalance = currencyBalance.toFixed(2);
+        currencyBalance = Number(currencyBalance).toLocaleString('en');
+        return currencyBalance;
     }
 
     self.otherAccounts = function() {

--- a/client/app/src/accounts/AccountController.js
+++ b/client/app/src/accounts/AccountController.js
@@ -593,11 +593,11 @@
       }, 0) / 100000000).toFixed(2);
     }
 
-    //(ul.myAccountsBalance()*(ul.connectedPeer.market.price[ul.currency.name] || 0)).toFixed(2)}}
+    // Function to return the accounts total balance in the selected currency.
     self.myAccountsCurrencyBalance = function() {
         var currencyBalance = self.myAccountsBalance()*self.connectedPeer.market.price[self.currency.name];
-        currencyBalance = currencyBalance.toFixed(2);
-        currencyBalance = Number(currencyBalance).toLocaleString('en');
+        currencyBalance = currencyBalance.toFixed(2); //fix to 2 decimal strings
+        currencyBalance = Number(currencyBalance).toLocaleString('en'); // TODO: Update for any locale?
         return currencyBalance;
     }
 


### PR DESCRIPTION
Inspired by #232. Will add commas as separators.

Can be expanded to have a mapping for each currency to its locale string, and then use that so it's right for any language! 

Just wanted to get this out there really quick and see if y'all would be OK with doing that? If so I could add it! 