### PR TITLE
Moved toastService into copy directive

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -235,7 +235,6 @@
     self.toggleList = toggleAccountsList
     self.createSecondPassphrase = createSecondPassphrase
     self.exportAccount = exportAccount
-    self.copiedToClipboard = copiedToClipboard
     self.formatAndToastError = formatAndToastError
 
     self.refreshAccountsAutomatically = storageService.get('refreshAccountsAutomatically') || false
@@ -428,10 +427,6 @@
 
     //   $mdToast.show(toast)
     // }
-
-    function copiedToClipboard () {
-      toastService.success('Copied to clipboard')
-    }
 
     self.selectAllLanguages = function () {
       return languages

--- a/client/app/src/components/account/templates/account-card.html
+++ b/client/app/src/components/account/templates/account-card.html
@@ -49,7 +49,7 @@
           </md-button>-->
           <span class="delegate-name">{{$ctrl.ab.getContactFromAddress($ctrl.ul.selected.address).name || $ctrl.ul.selected.username || 'Address'}} {{$ctrl.ul.selected.ledger}}</span>
       <br>
-      <md-button ng-click="$ctrl.ul.copiedToClipboard()" style="text-transform: none;" copy-to-clipboard="{{((!$ctrl.ul.showPublicKey) && $ctrl.ul.selected.address || $ctrl.ul.selected.publicKey)}}">
+      <md-button style="text-transform: none;" copy-to-clipboard="{{((!$ctrl.ul.showPublicKey) && $ctrl.ul.selected.address || $ctrl.ul.selected.publicKey)}}">
         <md-icon>content_copy</md-icon>
         <md-tooltip md-direction="top">
           {{ 'Copy' | translate }} {{ $ctrl.ul.showPublicKey ? ('Public Key' | translate | lowercase) : ('Address' | translate | lowercase) }}</translate>

--- a/client/app/src/components/account/templates/signing-tab.html
+++ b/client/app/src/components/account/templates/signing-tab.html
@@ -55,7 +55,7 @@
                   </md-tooltip>
                   <md-icon md-font-library="material-icons">check</md-icon>
                 </md-button>
-                <md-button ng-click="$ctrl.ul.copiedToClipboard()" copy-to-clipboard="{{signedMessage}}" class="md-mini md-fab md-primary">
+                <md-button copy-to-clipboard="{{signedMessage}}" class="md-mini md-fab md-primary">
                   <md-tooltip>
                     <translate>Copy</translate>
                   </md-tooltip>

--- a/client/app/src/directives/copy-to-clipboard.directive.js
+++ b/client/app/src/directives/copy-to-clipboard.directive.js
@@ -2,7 +2,7 @@
   'use strict'
 
   angular.module('arkclient.directives')
-    .directive('copyToClipboard', function ($window) {
+    .directive('copyToClipboard', ['toastService', '$window', function (toastService, $window) {
       var body = angular.element($window.document.body)
       var textarea = angular.element('<textarea/>')
       textarea.css({
@@ -18,8 +18,11 @@
         try {
           var successful = document.execCommand('copy')
           if (!successful) throw successful
+          else {
+            toastService.success('Copied to clipboard', 3000)
+          }
         } catch (err) {
-          console.log('failed to copy', toCopy)
+          toastService.error('Failed to copy', 3000)
         }
         textarea.remove()
       }
@@ -32,5 +35,5 @@
           })
         }
       }
-    })
+    }])
 })()


### PR DESCRIPTION
Previously what happened was ng-click -> called copyToClipBoard which always showed a successful toast message.

Passed in the toastService into the copy directive, so now what happens is the toast service will show the correct response. 

Partially inspired by a reddit post where the user stated that it would say copied to clipboard but then would not be able to past it. 

