### PR TITLE
Added libusb to Travis addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libusb-1.0-0-dev
 
 install:
   - export DISPLAY=':99.0'


### PR DESCRIPTION
The Travis build was always failing because it was missing libusb-1.0-0-dev