### PR TITLE
Sort peers & fix bug with filtered peer status

### DIFF
--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -286,6 +286,13 @@
         //peer.ip=network.peerseed;
         return;
       }
+      if (index === 0) {
+        peers = peers.filter(function(peer) {
+          return peer.status == "OK";
+        }).sort(function(a, b) {
+          return b.height - a.height || a.delay - b.delay;
+        });
+      }
       peer.ip = "http://" + peers[index].ip + ":" + peers[index].port;
       getFromPeer("/api/blocks/getheight").then(function(response) {
           if (response.success && response.height < peer.height) {

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -268,11 +268,13 @@
       if (!network.forcepeer) {
         getFromPeer("/api/peers").then(function(response) {
           if (response.success) {
-            let peers = response.peers.filter(function(peer) {
-              return peer.status == "OK";
+            getFromPeer('/api/peers/version').then(function(versionResponse) {
+              let peers = response.peers.filter(function(peer) {
+                return peer.status == "OK" && peer.version === versionResponse.version;
+              });
+              storageService.set("peers", peers);
+              findGoodPeer(peers, 0);
             });
-            storageService.set("peers", peers);
-            findGoodPeer(peers, 0);
           } else {
             findGoodPeer(storageService.get("peers"), 0);
           }

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -287,9 +287,7 @@
         return;
       }
       if (index === 0) {
-        peers = peers.filter(function(peer) {
-          return peer.status == "OK";
-        }).sort(function(a, b) {
+        peers = peers.sort(function(a, b) {
           return b.height - a.height || a.delay - b.delay;
         });
       }

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -268,10 +268,11 @@
       if (!network.forcepeer) {
         getFromPeer("/api/peers").then(function(response) {
           if (response.success) {
-            storageService.set("peers", response.peers.filter(function(peer) {
+            let peers = response.peers.filter(function(peer) {
               return peer.status == "OK";
-            }));
-            findGoodPeer(response.peers, 0);
+            });
+            storageService.set("peers", peers);
+            findGoodPeer(peers, 0);
           } else {
             findGoodPeer(storageService.get("peers"), 0);
           }

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -269,11 +269,15 @@
         getFromPeer("/api/peers").then(function(response) {
           if (response.success) {
             getFromPeer('/api/peers/version').then(function(versionResponse) {
-              let peers = response.peers.filter(function(peer) {
-                return peer.status == "OK" && peer.version === versionResponse.version;
-              });
-              storageService.set("peers", peers);
-              findGoodPeer(peers, 0);
+              if (versionResponse.success) {
+                let peers = response.peers.filter(function(peer) {
+                  return peer.status == "OK" && peer.version === versionResponse.version;
+                });
+                storageService.set("peers", peers);
+                findGoodPeer(peers, 0);
+              } else {
+                findGoodPeer(storageService.get("peers"), 0);
+              }
             });
           } else {
             findGoodPeer(storageService.get("peers"), 0);


### PR DESCRIPTION
This is to improve the initial connection to the network. More recently, there's been a lot of connect/disconnect activity. It now looks for the best peers based on highest Block Height, and lowest Delay.

@luciorubeens I couldn't use orderBy - it just didn't work (silently failing). Instead, I did this. I also didn't store in the serviceProvider as suggested, so i check on the first index of getGoodPeer and sort then, once.

Feedback welcome!