### PR TITLE
Fix theme on qr code dialog

### DIFF
--- a/client/app/src/components/qrScanner/qrScanner.html
+++ b/client/app/src/components/qrScanner/qrScanner.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="QR Scanner" ng-controller="qrScannerController" ng-cloak md-theme="ul.currentTheme">
+<md-dialog aria-label="QR Scanner" ng-controller="qrScannerController" ng-cloak md-theme="theme">
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2><span translate>QR Scanner</span></h2>


### PR DESCRIPTION
Hi. I noticed that in the qr code directive, the AccountController is not in scope.

Now it will follow the selected theme.