### PR TITLE
Update nl.po

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -15,7 +15,7 @@ msgid "- This also can help to prove if a file has been tampered with if the SHA
 msgstr "- Dit helpt te bewijzen dat een bestand is aangepast als de SHA256 handtekening niet overeen komt met degene welke is vastgelegd op de blockchain."
 
 msgid "- This means that the owner of this account can prove that he had in hand this file at the block timestamp."
-msgstr "Dit betekent dat de eigenaar van dit account kan bewijzen dat deze het bestand in bezit had op het tijdstip uit de tijdstempel van het block."
+msgstr "- Dit betekent dat de eigenaar van dit account kan bewijzen dat deze het bestand in bezit had op het tijdstip uit de tijdstempel van het block."
 
 msgid "{{ category }}"
 msgstr "{{ category }}"
@@ -33,13 +33,13 @@ msgid "Account deleted!"
 msgstr "Account verwijderd!"
 
 msgid "Account successfully created:"
-msgstr "Account aangemaakt:"
+msgstr "Account succesvol aangemaakt:"
 
 msgid "Account successfully imported:"
 msgstr "Account succesvol geïmporteerd:"
 
 msgid "Account was already imported:"
-msgstr "Account is al geÏmporteerd:"
+msgstr "Account is al geïmporteerd:"
 
 msgid "Accounts"
 msgstr "Accounts"
@@ -48,7 +48,7 @@ msgid "Actions"
 msgstr "Acties"
 
 msgid "Active delegates (forging)"
-msgstr "Actieve gedelegeerden (aan het forgen)"
+msgstr "Actieve gedelegeerden (aan het smeden)"
 
 msgid "Add"
 msgstr "Toevoegen"
@@ -63,22 +63,22 @@ msgid "Add Address"
 msgstr "Adres toevoegen"
 
 msgid "Add Delegate"
-msgstr "Voeg Delegate"
+msgstr "Delegatie toevoegen"
 
 msgid "Add Watch-Only Address"
-msgstr "Voeg een alleen lezen adres toe"
+msgstr "Voeg een alleen-lezen adres toe"
 
 msgid "Address"
 msgstr "Adres"
 
 msgid "Address version"
-msgstr "Versie adres"
+msgstr "Adres versie"
 
 msgid "After creating the second passphrase if you are having issues with forms (second passphrase field not showing up) please restart your client."
-msgstr "Mocht je na het aanmaken van een tweede passphrase problemen hebben met de invulvelden (tweede passphrase veld niet zichtbaar) dan kan je het beste je client herstarten."
+msgstr "Mocht u na het aanmaken van een tweede wachtwoord problemen hebben met de invulvelden (tweede wachtwoord veld niet zichtbaar) dan kunt u het beste de client herstarten."
 
 msgid "All your data, including created accounts, networks and contacts will be removed from the app and reset to default."
-msgstr "Al je data, inclusief aangemaakte accounts, netwerken en contacten worden verwijderd van de applicatie en worden gereset naar standaard."
+msgstr "Al uw data, inclusief aangemaakte accounts, netwerken en contacten worden verwijderd van de applicatie en worden gereset."
 
 msgid "Amount"
 msgstr "Bedrag"
@@ -105,7 +105,7 @@ msgid "Arab"
 msgstr "Arabisch"
 
 msgid "Are you sure?"
-msgstr "Weet je het zeker?"
+msgstr "Weet u het zeker?"
 
 msgid "Ark Client"
 msgstr "Ark client"
@@ -126,10 +126,10 @@ msgid "Cannot find delegate:"
 msgstr "Kan gedelegeerde niet vinden:"
 
 msgid "Cannot find delegates from this term:"
-msgstr "Kan geen delegatie vinden met deze zoekopdracht:"
+msgstr "Kan geen gedelegeerden vinden met deze zoekopdracht:"
 
 msgid "Cannot find delegates on this peer:"
-msgstr "Kan geen delegatie vinden met deze peer:"
+msgstr "Kan geen gedelegeerden vinden met deze peer:"
 
 msgid "Cannot get registered delegates"
 msgstr "Kan geregistreerde gedelegeerden niet ophalen"
