### PR TITLE
Provide feedback when user refreshes account

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -191,6 +191,10 @@ md-button.menuBtn>md-icon {
     background-color: transparent !important;
 }
 
+.rotate-360 .md-ripple-container {
+    display: none;
+}
+
 @-moz-keyframes rotate-360-keyframe { 100% { -moz-transform: rotate(-360deg); } }
 @-webkit-keyframes rotate-360-keyframe { 100% { -webkit-transform: rotate(-360deg); } }
 @keyframes rotate-360-keyframe { 100% { -webkit-transform: rotate(-360deg); transform:rotate(-360deg); } }

--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -181,6 +181,19 @@ md-button.menuBtn>md-icon {
     position: relative;
 }
 
+.rotate-360 {
+    -webkit-animation: rotate-360-keyframe 4s linear infinite;
+    -moz-animation: rotate-360-keyframe 4s linear infinite;
+    animation: rotate-360-keyframe 4s linear infinite;
+}
+
+.rotate-360:hover {
+    background-color: transparent !important;
+}
+
+@-moz-keyframes rotate-360-keyframe { 100% { -moz-transform: rotate(-360deg); } }
+@-webkit-keyframes rotate-360-keyframe { 100% { -webkit-transform: rotate(-360deg); } }
+@keyframes rotate-360-keyframe { 100% { -webkit-transform: rotate(-360deg); transform:rotate(-360deg); } }
 
 /* Typography support coming in 0.8.0 */
 

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -790,7 +790,7 @@
       })
     }
 
-    function refreshCurrentAccount () {
+    function refreshCurrentAccount (provideFeeback) {
       if (self.isRefreshingAccount) {
         return
       }
@@ -806,6 +806,11 @@
         }
 
         self.isRefreshingAccount = false
+
+        if (!provideFeeback) {
+          return
+        }
+
         if (!accountState.hasError && !transactionsState.hasError) {
           toastService.success('Account refreshed', 3000)
         } else {

--- a/client/app/src/components/account/templates/account-card.html
+++ b/client/app/src/components/account/templates/account-card.html
@@ -1,7 +1,7 @@
 <md-card flex="none">
 
   <div class="share">
-    <md-button ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount()" aria-label="Refresh Account">
+    <md-button ng-class="{'rotate-360': $ctrl.ul.isRefreshingAccount}" ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount()" aria-label="Refresh Account">
       <md-icon md-font-library="material-icons">cached</md-icon>
       <md-tooltip>
         <translate>Refresh Account</translate>

--- a/client/app/src/components/account/templates/account-card.html
+++ b/client/app/src/components/account/templates/account-card.html
@@ -1,7 +1,7 @@
 <md-card flex="none">
 
   <div class="share">
-    <md-button ng-class="{'rotate-360': $ctrl.ul.isRefreshingAccount}" ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount(true)" aria-label="Refresh Account">
+    <md-button ng-class="{'rotate-360': $ctrl.ul.accountRefreshState.isRefreshing}" ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount(true)" aria-label="Refresh Account">
       <md-icon md-font-library="material-icons">cached</md-icon>
       <md-tooltip>
         <translate>Refresh Account</translate>

--- a/client/app/src/components/account/templates/account-card.html
+++ b/client/app/src/components/account/templates/account-card.html
@@ -1,7 +1,7 @@
 <md-card flex="none">
 
   <div class="share">
-    <md-button ng-class="{'rotate-360': $ctrl.ul.isRefreshingAccount}" ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount()" aria-label="Refresh Account">
+    <md-button ng-class="{'rotate-360': $ctrl.ul.isRefreshingAccount}" ng-if="!$ctrl.ul.refreshAccountsAutomatically" md-no-ink ng-click="$ctrl.ul.refreshCurrentAccount(true)" aria-label="Refresh Account">
       <md-icon md-font-library="material-icons">cached</md-icon>
       <md-tooltip>
         <translate>Refresh Account</translate>

--- a/client/app/src/components/dashboard/account-box.html
+++ b/client/app/src/components/dashboard/account-box.html
@@ -13,7 +13,7 @@
       </md-tooltip>
       {{$ctrl.ac.toggleCurrency.symbol}}
     </md-button>
-    <md-button class="share" ng-click="$ctrl.ac.refreshAccountBalances()" aria-label="Refresh balances">
+    <md-button ng-class="{'rotate-360': $ctrl.ac.isRefreshingAccounts}" class="share" ng-click="$ctrl.ac.refreshAccountBalances(true)" aria-label="Refresh balances">
       <md-icon md-font-library="material-icons">cached</md-icon>
     </md-button>
   </div>

--- a/client/app/src/components/dashboard/account-box.html
+++ b/client/app/src/components/dashboard/account-box.html
@@ -13,7 +13,7 @@
       </md-tooltip>
       {{$ctrl.ac.toggleCurrency.symbol}}
     </md-button>
-    <md-button ng-class="{'rotate-360': $ctrl.ac.isRefreshingAccounts}" class="share" ng-click="$ctrl.ac.refreshAccountBalances(true)" aria-label="Refresh balances">
+    <md-button ng-class="{'rotate-360': $ctrl.ac.accountsRefreshState.isRefreshing}" class="share" ng-click="$ctrl.ac.refreshAccountBalances(true)" aria-label="Refresh balances">
       <md-icon md-font-library="material-icons">cached</md-icon>
     </md-button>
   </div>

--- a/client/app/src/filters/filters.js
+++ b/client/app/src/filters/filters.js
@@ -18,6 +18,11 @@
         // NOTE AccountController is being renaming to `ac` in refactored templates
         const ac = scope.ac || scope.ul
         const currencyName = bitcoinToggleIsActive && ac.btcValueActive ? 'btc' : ac.currency.name
+
+        if (!ac.connectedPeer.market.price) {
+          return 0
+        }
+
         const price = ac.connectedPeer.market.price[currencyName]
         return (amount * price).toFixed(5)
       }


### PR DESCRIPTION
I noticed that when you click the refresh button no _progress_ and no _feedback_ is provided.

I added an animation to the refresh button when a refresh is being done (which most often you can't even see because it's too fast - but you never know.. ;) ) and added feedback (toast) when the refresh is done.

The whole thing looks like this (note: I added a manually timeout of 3000ms for demo purposes):

![random](https://user-images.githubusercontent.com/1086065/33847829-20ef8de8-deac-11e7-8c17-387fa1674b78.gif)

I also disabled "button-spamming" which basically means when a request is already executing clicking the button again will not do another request.

I have 3 questions:

- What do you think in general? ;)
- In the error case should the user get a specific error message or is my implementation enough?
- Concering translations: Is it correct that I just pass them as a normal string to the toast service or do I need to do something more?

Greetings :)