### PR TITLE
added tooltips to peer buttons

### DIFF
--- a/client/app/src/components/dashboard/network-box.html
+++ b/client/app/src/components/dashboard/network-box.html
@@ -1,10 +1,16 @@
 <md-content id="home-box-network" md-whiteframe="3">
   <md-list flex>
     <md-list-item>
+      <md-tooltip>
+        <translate>Switch Network</translate>
+      </md-tooltip>
       <b translate>Network</b>
       <md-button class="md-secondary" aria-label="Switch Network" md-prevent-menu-close ng-click="$ctrl.ul.switchNetwork()">{{$ctrl.ul.connectedPeer.network}}/{{$ctrl.ul.connectedPeer.height}}</md-button>
     </md-list-item>
     <md-list-item>
+      <md-tooltip>
+				<translate>Pick Random Peer</translate>
+			</md-tooltip>
       <b translate>Peer</b>
       <md-button class="md-secondary" aria-label="Pick Random Peer" md-prevent-menu-close ng-click="$ctrl.ul.pickRandomPeer()">{{$ctrl.ul.connectedPeer.ip}}</md-button>
     </md-list-item>


### PR DESCRIPTION
Currently clicking on MAINNET or the peer ip address calls a function. I added the tooltip so that people know exactly what is going to happen before it occurs. 