### PR TITLE
Fix that qr scanner doesn't work correctly for 'To' field

### DIFF
--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -289,6 +289,11 @@
         remainingBalance: totalBalance(false) // <-- initial value, this will change by directive
       }
 
+      $scope.qrCodeToAddressCallback = (address) => {
+        // this will trigger the selectedContactChange function, which will then set the toAddress
+        $scope.send.data.selectedAddress = {address: address}
+      }
+
       $mdDialog.show({
         parent: angular.element(document.getElementById('app')),
         templateUrl: './src/components/account/templates/send-transaction-dialog.html',

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -289,7 +289,7 @@
         remainingBalance: totalBalance(false) // <-- initial value, this will change by directive
       }
 
-      $scope.qrCodeToAddressCallback = (address) => {
+      $scope.onQrCodeForToAddressScanned = (address) => {
         // this will trigger the selectedContactChange function, which will then set the toAddress
         $scope.send.data.selectedAddress = {address: address}
       }

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -14,7 +14,7 @@
       <div class="md-dialog-content">
         <div layout="row" flex layout-align="start start">
           <md-input-container flex="5">
-            <qr-scanner input-callback-func-name="qrCodeToAddressCallback"></qr-scanner>
+            <qr-scanner input-callback-func="onQrCodeForToAddressScanned(qr)"></qr-scanner>
           </md-input-container>
           <md-autocomplete flex="95" md-selected-item="send.data.selectedAddress" md-selected-item-change="send.selectedContactChange(contact)" md-search-text-change="send.searchTextChange(send.searchText)" md-search-text="send.searchText"
             md-items="contact in send.querySearch(send.searchText)" md-item-text="contact.address" md-min-length="0" md-autofocus="true" ng-attr-md-floating-label="{{'Type an address or a name'|translate}}" tabIndex="1">

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -14,9 +14,9 @@
       <div class="md-dialog-content">
         <div layout="row" flex layout-align="start start">
           <md-input-container flex="5">
-            <qr-scanner input-callback="toAddress"></qr-scanner>
+            <qr-scanner input-callback-func-name="qrCodeToAddressCallback"></qr-scanner>
           </md-input-container>
-          <md-autocomplete flex="95" ng-model="send.data.toAddress" , md-selected-item="send.data.selectedAddress" md-selected-item-change="send.selectedContactChange(contact)" md-search-text-change="send.searchTextChange(send.searchText)" md-search-text="send.searchText"
+          <md-autocomplete flex="95" md-selected-item="send.data.selectedAddress" md-selected-item-change="send.selectedContactChange(contact)" md-search-text-change="send.searchTextChange(send.searchText)" md-search-text="send.searchText"
             md-items="contact in send.querySearch(send.searchText)" md-item-text="contact.address" md-min-length="0" md-autofocus="true" ng-attr-md-floating-label="{{'Type an address or a name'|translate}}" tabIndex="1">
             <md-item-template>
               <span class="item-title">

--- a/client/app/src/components/qr-scanner/qr-scanner.directive.js
+++ b/client/app/src/components/qr-scanner/qr-scanner.directive.js
@@ -21,7 +21,13 @@
           toastService.success(`The ${result.type} ${result.qr} has been successfully scanned.`)
         }
 
-        $scope.$parent.send.data[$scope.inputCallback] = result.qr
+        if ($scope.inputCallback) {
+          $scope.$parent.send.data[$scope.inputCallback] = result.qr
+        }
+
+        if ($scope.inputCallbackFuncName) {
+          $scope.$parent[$scope.inputCallbackFuncName](result.qr)
+        }
 
         $timeout(function () {
           $mdDialog.hide()
@@ -63,7 +69,8 @@
         onSuccess: '&',
         onError: '&',
         onVideoError: '&',
-        inputCallback: '@'
+        inputCallback: '@',
+        inputCallbackFuncName: '@'
       },
       controller: controller,
       replace: true,

--- a/client/app/src/components/qr-scanner/qr-scanner.directive.js
+++ b/client/app/src/components/qr-scanner/qr-scanner.directive.js
@@ -25,8 +25,8 @@
           $scope.$parent.send.data[$scope.inputCallback] = result.qr
         }
 
-        if ($scope.inputCallbackFuncName) {
-          $scope.$parent[$scope.inputCallbackFuncName](result.qr)
+        if ($scope.inputCallbackFunc) {
+          $scope.inputCallbackFunc({qr: result.qr})
         }
 
         $timeout(function () {
@@ -70,7 +70,7 @@
         onError: '&',
         onVideoError: '&',
         inputCallback: '@',
-        inputCallbackFuncName: '@'
+        inputCallbackFunc: '&'
       },
       controller: controller,
       replace: true,


### PR DESCRIPTION
Problem was that `ng-model` is not supported on `md-autocomplete`.

To work around this we have to set the `selectAddress` property which is used on the `md-autocomplete`. However we cannot really set the field directly from the qr scanner directive (because it a "contact").

My solution was to introduce a callback-function parameter (which I personally find nicer anyway, instead of having to relay on, that the object path `send.data` exists).

Please note that I'm not very good with angular 1 - and it may very be possible that there is a better fix for this. I'm always open for feedback :)

fixes: #454