### PR TITLE
Fixed issue where contact with same address as selected address could…

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -440,14 +440,14 @@
             <md-button md-no-ink ng-click="ul.sendArk(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">send</md-icon>
             </md-button>
-            <md-button md-no-ink ng-click="ul.showAccountMenu(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
+            <md-button md-no-ink ng-if="ul.selected.virtual" ng-click="ul.showAccountMenu(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">more_vert</md-icon>
             </md-button>
-          </div>
-          <div class="share" ng-if="!ul.selected.virtual" ng-controller="AddressbookController as ab">
-            <md-button md-no-ink ng-click="ab.editAddressbookContact(ul.selected.address)" aria-label="Share with {{ ul.selected.address }}">
+            <span ng-controller="AddressbookController as ab">
+              <md-button md-no-ink ng-if="!ul.selected.virtual || ab.getContactFromAddress(ul.selected.address)" ng-click="ab.editAddressbookContact(ul.selected.address)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">edit</md-icon>
-            </md-button>
+              </md-button>
+            </span>
           </div>
           <md-card-title>
             <md-card-title-media>
@@ -460,7 +460,7 @@
                   <!--<md-button class="md-fab md-primary md-mini" ng-click="ul.openPassphrasesDialog(ul.selected)">
                     <md-icon md-font-library="material-icons">lock</md-icon>
                   </md-button>-->
-                  <span class="delegate-name" ng-controller="AddressbookController as ab">{{ab.getContactFromAddress(ul.selected.address).name || ul.selected.username || 'Address'}} {{ul.selected.ledger}}</span>
+                  <span class="delegate-name" ng-controller="AddressbookController as ab">{{ul.selected.username || ab.getContactFromAddress(ul.selected.address).name || 'Address'}} {{ul.selected.ledger}}</span>
               <br>
               <md-button ng-click="ul.copiedToClipboard()" style="text-transform: none;" copy-to-clipboard="{{((!ul.showPublicKey) && ul.selected.address || ul.selected.publicKey)}}">
                 <md-icon>content_copy</md-icon> {{((!ul.showPublicKey) && ul.selected.address || ul.selected.publicKey)}}


### PR DESCRIPTION
… not be edited.

Creating a contact with the same address as the opened account would create weird behavior. The user would not be able to edit the contact (or delete it) because it was the same address as the account. Now, it is possible to create a contact with the same address as the account, edit that contact, and delete that contact.