@@ -144,13 +144,13 @@ msgid "Cannot get voted delegates"
 msgstr "Kan gedelegeerden met stemmen niet ophalen"
 
 msgid "Change 1h/7h/7d"
-msgstr "Wijzig 1u/7u/7d"
+msgstr "Verandering 1u/7u/7d"
 
 msgid "Client"
 msgstr "Client"
 
 msgid "Close"
-msgstr "Sluit"
+msgstr "Sluiten"
 
 msgid "Coming Soon"
 msgstr "Binnenkort beschikbaar"
@@ -162,10 +162,10 @@ msgid "Network disconnected!"
 msgstr "Netwerkverbinding verbroken!"
 
 msgid "Passphrase is not saved on this computer."
-msgstr "De passphrase is niet op deze computer opgeslagen."
+msgstr "Het wachtwoord is niet op deze computer opgeslagen."
 
 msgid "Watch-Only Addresses"
-msgstr "Watch-only adressen"
+msgstr "Alleen-lezen adressen"
 
 msgid "Confirmations"
 msgstr "Bevestigingen"
@@ -186,7 +186,7 @@ msgid "Create Account"
 msgstr "Account aanmaken"
 
 msgid "Create Second Passphrase"
-msgstr "Tweede passphrase aanmaken"
+msgstr "Tweede wachtwoord aanmaken"
 
 msgid "Create Virtual Folder"
 msgstr "Virtuele map aanmaken"
@@ -204,7 +204,7 @@ msgid "Delay"
 msgstr "Vertraging"
 
 msgid "Delegate"
-msgstr "Delegeren"
+msgstr "Delegatie"
 
 msgid "Delegate name"
 msgstr "Naam delegatie"
@@ -234,7 +234,7 @@ msgid "Enable Virtual Folders"
 msgstr "Virtuele mappen inschakelen"
 
 msgid "Enable Votes"
-msgstr "Stem uitbrengen"
+msgstr "Stemmen inschakelen"
 
 msgid "English"
 msgstr "Engels"
@@ -261,7 +261,7 @@ msgid "Fee (Ѧ)"
 msgstr "Prijs "
 
 msgid "Folder Name"
-msgstr "Folder Naam"
+msgstr "Map naam"
 
 msgid "Force"
 msgstr "Forceer"
@@ -297,13 +297,13 @@ msgid "Id"
 msgstr "Id"
 
 msgid "If you own this account, you can enable Message Signing"
-msgstr "Als u eigenaar bent van dit account, kunt u Message Signing activeren."
+msgstr "Als u eigenaar bent van dit account, kunt u Bericht Ondertekenen inschakelen."
 
 msgid "If you own this account, you can enable Voting"
-msgstr "Als u eigenaar van dit account kunt u Voting inschakelen"
+msgstr "Als u eigenaar bent van dit account, kunt u Stemmen inschakelen"
 
 msgid "If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br> Moreover, this account will move under\n                          the \"My Accounts\" list."
-msgstr "Als u dit account beheert, kunt u virtuele mappen activeren. Virtuele Mappen zijn simpele subaccounts zodat u beter uw geld kan organiseren zonder de noodzakelijkheid om een transactie uit te voeren, en een vergoeding te betalen. Tevens wordt dit account verplaatst onder de \"Mijn Accounts\" lijst."
+msgstr "Als u eigenaar bent van dit account, kunt u virtuele mappen inschakelen. Virtuele mappen zijn eenvoudige subaccounts om uw geld kunt te organiseren, zonder een echte transactie te versturen en een vergoeding te betalen. Bovendien zal dit account vallen onder de \"Mijn Accounts\" lijst."
 
 msgid "Import"
 msgstr "Importeren"
@@ -312,7 +312,7 @@ msgid "Import Account"
 msgstr "Account importeren"
 
 msgid "If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br>\n                          Moreover, this account will move under the \"My Accounts\" list."
