### PR TITLE
fixes couldn't set selectedTextBackgroundColor

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -17,6 +17,9 @@ body {
     width: 12px;
 }
 
+::selection {
+    background: #ADD8E6;
+}
 
 /* Track */
 


### PR DESCRIPTION
Very small change, not necessary at all, but it was bothering me to have that error, so I decided to fix it. 

Fixes Electron Helper[14028:538660] Couldn't set selectedTextBackgroundColor from default ()
error that you get at startup