### PR TITLE
Removed nextCurrency function

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -29,7 +29,7 @@
       display: none;
       overflow-x: hidden;
     }
-    
+
     [ng-cloak].splash {
       background-color: #06060c;
       background-image: url("splashscreen.png");
@@ -367,7 +367,7 @@
         </md-list>
       </md-content>
     </div>
-    <!-- 
+    <!--
     <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
     <script type="text/javascript" src="https://files.coinmarketcap.com/static/widget/currency.js"></script>
     <div class="coinmarketcap-currency-widget" style="opacity:0.9; border-radius:10px; border:0; width: 360px; margin:10px; background:white;" data-currency="{{ul.network.token}}" data-base="{{ul.currency.name}}" data-secondary="BTC"></div> -->
@@ -449,14 +449,14 @@
                 <translate>Refresh Account</translate>
               </md-tooltip>
             </md-button>
-            
+
             <md-button ng-if="ul.selected.virtual" md-no-ink ng-click="ul.sendArk(ul.selected)" aria-label="Share with {{ ul.selected.address }}">
               <md-icon md-font-library="material-icons">send</md-icon>
               <md-tooltip>
                   <translate>Send</translate>
               </md-tooltip>
             </md-button>
-            
+
             <md-button md-no-ink ng-click="ul.exportAccount(ul.selected)" aria-label="Export Account">
               <md-icon md-font-library="material-icons">file_download</md-icon>
               <md-tooltip>
@@ -503,7 +503,7 @@
               </span>
               <span class="md-subhead description">
                   <translate class="balance">Balance</translate> {{ul.network.symbol}}{{ul.selected.balance/100000000}}
-                  <md-button ng-click="ul.selectNextCurrency()">{{ul.formatCurrencyBalance(ul.selected.balance/100000000)}}</md-button>
+                  <md-button>{{ul.formatCurrencyBalance(ul.selected.balance/100000000)}}</md-button>
                 </span>
             </md-card-title-text>
           </md-card-title>

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -635,17 +635,6 @@
       $mdMenuOpen(ev);
     };
 
-    self.selectNextCurrency = function() {
-      var currenciesNames = self.currencies.map(function(x) {
-        return x.name;
-      });
-      var currencyIndex = currenciesNames.indexOf(self.currency.name);
-      var newIndex = currencyIndex == currenciesNames.length-1 ? 0 : currencyIndex+1;
-
-      self.currency = self.currencies[newIndex];
-      self.changeCurrency();
-    };
-
     self.changeCurrency = function() {
       if (self.currency == undefined) self.currency = currencies[0];
       storageService.set("currency", self.currency);


### PR DESCRIPTION
Currently there exists a next currency function and a button where its used on the transactions page where we show the balance in the currency of their choice. If you click that button it will cycle through the list of currencies one by one. So you have to click it to go through all the currencies and go back to your original. That or change your settings to whichever currency.

Not too sure of the utility of this function. If the user clicks on it because it's a button and seems clickable, they'll now need to change their currency back to what it was through the settings or by clicking it over and over again. 

If they're looking for a currency they can look at the dropdown list in the settings, which would help them find their currency faster. If they want to know all the currencies available they could look at the list as well rather than cycling through.

So it seems like the function just causes a minor inconvenience to the user and should be removed since it isn't providing any great utility. 