### PR TITLE
Change the opacity of some dashboard elements and permit customizations of background textures (fixes #183)

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -7,6 +7,10 @@ body {
     padding: 0px;
 }
 
+body {
+    background-position: center;
+}
+
 .md-select-menu-container {
     z-index: 100;
 }

--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -356,3 +356,12 @@ md-autocomplete .md-errors-spacer {
 md-tooltip.tooltip-multiline {
     height: auto;
 }
+
+/* Main toolbar is transparent in almost all cases */
+body > md-toolbar:not(.md-menu-toolbar) {
+    background-color: transparent !important;
+}
+/* Useful with light background textures to outline the main toolbar buttons */
+body.too-pale-background-texture > md-toolbar:not(.md-menu-toolbar) {
+    background-color: rgba(20, 20, 20, 0.2) !important;
+}

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -40,8 +40,8 @@
 
 </head>
 
-<body style="background:{{ul.network.background}};background-position:center" ng-style="ul.network.background.match('textures') ? {'background-repeat': 'repeat'} : {'background-size': 'cover'}" id="app" ng-app="arkclient" layout="column" ng-controller="AccountController as ul"
-  ng-cloak md-theme="ul.network.theme">
+<body id="app" ng-app="arkclient" layout="column" ng-controller="AccountController as ul"
+  ng-cloak md-theme="ul.network.theme" background-style="ul.network.background">
   <md-toolbar style="background-color: rgba(0, 0, 0, 0)">
     <div class="md-toolbar-tools" style="-webkit-app-region: drag;">
       <img src="ark.png" alt="" height="30">

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -42,7 +42,7 @@
 
 <body id="app" ng-app="arkclient" layout="column" ng-controller="AccountController as ul"
   ng-cloak md-theme="ul.network.theme" background-style="ul.network.background">
-  <md-toolbar style="background-color: rgba(0, 0, 0, 0)">
+  <md-toolbar>
     <div class="md-toolbar-tools" style="-webkit-app-region: drag;">
       <img src="ark.png" alt="" height="30">
       <md-button ng-click="ul.selected?ul.selected=null:ul.selected=ul.accounts[0]"><strong>{{ul.network.token}} <translate>Client</translate> - {{ul.clientVersion}}</strong></md-button>
@@ -324,7 +324,7 @@
     </div>
 
     <div id="home-box-row" layout="row" layout-align="space-between stretch">
-      <md-content ng-if="ul.connectedPeer.market.marketCap" id="home-box-price" style="opacity:0.8; border-radius:10px; width: 360px; margin:10px;" md-whiteframe="3">
+      <md-content ng-if="ul.connectedPeer.market.marketCap" id="home-box-price" style="opacity:0.9; border-radius:10px; width: 360px; margin:10px;" md-whiteframe="3">
         <md-list>
           <md-list-item>
             <div>
@@ -346,7 +346,7 @@
           </md-list-item>
         </md-list>
       </md-content>
-      <md-content id="home-box-network" style="opacity:0.8; border-radius:10px; width: 360px; margin:10px;" md-whiteframe="3">
+      <md-content id="home-box-network" style="opacity:0.9; border-radius:10px; width: 360px; margin:10px;" md-whiteframe="3">
         <md-list flex>
           <md-list-item>
             <b translate>Network</b>

--- a/client/app/src/directives/backgroundStyle.directive.js
+++ b/client/app/src/directives/backgroundStyle.directive.js
@@ -1,0 +1,69 @@
+(function() {
+  'use strict';
+
+  /*
+   * This directive establishes the body background (color or texture).
+   * If that background is a texture, it could be configured to set a CSS class too.
+   *
+   * Since some background textures have light colors, they could use it to
+   * customize other elements, such as buttons that would not be distinguishable
+   * otherwise. Others could use it for improving the general aesthetics.
+   */
+  angular.module('arkclient.directives')
+    .directive('backgroundStyle', [function() {
+      return {
+        restrict: 'A',
+        require: '?ngModel',
+        link: function(scope, elem, attrs, ctrl) {
+
+          // This is the custom configuration of textures
+          var textures = {
+            'Ahoy.jpg': {
+              cssClass: 'pale-background-texture',
+            },
+            'Alchemy.gif': {
+              cssClass: 'pale-background-texture',
+            }
+          };
+
+          var classes = Object.values(textures).reduce(function(all, texture) {
+            if (all.indexOf(texture.cssClass) === -1)
+              all.push(texture.cssClass);
+            return all;
+          }, []);
+
+          // Used to extract the image filename
+          var textureRe = /url\(.+\/([^/]+).\)/;
+
+          scope.$watch(attrs.backgroundStyle, function(value) {
+            var style = { background: value };
+            var newClass = null;
+
+            if (value.match('textures'))
+              style.backgroundRepeat = 'repeat';
+            else
+              style.backgroundSize = 'cover';
+
+            elem.css(style);
+
+            var matches = value.match(textureRe);
+            if (matches) {
+              var filename = matches[1];
+
+              if (textures[filename]) {
+                newClass = textures[filename].cssClass;
+                elem.addClass(newClass);
+              }
+            }
+
+            classes.forEach(function(textureClass) {
+              if (newClass !== textureClass) {
+                elem.removeClass(textureClass);
+              }
+            })
+          });
+        }
+      }
+    }]);
+    
+})();

--- a/client/app/src/directives/backgroundStyle.directive.js
+++ b/client/app/src/directives/backgroundStyle.directive.js
@@ -3,7 +3,7 @@
 
   /*
    * This directive establishes the body background (color or texture).
-   * If that background is a texture, it could be configured to set a CSS class too.
+   * If that background is a texture, it could be configured to use a CSS class too.
    *
    * Since some background textures have light colors, they could use it to
    * customize other elements, such as buttons that would not be distinguishable
@@ -19,10 +19,16 @@
           // This is the custom configuration of textures
           var textures = {
             'Ahoy.jpg': {
-              cssClass: 'pale-background-texture',
+              cssClass: 'too-pale-background-texture',
             },
             'Alchemy.gif': {
-              cssClass: 'pale-background-texture',
+              cssClass: 'too-pale-background-texture',
+            },
+            'Isometropolis.png': {
+              cssClass: 'too-pale-background-texture',
+            },
+            'Subway Lines.png': {
+              cssClass: 'too-pale-background-texture',
             }
           };
 


### PR DESCRIPTION
This PR:
- Changes the opacity of some dashboard elements (https://github.com/ArkEcosystem/ark-desktop/issues/183)
- Permits customizations of background textures
- Customizes some background textures that are too pale for highlighting the main menu bar buttons

As a reference of the changes, this is the main toolbar before and after:

![alchemy-buttons](https://user-images.githubusercontent.com/1161224/30632205-99d102b0-9de7-11e7-976b-482d8b7b5c15.png)

![alchemy-buttons-after](https://user-images.githubusercontent.com/1161224/30672133-e3b22138-9e6a-11e7-9ebb-0c720f4e0296.png)
