### PR TITLE
Make Ark values in transaction tab selectable

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -174,6 +174,13 @@ md-button.menuBtn>md-icon {
     padding: 0 15px;
 }
 
+.selectable-text {
+    -webkit-user-select: text ;
+    -moz-user-select: text ;
+    -ms-user-select: text ;
+    user-select: text ;
+    cursor: text;
+  }
 
 /* Utils */
 

--- a/client/app/src/components/account/templates/offchain-tab.html
+++ b/client/app/src/components/account/templates/offchain-tab.html
@@ -30,7 +30,7 @@
         <h3>
           <translate>Default</translate> {{(($ctrl.ul.getDefaultValue($ctrl.ul.selected) | convertToArkValue) | amountToCurrency:$ctrl | formatCurrency:$ctrl.ul)}}</h3>
         <span class="md-secondary">
-          <md-button md-block md-colors="{'background' : $ctrl.ul.getDefaultValue($ctrl.ul.selected)>0 ? 'default-green-200':'default-red-200' }"> {{$ctrl.ul.getDefaultValue($ctrl.ul.selected) | convertToArkValue}}</md-button>
+          <span class="md-button selectable-text" md-block md-colors="{'background' : $ctrl.ul.getDefaultValue($ctrl.ul.selected)>0 ? 'default-green-200':'default-red-200' }">{{$ctrl.ul.getDefaultValue($ctrl.ul.selected) | convertToArkValue}}<span>
         </span>
       </md-list-item>
       <md-list-item ng-repeat="folder in $ctrl.ul.selected.virtual.getFolders()">

--- a/client/app/src/components/account/templates/transaction-tab.html
+++ b/client/app/src/components/account/templates/transaction-tab.html
@@ -29,16 +29,16 @@
           </td>
           <td md-cell>{{it.date | date: 'short'}}</td>
           <td ng-if="it.recipientId==it.senderId && it.type==0" md-cell>
-            <md-button disabled md-colors="{'background' : 'default-blue-grey-600' }">{{ '+' + ((it.amount | convertToArkValue)) + ' / -' + (it.fee | convertToArkValue) }}</md-button>
+            <span class="md-button selectable-text" md-colors="{'background' : 'default-blue-grey-600' }">{{ '+' + ((it.amount | convertToArkValue)) + ' / -' + (it.fee | convertToArkValue) }}</span>
           </td>
           <td ng-if="it.type>0" md-cell>
-            <md-button disabled md-colors="{'background' : 'default-blue-grey-600' }">{{it.humanTotal}}</md-button>
+            <span class="md-button selectable-text" md-colors="{'background' : 'default-blue-grey-600' }">{{it.humanTotal}}</span>
           </td>
           <td ng-if="it.total>=0 && it.recipientId!=it.senderId" md-cell>
-            <md-button disabled md-colors="{'background' : 'default-green-200' }">+{{it.humanTotal}}</md-button>
+            <span class="md-button selectable-text" md-colors="{'background' : 'default-green-200' }">+{{it.humanTotal}}</span>
           </td>
           <td ng-if="it.total<0 && it.recipientId!=it.senderId && it.type==0" md-cell>
-            <md-button disabled md-colors="{'background' : 'default-red-200' }">{{it.humanTotal}}</md-button>
+            <span class="md-button selectable-text" md-colors="{'background' : 'default-red-200' }">{{it.humanTotal}}</span>
           </td>
           <td md-cell><a ng-click="$ctrl.ul.gotoAddress(it.senderId)" md-colors="::{color: '{{ $ctrl.ul.network.themeDark ? 'background-200' : 'background-800' }}'}">{{it.senderId | accountlabel}}</a></td>
           <td md-cell>


### PR DESCRIPTION
I noticed that the actual Ark values (total) are not selectable because they are "disabled buttons".
This really bugged me since all other values in this table are selectable and the value is in my opinion one of the most important things and should definitely be selectable.

So what I did the following:
Changed them all to `span`'s, gave them the button style and removed (with a second class) the styles which made the text not selectable.

The before and after look was the exact same for me :)

![image](https://user-images.githubusercontent.com/1086065/33803885-846fd2d2-dd9a-11e7-8ef6-537c2d449c43.png)

Let me know what you think!
Note that this is my first commit here and I'm not sure if my apporach is good :)

BTW: There may be other places in code where this should be done, but I thought before I look for them I wanted to get feedback on this.