### PR TITLE
Avoid duplicated contacts or contacts that are the same that user addresses

### DIFF
--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -665,7 +665,6 @@
 
     function setToFolder(address, folder, amount) {
       var virtual = getVirtual(address);
-      console.log(virtual);
       var f = virtual[folder];
       if (f && amount >= 0) {
         f.amount = amount;
@@ -780,7 +779,6 @@
           }
         }
         accounts = uniqueaccounts;
-        console.log(uniqueaccounts);
         accounts = accounts.filter(function(address) {
           return (storageService.get("username-" + address) != null ||  storageService.get("virtual-" + address) != null) && !storageService.get(address).ledger;
         });


### PR DESCRIPTION
These changes avoid using the same contact name several times. It also avoids creating contacts that have the same name or address than any user address.

BTW: these errors don't seem to be translated.