### PR TITLE
Exit ledger-worker process on quit signal

### DIFF
--- a/ledger-worker.js
+++ b/ledger-worker.js
@@ -9,5 +9,8 @@ setInterval(()=>{
   })
 }, connected ? 5000:1000)
 
-
-
+process.on('message', function (message) {
+  if (message.quit) {
+    process.exit()
+  }
+})

--- a/main.js
+++ b/main.js
@@ -186,6 +186,7 @@ function createWindow () {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
+    ledgerWorker.send({quit: true})
     mainWindow = null
   })
 

--- a/main.js
+++ b/main.js
@@ -186,7 +186,9 @@ function createWindow () {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
-    ledgerWorker.send({quit: true})
+    if (ledgerWorker.connected) {
+      ledgerWorker.send({quit: true})
+    }
     mainWindow = null
   })
 


### PR DESCRIPTION
An issue was reported on [reddit](https://www.reddit.com/r/ArkEcosystem/comments/77tjkj/uninstalled_ark_client_taking_over_computer/) saying that instances of Ark were still running after the client was closed. I found that the ledger-worker was not being closed when ArkClient was closed, so ledger-worker.js and main.js were still running.

I fixed it by calling process.exit() in ledger-worker when it receives a quit message. All parts of the client now exit completely when the window is closed.