### PR TITLE
Add accounts to list of addresses to send Ark to

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1347,6 +1347,14 @@
       function querySearch(text) {
         text = text.toLowerCase();
         var contacts = storageService.get("contacts");
+        var accounts = self.getAllAccounts();
+        contacts = contacts.concat(accounts).sort(function(a, b) {
+          if (a.name && b.name) return a.name < b.name;
+          else if (a.username && b.username) return a.username < b.username;
+          else if (a.username && b.name) return a.username < b.name;
+          else if (a.name && b.username) return a.name < b.username;
+        });
+
         if (!contacts) {
           return [];
         }

--- a/client/app/src/accounts/view/sendArk.html
+++ b/client/app/src/accounts/view/sendArk.html
@@ -19,7 +19,7 @@
             md-items="contact in send.querySearch(send.searchText)" md-item-text="contact.address" md-min-length="0" md-autofocus="true" ng-attr-md-floating-label="{{'Type an address or a name'|translate}}" tabIndex="1">
             <md-item-template>
               <span class="item-title">
-                  <span> {{contact.name || contact.address}} </span>
+                  <span> {{contact.name || contact.username || contact.address}} </span>
               </span>
             </md-item-template>
           </md-autocomplete>


### PR DESCRIPTION
When sending Ark, the list of addresses/names that popup now shows your accounts and contacts, not just contacts. They are also sorted by account label / contact name.

Partially addresses #368 