### PR TITLE
Only request currencies we want from api

### DIFF
--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -345,7 +345,7 @@
     }
 
 
-    // Updates peer with all currency values relative to the USD price.
+    // Updates peer with all currency values relative to the EUR price.
     function updatePeerWithCurrencies(peer, res) {
       var currencies = ["aud", "brl", "cad", "chf", "cny", "eur", "gbp", "hkd", "idr", "inr", "jpy", "krw", "mxn", "rub", "usd"]
       var currency_request_url = createCurrencyApiCall(currencies)

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -347,13 +347,13 @@
 
     // Updates peer with all currency values relative to the EUR price.
     function updatePeerWithCurrencies(peer, res) {
-      var currencies = ["aud", "brl", "cad", "chf", "cny", "eur", "gbp", "hkd", "idr", "inr", "jpy", "krw", "mxn", "rub", "usd"]
+      var currencies = ["AUD", "BRL", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "IDR", "INR", "JPY", "KRW", "MXN", "RUB", "USD"]
       var currency_request_url = createCurrencyApiCall(currencies)
       $http.get(currency_request_url, { timeout: 2000}).then( function (result) {
         const EUR_PRICE = Number(res.data[0].price_eur)
         var prices = {}
         currencies.forEach(function(currency) {
-          prices[currency] = result.data.rates[currency.toUpperCase()] * EUR_PRICE
+          prices[currency.toLowerCase()] = result.data.rates[currency] * EUR_PRICE
         })
         prices["btc"] = Number(res.data[0].price_btc)
         prices["eur"] = Number(EUR_PRICE)
@@ -364,12 +364,10 @@
       return peer
     }
 
+    // creates the get request to fixer for each currency in currencies.
     function createCurrencyApiCall(currencies) {
         var get_request = 'https://api.fixer.io/latest?symbols='
-        currencies.forEach(function(currency) {
-            get_request += '' + currency.toUpperCase() + ','
-        })
-        get_request = get_request.substring(0, get_request.length-1)
+        get_request += currencies.toString()
         return get_request
     }
 


### PR DESCRIPTION
Had to change our base to the Euro since fixer.io can't do multiple parameters (I think).

This requests only the currencies we want from fixer.io, rather than get a list of all the currencies conversion rates.

Minor change, but now we won't be storing information we don't need. Or we could add all the currencies but that's 30+, which might make the currency list a bit too large?