### PR TITLE
working travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
-node_js: "6.9.2"
+node_js:
+    - "node"
+
+os: osx
 
 addons:
   apt:
@@ -8,13 +11,8 @@ addons:
       - libusb-1.0-0-dev
 
 install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-
-before_script:
   - npm install
 
-  # TODO build?
 
 script:
   # export DISPLAY=:99.0


### PR DESCRIPTION
Looks like electron uses fsevents, which is for OSX only. When you try to do the travis build on linux, this causes it to break. 

So I've set it so Travis uses os x as its operating system for the build.

Tested this on my fork, and it seems to work and pass the builds.

https://travis-ci.org/ckhatri/ark-desktop/builds/292445286

