### PR TITLE
Fixes for virtual folders

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -582,7 +582,7 @@
                     <translate>
                       If you own this account, you can enable Voting
                     </translate><br>
-                    <md-button ng-click="ul.createFolder(ul.selected)">
+                    <md-button ng-click="ul.manageFolder(ul.selected)">
                       <translate>Enable Votes</translate>
                     </md-button>
                   </md-card-title-text>
@@ -689,7 +689,7 @@
                     <translate>
                       If you own this account, you can enable Message Signing
                     </translate><br>
-                    <md-button ng-click="ul.createFolder(ul.selected)">
+                    <md-button ng-click="ul.manageFolder(ul.selected)">
                       <translate>Enable Signing</translate>
                     </md-button>
                   </md-card-title-text>
@@ -970,7 +970,7 @@
                           If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br> Moreover, this account will move under
                           the "My Accounts" list.
                         </translate>
-                        <md-button ng-click="ul.createFolder(ul.selected)">
+                        <md-button ng-click="ul.manageFolder(ul.selected)">
                           <translate>Enable Virtual Folders</translate>
                         </md-button>
                       </md-card-title-text>
@@ -1000,7 +1000,7 @@
                           </md-button>
                         </md-menu-item>
                         <md-menu-item>
-                          <md-button ng-click="ul.renameVirtuaFolder(folder)">
+                          <md-button ng-click="ul.manageFolder(ul.selected, folder)">
                             <translate>Rename</translate>
                           </md-button>
                         </md-menu-item>
@@ -1017,7 +1017,7 @@
 
                 </md-list-item>
                 <md-list-item ng-if="ul.selected.virtual">
-                  <md-button ng-click="ul.createFolder(ul.selected)">
+                  <md-button ng-click="ul.manageFolder(ul.selected)">
                     <translate>Create a new virtual folder</translate>
                   </md-button>
                 </md-list-item>

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -675,23 +675,38 @@
       account.virtual = accountService.deleteFolder(account.address, foldername);
     }
 
-    self.createFolder = function(account) {
+    self.manageFolder = function(account, currentFolderName) {
+      var titleText = (!currentFolderName ? 'Create' : 'Rename') + ' Virtual Folder';
+      var buttonText = (!currentFolderName ? 'Add' : 'Save');
+      var confirmText = 'Virtual folder ' + (!currentFolderName ? 'added' : 'saved') + '!';
+      var currentValue = (!currentFolderName ? null : currentFolderName);
       if (account.virtual) {
         var confirm = $mdDialog.prompt()
-          .title(gettextCatalog.getString('Create Virtual Folder'))
+          .title(gettextCatalog.getString(titleText))
           .theme(self.currentTheme)
           .textContent(gettextCatalog.getString('Please enter a folder name.'))
-          .placeholder(gettextCatalog.getString('folder name'))
+          .placeholder(gettextCatalog.getString('Folder name'))
+          .initialValue(currentValue)
           .ariaLabel(gettextCatalog.getString('Folder Name'))
-          .ok(gettextCatalog.getString('Add'))
+          .ok(gettextCatalog.getString(buttonText))
           .cancel(gettextCatalog.getString('Cancel'));
         $mdDialog.show(confirm).then(function(foldername) {
-          account.virtual = accountService.setToFolder(account.address, foldername, 0);
-          $mdToast.show(
-            $mdToast.simple()
-            .textContent(gettextCatalog.getString('Virtual folder added!'))
-            .hideDelay(3000)
-          );
+          if (account.virtual[foldername]) {
+            formatAndToastError(gettextCatalog.getString(
+              'A folder with that name already exists.'
+            ));
+          } else {
+            if (!currentFolderName) {
+              account.virtual = accountService.setToFolder(account.address, foldername, 0);
+            } else {
+              account.virtual = accountService.renameFolder(account.address, currentFolderName, foldername);
+            }
+            $mdToast.show(
+              $mdToast.simple()
+              .textContent(gettextCatalog.getString(confirmText))
+              .hideDelay(3000)
+            );
+          }
         });
       } else {
         var confirm = $mdDialog.prompt()

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -726,6 +726,14 @@
       return getVirtual(address);
     };
 
+    function renameFolder(address, folder, newFolder) {
+      var virtual = storageService.get("virtual-" + address);
+      virtual[newFolder] = virtual[folder];
+      delete virtual[folder];
+      storageService.set("virtual-" + address, virtual);
+      return getVirtual(address);
+    };
+
     function getVirtual(address) {
       var virtual = storageService.get("virtual-" + address);
       if (virtual) {
@@ -896,6 +904,8 @@
       setToFolder: setToFolder,
 
       deleteFolder: deleteFolder,
+
+      renameFolder: renameFolder,
 
       sanitizeDelegateName: sanitizeDelegateName,
 


### PR DESCRIPTION
This covers 2 issues:

- Could not rename a virtual folder at all. The option did nothing.
- Prevents adding the same foldername twice, showing a message to that effect.