### PR TITLE
now will only get check price if not undefined

### DIFF
--- a/client/app/src/filters/filters.js
+++ b/client/app/src/filters/filters.js
@@ -18,7 +18,7 @@
         // NOTE AccountController is being renaming to `ac` in refactored templates
         const ac = scope.ac || scope.ul
         const currencyName = bitcoinToggleIsActive && ac.btcValueActive ? 'btc' : ac.currency.name
-        const price = ac.connectedPeer.market.price[currencyName]
+        const price = typeof ac.connectedPeer.market.price === 'undefined' ? 0 : ac.connectedPeer.market.price[currencyName]
         return (amount * price).toFixed(5)
       }
     })


### PR DESCRIPTION
Saw in debugging tools that filter was throwing a lot of errors because price wouldn't be defined but we'd try accessing it. 

Now if it's undefined we return 0.