### PR TITLE
now when you hover over the icons in wallet page, will show text

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -438,6 +438,9 @@
           <div class="share">
             <md-button ng-if="ul.selected.virtual" md-no-ink ng-click="ul.sendArk(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">send</md-icon>
+              <md-tooltip>
+                  <translate>Send</translate>
+              </md-tooltip>
             </md-button>
 
             <md-button md-no-ink ng-click="ul.exportAccount(ul.selected)" aria-label="Export Account">
@@ -450,6 +453,9 @@
             <span ng-controller="AddressbookController as ab">
               <md-button md-no-ink ng-if="!ul.selected.virtual || ab.getContactFromAddress(ul.selected.address)" ng-click="ab.editAddressbookContact(ul.selected.address)" aria-label="Share with {{ ul.selected.address }}">
                 <md-icon md-font-library="material-icons">edit</md-icon>
+                <md-tooltip>
+                    <translate>Edit Contact</translate>
+                </md-tooltip>
               </md-button>
             </span>
 


### PR DESCRIPTION
Currently if you hover over the send button and edit contact button it doesn't show any text, but the export account does. This fixes it so the word send and edit contact will show over the hovers of the icons. 