### PR TITLE
Disable screenshot protection setting if the platform is linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ function createWindow () {
             })
         },
         { type: "separator" },
-        { label: "Disable screenshot protection (unsafe)", click: function() { updateScreenshotProtectionItem(); }},
+        { label: getScreenshotProtectionLabel(), click: function() { updateScreenshotProtectionItem(); }, enabled: process.platform !== "linux"},
         { type: "separator" },
         { label: "Minimize", click: function() { mainWindow.minimize(); }},
         { label: "Maximize", click: function() { mainWindow.maximize(); }},
@@ -176,10 +176,6 @@ function createWindow () {
       ]
     }
   ];
-
-  if (process.platform === "linux") {
-    template[0].submenu[2] = { label: "Screenshot Protection Not Available On Linux", enabled: false};
-  }
 
   menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
@@ -253,6 +249,16 @@ function updateScreenshotProtectionItem() {
 
     menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
+}
+
+function getScreenshotProtectionLabel() {
+  if (process.platform === "linux") {
+    return "Screenshot Protection Not Available On Linux";
+  } else if (enableScreenshotProtection) {
+    return "Disable screenshot protection (unsafe)";
+  } else {
+    return "Enable screenshot protection (recommended)";
+  }
 }
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/main.js
+++ b/main.js
@@ -177,6 +177,10 @@ function createWindow () {
     }
   ];
 
+  if (process.platform === "linux") {
+    template[0].submenu[2] = { label: "Screenshot Protection Not Available On Linux", enabled: false};
+  }
+
   menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 


### PR DESCRIPTION
Because Electron doesn't have content protection on Linux, I think the screenshot protection settings button should be disabled on Linux. Users shouldn't be given an option that they may think provides some security if the option actually does nothing, it's misleading.

Resolves #336 