### PR TITLE
doesn't scroll to top of transactions on refresh fixes #457

### DIFF
--- a/client/app/src/accounts/account-transactions.controller.js
+++ b/client/app/src/accounts/account-transactions.controller.js
@@ -30,7 +30,6 @@
 
     $scope.$on('account:onRefreshTransactions', function (evt, transactions) {
       reset()
-      angular.element(document.querySelector('.tx-list-container'))[0].scrollTop = 0
       updateTransactions(transactions)
     })
 


### PR DESCRIPTION
Thanks to Thomgru for the suggestion in #457 