### PR TITLE
Avoid showing several "toasts" while the app connects to the network

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -230,25 +230,25 @@
       function() {},
       function(connectedPeer) {
         self.connectedPeer = connectedPeer;
-        if (!self.connectedPeer.isConnected && self.isNetworkConnected) {
-          self.isNetworkConnected = false;
-          $mdToast.show(
-            $mdToast.simple()
-            .textContent(gettextCatalog.getString('Network disconnected!'))
-            .hideDelay(10000)
-          );
-        } else if (self.connectedPeer.isConnected && !self.isNetworkConnected) {
-          self.isNetworkConnected = true;
-          // trick to make it appear last.
-          $timeout(function() {
-            $mdToast.show(
-              $mdToast.simple()
-              .textContent(gettextCatalog.getString('Network connected and healthy!'))
-              .hideDelay(10000)
-            );
-          }, 1000);
 
+        function showToast(msg) {
+          var toast = $mdToast.simple()
+            .hideDelay(5000)
+            .textContent(gettextCatalog.getString(msg));
+          $mdToast.show(toast);
         }
+
+        // Wait a little to ignore the initial connection delay and short interruptions
+        $timeout(function() {
+          if (! self.connectedPeer.isConnected && self.isNetworkConnected) {
+            self.isNetworkConnected = false;
+            showToast('Network disconnected!');
+
+          } else if (self.connectedPeer.isConnected && ! self.isNetworkConnected) {
+            self.isNetworkConnected = true;
+            showToast('Network connected and healthy!');
+          }
+        }, 500);
       }
     );
 


### PR DESCRIPTION
This is the previous behaviour when starting (or restarting) the app:

![connection-toasts](https://user-images.githubusercontent.com/1161224/30729310-f87b1a3a-9f5e-11e7-925f-8d8ae937186b.gif)

Now it shouldn't occur.