-msgstr "Als u eigenaar van dit account kunt u virtuele mappen in te schakelen. Virtual Folders zijn eenvoudig subaccounts om uw geld beter te organiseren, zonder dat een echte transactie te sturen en een vergoeding betalen. <br>\nBovendien zal deze account bewegen onder de \"Mijn Accounts\" lijst."
+msgstr "Als u eigenaar bent van dit account, kunt u virtuele mappen in te schakelen. Virtuele mappen zijn eenvoudige subaccounts om uw geld beter te organiseren, zonder een echte transactie te versturen en een vergoeding te betalen. <br>\nBovendien zal dit account vallen onder de \"Mijn Accounts\" lijst."
 
 msgid "Indonesian"
 msgstr "Indonesisch"
@@ -330,13 +330,13 @@ msgid "Language"
 msgstr "Taal"
 
 msgid "Last checked"
-msgstr "laatst gecontroleerd"
+msgstr "Laatst gecontroleerd"
 
 msgid "Ledger Nano S"
 msgstr "Ledger Nano S"
 
 msgid "List full or delegate already voted."
-msgstr "Lijst geheel of afgevaardigde al gestemd."
+msgstr "Lijst is vol of gedelegeerde heeft al gestemd."
 
 msgid "Login"
 msgstr "Inloggen"
@@ -348,7 +348,7 @@ msgid "Market"
 msgstr "Markt"
 
 msgid "Market Cap."
-msgstr "Marktkapitalisatie."
+msgstr "Marktkapitalisatie"
 
 msgid "Maximize"
 msgstr "Maximaliseren"
@@ -360,7 +360,7 @@ msgid "Minimize"
 msgstr "Minimaliseren"
 
 msgid "Minify"
-msgstr "Kleineren"
+msgstr "Verkleinen"
 
 msgid "My Accounts"
 msgstr "Mijn accounts"
@@ -381,16 +381,16 @@ msgid "New version available!"
 msgstr "Nieuwe versie beschikbaar!"
 
 msgid "Network connected and healthy!"
-msgstr "Het netwerk aangesloten en gezond!"
+msgstr "Het netwerk is verbonden en gezond!"
 
 msgid "Network disconected!"
-msgstr "Netwerk disconected!"
+msgstr "Netwerk verbroken!"
 
 msgid "Next"
 msgstr "Volgende"
 
 msgid "No difference from original delegate list"
-msgstr "Geen verschil van origineel afgevaardigde lijst"
+msgstr "Geen verschil met origineel gedelegeerden lijst"
 
 msgid "No publicKey"
 msgstr "Geen publieke sleutel"
@@ -408,7 +408,7 @@ msgid "Ok"
 msgstr "OK"
 
 msgid "Open Delegate Monitor"
-msgstr "Open afgevaardigde Monitor"
+msgstr "Open Gedelegeerden Monitor"
 
 msgid "Open File"
 msgstr "Bestand openen"
@@ -426,16 +426,16 @@ msgid "Optional"
 msgstr "Optioneel"
 
 msgid "Original Passphrase"
-msgstr "Eerste passphrase"
+msgstr "Eerste wachtwoord"
 
 msgid "Other Accounts"
 msgstr "Andere accounts"
 
 msgid "Passphrase"
-msgstr "wachtwoord"
+msgstr "Wachtwoord"
 
 msgid "Passphrase does not match your address"
-msgstr "Passphrase komt niet overeen met uw adres"
+msgstr "Wachtwoord komt niet overeen met uw adres"
 
 msgid "Passphrase is not corresponding to account"
 msgstr "Wachtwoord is niet overeenkomt met verantwoording"
@@ -447,7 +447,7 @@ msgid "Passphrases saved"
 msgstr "Bewaarde wachtwoorden"
 
 msgid "Peer"
-msgstr "Turen"
+msgstr "Peer"
 
 msgid "Peer Status"
 msgstr "Peer status"
@@ -462,25 +462,25 @@ msgid "Please enter a new address."
 msgstr "Geef een nieuw adres."
 
 msgid "Please enter a short label."
