### PR TITLE
Add live reload to Electron workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ brew tap Homebrew/bundle
 brew bundle
 ```
 
+## Development
+
+It is possible to execute a script to reload the [Electron](https://electron.atom.io/) application on changes:
+```bash
+npm run-script live-reload
+```
+
 ## Authors
 - FX Thoorens <fx@ark.io>
 - Guillaume Verbal <doweig@ark.io>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,6 @@
 const electron = require('electron')
+const elemon = require('elemon')
+
 // Module to control application life.
 const app = electron.app
 // Module to create native browser window.
@@ -175,10 +177,26 @@ function createWindow () {
 
 }
 
+function configureReload() {
+  elemon({
+    app: app,
+    mainFile: 'main.js',
+    bws: [
+      { bw: mainWindow, res: [] }
+    ]
+  })
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createWindow)
+app.on('ready', function () {
+  createWindow()
+
+  if (process.env.LIVE_RELOAD) {
+    configureReload()
+  }
+})
 
 
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rebuild": "electron-rebuild --force --module_dir . -w node-hid ",
     "electron": "electron --version",
     "start": "electron main.js",
+    "live-reload": "LIVE_RELOAD=true electron main.js",
     "pack": "build --dir",
     "dist": "npm run dist:win && npm run dist:macos && npm run dist:linux && npm run dist:win32",
     "dist-quick": "npm run dist:win && npm run dist:macos && npm run dist:linux",
@@ -32,7 +33,8 @@
     "email": "fixcrypt@gmail.com",
     "url": "https://github.com/fix"
   },
-  "contributors": [{
+  "contributors": [
+    {
       "name": "Guillaume Verbal",
       "email": "doweig@ark.io",
       "url": "https://github.com/doweig"
@@ -59,6 +61,7 @@
     "electron": "^1.7.5",
     "electron-builder": "^19.20.1",
     "electron-rebuild": "^1.6.0",
+    "elemon": "^5.0.3",
     "grunt": "~1.0.1",
     "grunt-angular-gettext": "^2.3.6",
     "grunt-contrib-jshint": "~1.1.0",


### PR DESCRIPTION
This PR adds something that I find very useful:
the `npm run-script live-reload` command will listen to changes in the project tree and will reload the Electron app.