### PR TITLE
Add border to QR Code on Dark Theme

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -409,6 +409,12 @@ md-toast.debug .md-toast-content {
     object-fit: cover;
 }
 
+/* Add a white border around the QR code to make it easier on QR Code readers to decode on dark theme */
+.md-dark-theme qrcode canvas.qrcode {
+    border: 8px solid white;
+    margin-left: -8px;
+}
+
 md-bottom-sheet button md-icon.material-icons {
     font-size: 36px;
     padding: 15px;


### PR DESCRIPTION
While trying to scan the QR Code of my wallet address in the wallet, the
dark theme ended up being problematic as my phone was unable to find the
borders of the QR Code. The dark theme's QR Code should have a white
border around it to counteract this problem with scanning when using
dark theme.

I opted for an 8px border and added an element offset margin so it stays
in the place it is supposed to be.