-msgstr "Geef een korte Etiket."
+msgstr "Geef een korte label."
 
 msgid "Please enter this account passphrase to login."
-msgstr "Vul deze account wachtwoord om in te loggen."
+msgstr "Vul het wachtwoord van dit account in om in te loggen."
 
 msgid "Please paste the original and second passphrase to validate the creation."
-msgstr "Voer de eerste en tweede passphrase in ter validatie."
+msgstr "Voer het eerste en tweede wachtwoord in ter validatie."
 
 msgid "Please backup securely the second passphrase, this client does NOT store it and thus cannot recover your it."
-msgstr "Maak een back-up van de tweede passphrase. De client slaat deze NIET op en kan de passphrase dus ook NIET herstellen!"
+msgstr "Maak een back-up van het tweede wachtwoord. De client slaat deze NIET op en kan het wachtwoord dus ook NIET herstellen!"
 
 msgid "Please restart your client after the delegate registration has been put in a block to reflect the changes."
-msgstr "Start je client opnieuw op, nadat de delegate registratie in een block verwerkt is, om de instellingen weer te geven."
+msgstr "Start de client opnieuw op, nadat de delegatie registratie in een block verwerkt is, om de instellingen weer te geven."
 
 msgid "Please first BACKUP SECURELY THE PASSPHRASE, this client does NOT store it and thus cannot recover your passphrase"
-msgstr "MAAK EEN BACK-UP VAN DE PASSPHRASE. De client slaat deze NIET op en kan de passphrase dus ook NIET herstellen."
+msgstr "MAAK EEN BACK-UP VAN HET WACHTWOORD. De client slaat deze NIET op en kan het wachtwoord dus ook NIET herstellen."
 
 msgid "Please type word 3, 6 and 9 from your passphrase to validate the account creation."
-msgstr "Voer woord 3, 6 en 9 van uw passphrase in om het nieuwe account te valideren."
+msgstr "Voer woord 3, 6 en 9 van uw wachtwoord in om het nieuwe account te valideren."
 
 msgid "Polish"
 msgstr "Pools"
@@ -492,7 +492,7 @@ msgid "Price"
 msgstr "Prijs"
 
 msgid "Productivity"
-msgstr "Produktiviteit"
+msgstr "Productiviteit"
 
 msgid "Public Key"
 msgstr "Publieke sleutel"
@@ -501,10 +501,10 @@ msgid "QR Scanner"
 msgstr "QR-scanner"
 
 msgid "Quit"
-msgstr "Ophouden"
+msgstr "Afsluiten"
 
 msgid "Quit Ark Client?"
-msgstr "Stoppen Ark Client?"
+msgstr "Ark Client afsluiten?"
 
 msgid "Rank"
 msgstr "Rang"
@@ -513,7 +513,7 @@ msgid "Receive Ark"
 msgstr "Ontvang Ark"
 
 msgid "Register Delegate"
-msgstr "Registreer gedelegeerde "
+msgstr "Registreer gedelegeerde"
 
 msgid "Register delegate for"
 msgstr "Registreer gedelegeerde voor"
@@ -537,7 +537,7 @@ msgid "Remove this account from your wallet. The account may be added again usin
 msgstr "Verwijder dit account uit uw portemonnee. Het account kan later opnieuw worden toegevoegd met het oorspronkelijke wachtwoord."
 
 msgid "Rename"
-msgstr "andere naam geven"
+msgstr "Hernoem"
 
 msgid "Reset Data"
 msgstr "Gegevens resetten"
@@ -561,22 +561,22 @@ msgid "Save Passphrases for"
 msgstr "Bewaar wachtwoord voor"
 
 msgid "Second Passphrase"
-msgstr "Tweede wachtwoordzin"
+msgstr "Tweede wachtwoord"
 
 msgid "Seed Server"
 msgstr "Server seeden"
 
 msgid "Send"
-msgstr "Sturen"
+msgstr "Verstuur"
 
 msgid "Send All"
 msgstr "Alles versturen"
 
 msgid "Send Ark"
