### PR TITLE
Set BTC to default currency and first in currencies list

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -78,8 +78,8 @@
     pluginLoader.triggerEvent("onStart");
 
     self.currencies = [
-      { name: "usd", symbol: "$" },
       { name: "btc", symbol: "Ƀ" },
+      { name: "usd", symbol: "$" },
       { name: "aud", symbol: "A$" },
       { name: "brl", symbol: "R$" },
       { name: "cad", symbol: "Can$" },
@@ -177,7 +177,7 @@
     self.addDelegate = addDelegate;
     self.showAccountMenu = showAccountMenu;
     self.selectNextLanguage = selectNextLanguage;
-    self.currency = storageService.get("currency") || { name: "btc", symbol: "Ƀ" };
+    self.currency = storageService.get("currency") || self.currencies[0];
     self.switchNetwork = networkService.switchNetwork;
     self.marketinfo = {};
     self.network = networkService.getNetwork();


### PR DESCRIPTION
Previously, if a currency was not set, the currency option in the settings menu would be blank even though the currency defaulted to BTC. The currency still defaults to BTC, but it will now show in the settings menu that the currency is BTC. It also makes sense to make BTC first in the list as it's more universal than USD (which was first in the list).