### PR TITLE
Add 'use strict' into all services/controllers

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   angular
     .module('arkclient.accounts')
     .controller('AccountController', [
@@ -601,7 +603,7 @@
     }
 
     self.openMenu = function($mdMenuOpen, ev) {
-      originatorEv = ev;
+      // originatorEv = ev; // unused
       $mdMenuOpen(ev);
     };
 

--- a/client/app/src/components/addressbook/addressbook.controller.js
+++ b/client/app/src/components/addressbook/addressbook.controller.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   angular
     .module('arkclient.components')
     .controller('AddressbookController', ['$scope', '$mdDialog', "$mdToast", "storageService", "gettextCatalog", "accountService", AddressbookController]);

--- a/ledger-worker.js
+++ b/ledger-worker.js
@@ -1,3 +1,4 @@
+'use strict';
 const ledger = require('ledgerco')
  
 var connected = false


### PR DESCRIPTION
Hey guys, I noticed that we don't have strict-mode set for all services/controllers. Now we will be able to handle some errors in `account.controller`.

Cheers. 