### PR TITLE
Fixes transaction not translating next to income/expend issue #244

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -417,9 +417,9 @@
               <md-icon ng-if="ul.selected" style="pointer-events: auto" ng-click="" ng-mouseover="stats = ab.getStats(ul.selected.address, contact.address)" aria-label="Stats" class="md-secondary" md-menu-align-target>
                 info_outline
                 <md-tooltip md-direction="bottom" class="tooltip-multiline">
-                  {{'Income' | translate}}: {{ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate}})
+                  {{'Expend' | translate}}: {{ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate}})
                   <br>
-                  {{'Expend' | translate}}: {{ul.network.symbol}}{{stats.expend.amount}} ({{stats.expend.transactions}} {{'Transactions' | translate}})
+                  {{'Income' | translate}}: {{ul.network.symbol}}{{stats.expend.amount}} ({{stats.expend.transactions}} {{'Transactions' | translate}})
                 </md-tooltip>
               </md-icon>
             </span>

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -20,14 +20,14 @@
     body {
       background-color: #000
     }
-    
+
     html {
       border-radius: 10px;
     }
     /**
          * Hide when Angular is not yet loaded and initialized
          */
-    
+
     [ng\:cloak],
     [ng-cloak],
     [data-ng-cloak],
@@ -417,9 +417,9 @@
               <md-icon ng-if="ul.selected" style="pointer-events: auto" ng-click="" ng-mouseover="stats = ab.getStats(ul.selected.address, contact.address)" aria-label="Stats" class="md-secondary" md-menu-align-target>
                 info_outline
                 <md-tooltip md-direction="bottom" class="tooltip-multiline">
-                  {{'Income' | translate}}: {{ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'transactions' | translate}})
+                  {{'Income' | translate}}: {{ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate}})
                   <br>
-                  {{'Expend' | translate}}: {{ul.network.symbol}}{{stats.expend.amount}} ({{stats.expend.transactions}} {{'transactions' | translate}})
+                  {{'Expend' | translate}}: {{ul.network.symbol}}{{stats.expend.amount}} ({{stats.expend.transactions}} {{'Transactions' | translate}})
                 </md-tooltip>
               </md-icon>
             </span>


### PR DESCRIPTION
Was looking at issue number #244 and noticed that transactions wasn't translating so I fixed that. 
Looks like the issue with the word income and expend is that there are no translations in translations.js so those would need to be added?

Wondering where we could verify translations before adding those keys and their translations to each language! Or how to best to proceed to get those translations and then I'll add 'em!