-msgstr "Stuur Ark"
+msgstr "Verstuur Ark"
 
 msgid "Send Ark from"
-msgstr "Stuur Ark van"
+msgstr "Verstuur Ark van"
 
 msgid "Set"
 msgstr "Set"
@@ -621,16 +621,16 @@ msgid "The message is NOT verified"
 msgstr "Het bericht is NIET geverifieerd"
 
 msgid "The message is verified successfully"
-msgstr "Het bericht is geverifieerd"
+msgstr "Het bericht is succesvol geverifieerd"
 
 msgid "Second Passphrase added successfully:"
-msgstr "Tweede passphrase succesvol toegevoegd:"
+msgstr "Tweede wachtwoord succesvol toegevoegd:"
 
 msgid "The second passphrase does not match the one you just got."
-msgstr "De tweede wachtwoord komt niet overeen met je eerste wachtwoord."
+msgstr "Het tweede wachtwoord komt niet overeen met wat u gekregen heeft."
 
 msgid "The words does not match the original passphrase."
-msgstr "De woorden komen niet overeen met de passphrase."
+msgstr "De woorden komen niet overeen met het wachtwoord."
 
 msgid "Theme"
 msgstr "Thema"
@@ -639,7 +639,7 @@ msgid "Themes"
 msgstr "Thema's"
 
 msgid "This account already has a second passphrase:"
-msgstr "Dit account heeft al een tweede passphrase:"
+msgstr "Dit account heeft al een tweede wachtwoord:"
 
 msgid "This signature can't be forged."
 msgstr "Deze handtekening kan niet worden vervalst."
@@ -714,10 +714,10 @@ msgid "approval"
 msgstr "toestemming"
 
 msgid "address"
-msgstr "Adres"
+msgstr "adres"
 
 msgid "folder name"
-msgstr "Mapnaam"
+msgstr "mapnaam"
 
 msgid "from"
 msgstr "van"
@@ -747,17 +747,17 @@ msgid "productivity"
 msgstr "productiviteit"
 
 msgid "sent with success!"
-msgstr "Verzonden met succes!"
+msgstr "succesvol verstuurd!"
 
 msgid "you need at least 1 ARK to vote"
-msgstr "U heeft minimaal 1 ARK nodig om te stemmen."
+msgstr "u heeft minimaal 1 ARK nodig om te stemmen."
 
 msgid "you need at least 25 ARK to register delegate"
-msgstr "U heeft minimaal 25 ARK nodig om delegat te registreren."
+msgstr "u heeft minimaal 25 ARK nodig om een delegatie te registreren."
 
 msgid "Voting is an optional, but important mechanism that keeps the Ark network secure.\n                The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks.\n                This page can be used to cast your vote for a delegate that you support."
-msgstr "Stemmen is optioneel, maar een belangrijk mechanisme wat het Ark netwerk veilig houdt.\nDe 51 gedelegeerden met de meeste stemmen van het netwerk zijn verantwoordelijk voor het verifiëren en het smeden van transacties in nieuwe blokken.\nDeze pagina kan gebruikt worden om uw stem te doen voor de gedelegeerde welke u steunt."
+msgstr "Stemmen is optioneel, maar een belangrijk mechanisme wat het Ark netwerk veilig houdt.\n                De 51 gedelegeerden met de meeste stemmen van het netwerk zijn verantwoordelijk voor het verifiëren en het smeden van transacties in nieuwe blokken.\n                Deze pagina kan gebruikt worden om te stemmen voor de gedelegeerde die u steunt."
 
 msgid "you need at least 5 ARK to create a second passphrase"
-msgstr "U heeft minimaal 5 ARK nodig om een tweede passphrase aan te maken"
+msgstr "u heeft minimaal 5 ARK nodig om een tweede wachtwoord aan te maken"
 


### PR DESCRIPTION
- More uniform texts,
- Improved translations

Multiple texts do not seem to be translated, e.g.: Settings > 'Currency', 'Play sound when receiving transactions?', 'Refresh accounts automatically?'. Also: 'Export account'.