### PR TITLE
noticed toggling btc didn't change market to btc values

### DIFF
--- a/client/app/src/components/dashboard/market-box.html
+++ b/client/app/src/components/dashboard/market-box.html
@@ -4,8 +4,7 @@
       <div>
         <b><translate>Price</translate></b>
       </div>
-
-      <span class="md-secondary">{{$ctrl.ul.connectedPeer.market.price[$ctrl.ul.currency.name] | formatCurrency:$ctrl.ul}}</span>
+      <span class="md-secondary">{{($ctrl.ul.btcValueActive ? $ctrl.ul.connectedPeer.market.price[$ctrl.ul.bitcoinCurrency.name] : $ctrl.ul.connectedPeer.market.price[$ctrl.ul.currency.name]) | formatCurrency:$ctrl.ul:$ctrl.ul.btcValueActive}}</span>
     </md-list-item>
     <md-list-item>
       <b translate>Change 1h/24h/7d</b>
@@ -16,7 +15,7 @@
       </span>
     </md-list-item>
     <md-list-item>
-      <b translate>Market Cap.</b> <span class="md-secondary">{{$ctrl.ul.connectedPeer.market.available_supply | amountToCurrency:$ctrl | formatCurrency:$ctrl.ul}}</span>
+      <b translate>Market Cap.</b> <span class="md-secondary">{{($ctrl.ul.connectedPeer.market.available_supply | amountToCurrency:$ctrl:$ctrl.ul.btcValueActive) | formatCurrency:$ctrl.ul:$ctrl.ul.btcValueActive}}</span>
     </md-list-item>
   </md-list>
 </md-content>

--- a/client/app/src/components/layout/main-navbar.html
+++ b/client/app/src/components/layout/main-navbar.html
@@ -134,7 +134,7 @@
 								<b><translate>Price</translate></b>
 							</div>
 
-							<span class="md-secondary">{{$ctrl.ul.connectedPeer.market.price[$ctrl.ul.currency.name] | formatCurrency: $ctrl.ul}}</span>
+							<span class="md-secondary">{{($ctrl.ul.btcValueActive ? $ctrl.ul.connectedPeer.market.price[$ctrl.ul.bitcoinCurrency.name] : $ctrl.ul.connectedPeer.market.price[$ctrl.ul.currency.name]) | formatCurrency:$ctrl.ul:$ctrl.ul.btcValueActive}}</span>
 						</md-list-item>
 						<md-list-item>
 							<b translate>Change 1h/24h/7d</b>
@@ -149,7 +149,7 @@
 								<b><translate>Market Cap.</translate></b>
 							</div>
 
-							<span class="md-secondary">{{$ctrl.ul.connectedPeer.market.available_supply | amountToCurrency:$ctrl | formatCurrency:$ctrl.ul}}</span>
+							<span class="md-secondary">{{($ctrl.ul.connectedPeer.market.available_supply | amountToCurrency:$ctrl:$ctrl.ul.btcValueActive) | formatCurrency:$ctrl.ul:$ctrl.ul.btcValueActive}}</span>
 						</md-list-item>
 						<md-list-item ng-show="$ctrl.ul.connectedPeer.market.isOffline">
 							<b translate>Last checked</b> <span class="md-secondary">


### PR DESCRIPTION
Toggling BTC using the button wouldn't update the market box to show BTC. We want to store the original/current currency for the toggle though, so we can't just overwrite currency to be btc. 

Updated so the filters pass in isBitcoinToggle.