### PR TITLE
Pressing refresh button now gives user a response

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -274,7 +274,7 @@
             <translate>My Accounts</translate> {{ul.network.symbol}}{{ul.myAccountsBalance()}} / {{ul.myAccountsCurrencyBalance()}}
           </h2>
           <span flex></span>
-          <md-button class="share" md-no-ink ng-click="ul.refreshAccountBalances()" aria-label="Refresh balances">
+          <md-button class="share" ng-click="ul.refreshAccountBalances()" aria-label="Refresh balances">
             <md-icon md-font-library="material-icons">cached</md-icon>
           </md-button>
         </div>
@@ -1048,7 +1048,7 @@
 
   <script src="src/init.js"></script>
   <script src="src/filters/filters.js"></script>
-  
+
   <script src="src/addons/pluginLoader.addon.js"></script>
 
   <script src="src/services/storage.service.js"></script>
@@ -1056,10 +1056,10 @@
   <script src="src/services/changer.service.js"></script>
   <script src="src/services/ledger.service.js"></script>
   <script src="src/services/time.service.js"></script>
-  
+
   <script src="src/accounts/account.service.js"></script>
   <script src="src/accounts/account.controller.js"></script>
-  
+
   <script src="src/directives/validAmount.directive.js"></script>
   <script src="src/directives/copyToClipboard.directive.js"></script>
 


### PR DESCRIPTION
For the refresh button on the home page next to my accounts, when you click it now there isn't any response 

For user experience reasons I believe it'd be better that the icon, when clicked, gives some response back to the user, even if the amounts don't update. 

Not sure if I need to create an open issue for this, but the idea is simple and I think this would lead to a better UX. 