### PR TITLE
Fix multiple bugs with fees & refactor

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -113,8 +113,10 @@
   <script src="src/services/ledger.service.js"></script>
   <script src="src/services/time.service.js"></script>
   <script src="src/services/toast.service.js"></script>
+  <script src="src/services/utility.service.js"></script>
 
   <script src="src/accounts/account.service.js"></script>
+  <script src="src/accounts/transaction-builder.service.js"></script>
   <script src="src/accounts/account-transactions.controller.js"></script>
   <script src="src/accounts/account.controller.js"></script>
   <script src="src/accounts/export-account.controller.js"></script>

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -25,6 +25,7 @@
       '$window',
       'ARKTOSHI_UNIT',
       '$rootScope',
+      'transactionBuilderService',
       AccountController
     ])
 
@@ -56,7 +57,8 @@
     $mdTheming,
     $window,
     ARKTOSHI_UNIT,
-    $rootScope
+    $rootScope,
+    transactionBuilderService
   ) {
     const _path = require('path')
 
@@ -433,6 +435,7 @@
       storageService.set('language', self.language)
       gettextCatalog.setCurrentLanguage(self.language)
     }
+
 
 
     // Load all registered accounts
@@ -963,7 +966,7 @@
           return delegate.vote + delegate.publicKey
         }).join(',')
         console.log(publicKeys)
-        accountService.createVoteTransaction({
+        transactionBuilderService.createVoteTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.voteDialog.data.fromAddress,
@@ -1016,7 +1019,7 @@
 
         $mdDialog.hide()
         var smartbridge = $scope.send.data.smartbridge
-        accountService.createSendTransaction({
+        transactionBuilderService.createSendTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.send.data.fromAddress,
@@ -1480,7 +1483,7 @@
           return formatAndToastError(error)
         }
 
-        accountService.createDelegateCreationTransaction({
+        transactionBuilderService.createDelegateCreationTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.createDelegate.data.fromAddress,
@@ -1699,7 +1702,7 @@
         } else if ($scope.createSecondPassphraseDialog.data.reSecondPassphrase !== $scope.createSecondPassphraseDialog.data.secondPassphrase) {
           $scope.createSecondPassphraseDialog.data.showWrongRepassphrase = true
         } else {
-          accountService.createSecondPassphraseCreationTransaction({
+          transactionBuilderService.createSecondPassphraseCreationTransaction({
             fromAddress: selectedAccount.address,
             masterpassphrase: $scope.createSecondPassphraseDialog.data.passphrase,
             secondpassphrase: $scope.createSecondPassphraseDialog.data.reSecondPassphrase

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1659,7 +1659,7 @@
       }
 
       function warnAboutSecondPassphraseFee () {
-        accountService.getFees().then(
+        accountService.getFees(true).then(
               function (fees) {
                 let secondPhraseArktoshiVal = fees['secondsignature']
                 var secondPhraseArkVal = secondPhraseArktoshiVal / ARKTOSHI_UNIT

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -434,6 +434,7 @@
       gettextCatalog.setCurrentLanguage(self.language)
     }
 
+
     // Load all registered accounts
     self.accounts = accountService.loadAllAccounts()
 
@@ -962,7 +963,7 @@
           return delegate.vote + delegate.publicKey
         }).join(',')
         console.log(publicKeys)
-        accountService.createTransaction(3, {
+        accountService.createVoteTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.voteDialog.data.fromAddress,
@@ -1015,7 +1016,7 @@
 
         $mdDialog.hide()
         var smartbridge = $scope.send.data.smartbridge
-        accountService.createTransaction(0, {
+        accountService.createSendTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.send.data.fromAddress,
@@ -1479,7 +1480,7 @@
           return formatAndToastError(error)
         }
 
-        accountService.createTransaction(2, {
+        accountService.createDelegateCreationTransaction({
           ledger: selectedAccount.ledger,
           publicKey: selectedAccount.publicKey,
           fromAddress: $scope.createDelegate.data.fromAddress,
@@ -1698,7 +1699,7 @@
         } else if ($scope.createSecondPassphraseDialog.data.reSecondPassphrase !== $scope.createSecondPassphraseDialog.data.secondPassphrase) {
           $scope.createSecondPassphraseDialog.data.showWrongRepassphrase = true
         } else {
-          accountService.createTransaction(1, {
+          accountService.createSecondPassphraseCreationTransaction({
             fromAddress: selectedAccount.address,
             masterpassphrase: $scope.createSecondPassphraseDialog.data.passphrase,
             secondpassphrase: $scope.createSecondPassphraseDialog.data.reSecondPassphrase

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -26,6 +26,7 @@
       'ARKTOSHI_UNIT',
       '$rootScope',
       'transactionBuilderService',
+      'utilityService',
       AccountController
     ])
 
@@ -58,7 +59,8 @@
     $window,
     ARKTOSHI_UNIT,
     $rootScope,
-    transactionBuilderService
+    transactionBuilderService,
+    utilityService
   ) {
     const _path = require('path')
 
@@ -435,8 +437,6 @@
       storageService.set('language', self.language)
       gettextCatalog.setCurrentLanguage(self.language)
     }
-
-
 
     // Load all registered accounts
     self.accounts = accountService.loadAllAccounts()
@@ -1792,8 +1792,8 @@
         transaction: transaction,
         label: accountService.getTransactionLabel(transaction),
         // to avoid small transaction to be displayed as 1e-8
-        humanAmount: accountService.numberToFixed(transaction.amount / ARKTOSHI_UNIT).toString(),
-        totalAmount: ((parseFloat(transaction.amount) + transaction.fee) / ARKTOSHI_UNIT).toString()
+        humanAmount: utilityService.arktoshiToArk(transaction.amount).toString(),
+        totalAmount: utilityService.arktoshiToArk(parseFloat(transaction.amount) + transaction.fee, true).toString()
       }
 
       $mdDialog.show({

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -570,6 +570,7 @@
             return deferred.promise
           }
 
+          transaction.fee = fees.send
           transaction.senderId = config.fromAddress
 
           if (config.ledger) {
@@ -605,6 +606,7 @@
             return deferred.promise
           }
 
+          transaction.fee = fees.secondpassphrase
           transaction.senderId = config.fromAddress
 
           if (config.ledger) {
@@ -641,6 +643,7 @@
             return deferred.promise
           }
 
+          transaction.fee = fees.delegate
           transaction.senderId = config.fromAddress
 
           if (config.ledger) {
@@ -676,6 +679,7 @@
             return deferred.promise
           }
 
+          transaction.fee = fees.vote
           transaction.senderId = config.fromAddress
 
           if (config.ledger) {

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -563,120 +563,6 @@
       return ark
     }
 
-    function createTransaction (deferred, config, fee, createTransactionFunc, setAdditionalTransactionPropsOnLedger) {
-      var transaction
-
-      try {
-        transaction = createTransactionFunc(config)
-      } catch (e) {
-        deferred.reject(e)
-        return
-      }
-
-      transaction.fee = fee
-      transaction.senderId = config.fromAddress
-
-      if (config.ledger) {
-        delete transaction.signature
-        transaction.senderPublicKey = config.publicKey
-        if (setAdditionalTransactionPropsOnLedger) {
-          setAdditionalTransactionPropsOnLedger(transaction)
-        }
-        ledgerService.signTransaction(config.ledger, transaction).then((result) => {
-          transaction.signature = result.signature
-          transaction.id = ark.crypto.getId(transaction)
-          deferred.resolve(transaction)
-        },
-        (error) => deferred.reject(error))
-        return
-      }
-
-      if (ark.crypto.getAddress(transaction.senderPublicKey, networkService.getNetwork().version) !== config.fromAddress) {
-        deferred.reject(gettextCatalog.getString('Passphrase is not corresponding to account ') + config.fromAddress)
-        return
-      }
-
-      deferred.resolve(transaction)
-    }
-
-    function prepareTransaction (config, prepareFunc) {
-      var deferred = $q.defer()
-      var account = getAccount(config.fromAddress)
-      getFees(false).then((fees) => {
-        prepareFunc(deferred, account, fees)
-      })
-      return deferred.promise
-    }
-
-    function createSendTransaction (config) {
-      return prepareTransaction(config, (deferred, account, fees) => {
-        if (!ark.crypto.validateAddress(config.toAddress, networkService.getNetwork().version)) {
-          deferred.reject(gettextCatalog.getString('The destination address ') + config.toAddress + gettextCatalog.getString(' is erroneous'))
-          return
-        }
-
-        if (config.amount + fees.send > account.balance) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress)
-          return
-        }
-
-        createTransaction(deferred,
-                          config,
-                          fees.send,
-                          () => ark.transaction.createTransaction(config.toAddress,
-                                                                  config.amount,
-                                                                  config.smartbridge,
-                                                                  config.masterpassphrase,
-                                                                  config.secondpassphrase))
-      })
-    }
-
-    function createSecondPassphraseCreationTransaction (config) {
-      return prepareTransaction(config, (deferred, account, fees) => {
-        if (account.balance < fees.secondpassphrase) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                          ', ' + gettextCatalog.getString('you need at least ' + arkToshiToArk(fees.secondpassphrase, true) + ' to create a second passphrase'))
-          return
-        }
-
-        createTransaction(deferred,
-                          config,
-                          fees.secondpassphrase,
-                          () => ark.transaction.createSignature(config.masterpassphrase, config.secondpassphrase))
-      })
-    }
-
-    function createDelegateCreationTransaction (config) {
-      return prepareTransaction(config, (deferred, account, fees) => {
-        if (account.balance < fees.delegate) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress + ', ' +
-                          gettextCatalog.getString('you need at least ' + arkToshiToArk(fees.delegate, true) + ' to register delegate'))
-          return
-        }
-
-        createTransaction(deferred,
-                          config,
-                          fees.delegate,
-                          () => ark.delegate.createDelegate(config.masterpassphrase, config.username, config.secondpassphrase))
-      })
-    }
-
-    function createVoteTransaction (config) {
-      return prepareTransaction(config, (deferred, account, fees) => {
-        if (account.balance < fees.vote) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                           ', ' + gettextCatalog.getString('you need at least ' + arkToshiToArk(fees.vote, true) + ' to vote'))
-          return
-        }
-
-        createTransaction(deferred,
-                          config,
-                          fees.vote,
-                          () => ark.vote.createVote(config.masterpassphrase, config.publicKeys.split(','), config.secondpassphrase),
-                          (transaction) => { transaction.recipientId = config.fromAddress })
-      })
-    }
-
     // Given a final list of delegates, create a vote assets list to be sent
     // return null if could not make it
     function createDiffVote (address, newdelegates) {
@@ -953,11 +839,6 @@
       getAllTransactions: getAllTransactions,
 
       getRangedTransactions: getRangedTransactions,
-      createSecondPassphraseCreationTransaction: createSecondPassphraseCreationTransaction,
-
-      createDelegateCreationTransaction: createDelegateCreationTransaction,
-
-      createVoteTransaction: createVoteTransaction,
 
       verifyMessage: verifyMessage,
 
@@ -991,7 +872,9 @@
 
       numberToFixed: numberToFixed,
 
-      formatTransaction: formatTransaction
+      formatTransaction: formatTransaction,
+
+      arkToshiToArk: arkToshiToArk
 
     }
   }

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -2,7 +2,7 @@
   'use strict'
 
   angular.module('arkclient.accounts')
-    .service('accountService', ['$q', '$http', 'networkService', 'storageService', 'ledgerService', 'gettextCatalog', 'ARKTOSHI_UNIT', AccountService])
+    .service('accountService', ['$q', '$http', 'networkService', 'storageService', 'ledgerService', 'gettextCatalog', 'utilityService', 'ARKTOSHI_UNIT', AccountService])
 
   /**
    * Accounts DataService
@@ -12,7 +12,7 @@
    * @returns {{loadAll: Function}}
    * @constructor
    */
-  function AccountService ($q, $http, networkService, storageService, ledgerService, gettextCatalog, ARKTOSHI_UNIT) {
+  function AccountService ($q, $http, networkService, storageService, ledgerService, gettextCatalog, utilityService, ARKTOSHI_UNIT) {
     var self = this
     var ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
 
@@ -263,7 +263,7 @@
         transaction.total = -transaction.amount - transaction.fee
       }
       // to avoid small transaction to be displayed as 1e-8
-      transaction.humanTotal = numberToFixed(transaction.total / ARKTOSHI_UNIT) + ''
+      transaction.humanTotal = utilityService.arktoshiToArk(transaction.total) + ''
 
       return transaction
     }
@@ -554,15 +554,6 @@
       return deferred.promise
     }
 
-    function arkToshiToArk (amount, appendTokenName) {
-      var ark = numberToFixed(amount / ARKTOSHI_UNIT)
-      if (appendTokenName) {
-        return ark + ' ' + networkService.getNetwork().token
-      }
-
-      return ark
-    }
-
     // Given a final list of delegates, create a vote assets list to be sent
     // return null if could not make it
     function createDiffVote (address, newdelegates) {
@@ -747,25 +738,6 @@
       return sanitizedName
     }
 
-    function numberToFixed (x) {
-      var e
-      if (Math.abs(x) < 1.0) {
-        e = parseInt(x.toString().split('e-')[1])
-        if (e) {
-          x *= Math.pow(10, e - 1)
-          x = '0.' + (new Array(e)).join('0') + x.toString().substring(2)
-        }
-      } else {
-        e = parseInt(x.toString().split('+')[1])
-        if (e > 20) {
-          e -= 20
-          x /= Math.pow(10, e)
-          x += (new Array(e + 1)).join('0')
-        }
-      }
-      return x
-    }
-
     return {
       loadAllAccounts: function () {
         var accounts = storageService.get('addresses')
@@ -870,12 +842,7 @@
 
       sanitizeDelegateName: sanitizeDelegateName,
 
-      numberToFixed: numberToFixed,
-
-      formatTransaction: formatTransaction,
-
-      arkToshiToArk: arkToshiToArk
-
+      formatTransaction: formatTransaction
     }
   }
 })()

--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -1,0 +1,138 @@
+;(function () {
+  'use strict'
+
+  angular.module('arkclient.accounts')
+    .service('transactionBuilderService', ['$q', 'networkService', 'accountService', 'ledgerService', 'gettextCatalog', TransactionBuilderService])
+
+  /**
+   * TransactionBuilderService
+   *
+   * @returns {{loadAll: Function}}
+   * @constructor
+   */
+  function TransactionBuilderService ($q, networkService, accountService, ledgerService, gettextCatalog) {
+    var ark = require('../node_modules/arkjs')
+
+    function createTransaction (deferred, config, fee, createTransactionFunc, setAdditionalTransactionPropsOnLedger) {
+      var transaction
+      try {
+        transaction = createTransactionFunc(config)
+      } catch (e) {
+        deferred.reject(e)
+        return
+      }
+
+      transaction.fee = fee
+      transaction.senderId = config.fromAddress
+
+      if (config.ledger) {
+        delete transaction.signature
+        transaction.senderPublicKey = config.publicKey
+        if (setAdditionalTransactionPropsOnLedger) {
+          setAdditionalTransactionPropsOnLedger(transaction)
+        }
+        ledgerService.signTransaction(config.ledger, transaction).then((result) => {
+          transaction.signature = result.signature
+          transaction.id = ark.crypto.getId(transaction)
+          deferred.resolve(transaction)
+        },
+        (error) => deferred.reject(error))
+        return
+      }
+
+      if (ark.crypto.getAddress(transaction.senderPublicKey, networkService.getNetwork().version) !== config.fromAddress) {
+        deferred.reject(gettextCatalog.getString('Passphrase is not corresponding to account ') + config.fromAddress)
+        return
+      }
+      deferred.resolve(transaction)
+    }
+
+    function prepareTransaction (config, prepareFunc) {
+      var deferred = $q.defer()
+      var account = accountService.getAccount(config.fromAddress)
+      accountService.getFees(false).then((fees) => {
+        prepareFunc(deferred, account, fees)
+      })
+      return deferred.promise
+    }
+
+    function createSendTransaction (config) {
+      return prepareTransaction(config, (deferred, account, fees) => {
+        if (!ark.crypto.validateAddress(config.toAddress, networkService.getNetwork().version)) {
+          deferred.reject(gettextCatalog.getString('The destination address ') + config.toAddress + gettextCatalog.getString(' is erroneous'))
+          return
+        }
+
+        if (config.amount + fees.send > account.balance) {
+          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress)
+          return
+        }
+
+        createTransaction(deferred,
+                          config,
+                          fees.send,
+                          () => ark.transaction.createTransaction(config.toAddress,
+                                                                  config.amount,
+                                                                  config.smartbridge,
+                                                                  config.masterpassphrase,
+                                                                  config.secondpassphrase))
+      })
+    }
+
+    function createSecondPassphraseCreationTransaction (config) {
+      return prepareTransaction(config, (deferred, account, fees) => {
+        if (account.balance < fees.secondsignature) {
+          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
+                          ', ' + gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.secondsignature, true) + ' to create a second passphrase'))
+          return
+        }
+
+        createTransaction(deferred,
+                          config,
+                          fees.secondsignature,
+                          () => ark.signature.createSignature(config.masterpassphrase, config.secondpassphrase))
+      })
+    }
+
+    function createDelegateCreationTransaction (config) {
+      return prepareTransaction(config, (deferred, account, fees) => {
+        if (account.balance < fees.delegate) {
+          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress + ', ' +
+                          gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.delegate, true) + ' to register delegate'))
+          return
+        }
+
+        createTransaction(deferred,
+                          config,
+                          fees.delegate,
+                          () => ark.delegate.createDelegate(config.masterpassphrase, config.username, config.secondpassphrase))
+      })
+    }
+
+    function createVoteTransaction (config) {
+      return prepareTransaction(config, (deferred, account, fees) => {
+        if (account.balance < fees.vote) {
+          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
+                           ', ' + gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.vote, true) + ' to vote'))
+          return
+        }
+
+        createTransaction(deferred,
+                          config,
+                          fees.vote,
+                          () => ark.vote.createVote(config.masterpassphrase, config.publicKeys.split(','), config.secondpassphrase),
+                          (transaction) => { transaction.recipientId = config.fromAddress })
+      })
+    }
+
+    return {
+      createSendTransaction: createSendTransaction,
+
+      createSecondPassphraseCreationTransaction: createSecondPassphraseCreationTransaction,
+
+      createDelegateCreationTransaction: createDelegateCreationTransaction,
+
+      createVoteTransaction: createVoteTransaction
+    }
+  }
+})()

--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -2,16 +2,10 @@
   'use strict'
 
   angular.module('arkclient.accounts')
-    .service('transactionBuilderService', ['$q', 'networkService', 'accountService', 'ledgerService', 'gettextCatalog', TransactionBuilderService])
+    .service('transactionBuilderService', ['$q', 'networkService', 'accountService', 'ledgerService', 'gettextCatalog', 'utilityService', TransactionBuilderService])
 
-  /**
-   * TransactionBuilderService
-   *
-   * @returns {{loadAll: Function}}
-   * @constructor
-   */
-  function TransactionBuilderService ($q, networkService, accountService, ledgerService, gettextCatalog) {
-    var ark = require('../node_modules/arkjs')
+  function TransactionBuilderService ($q, networkService, accountService, ledgerService, gettextCatalog, utilityService) {
+    var ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
 
     function createTransaction (deferred, config, fee, createTransactionFunc, setAdditionalTransactionPropsOnLedger) {
       var transaction
@@ -83,7 +77,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.secondsignature) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                          ', ' + gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.secondsignature, true) + ' to create a second passphrase'))
+                          ', ' + gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.secondsignature, false, true) + ' to create a second passphrase'))
           return
         }
 
@@ -98,7 +92,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.delegate) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress + ', ' +
-                          gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.delegate, true) + ' to register delegate'))
+                          gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.delegate, false, true) + ' to register delegate'))
           return
         }
 
@@ -113,7 +107,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.vote) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                           ', ' + gettextCatalog.getString('you need at least ' + accountService.arkToshiToArk(fees.vote, true) + ' to vote'))
+                           ', ' + gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.vote, false, true) + ' to vote'))
           return
         }
 

--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -5,10 +5,10 @@
     .service('transactionBuilderService', ['$q', 'networkService', 'accountService', 'ledgerService', 'gettextCatalog', 'utilityService', TransactionBuilderService])
 
   function TransactionBuilderService ($q, networkService, accountService, ledgerService, gettextCatalog, utilityService) {
-    var ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
+    const ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
 
     function createTransaction (deferred, config, fee, createTransactionFunc, setAdditionalTransactionPropsOnLedger) {
-      var transaction
+      let transaction
       try {
         transaction = createTransactionFunc(config)
       } catch (e) {
@@ -42,8 +42,8 @@
     }
 
     function prepareTransaction (config, prepareFunc) {
-      var deferred = $q.defer()
-      var account = accountService.getAccount(config.fromAddress)
+      const deferred = $q.defer()
+      const account = accountService.getAccount(config.fromAddress)
       accountService.getFees(false).then((fees) => {
         prepareFunc(deferred, account, fees)
       })

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -203,15 +203,24 @@
       //   toAddress: 'AYxKh6vwACWicSGJATGE3rBreFK7whc7YA',
       //   amount: 1,
       // }
-      function totalBalance (minusFee) {
-        var fee = 10000000
+      function getTotalBalance (fee) {
         var balance = selectedAccount.balance
-        return accountService.numberToFixed((minusFee ? balance - fee : balance) / ARKTOSHI_UNIT)
+        return accountService.numberToFixed((fee ? balance - fee : balance) / ARKTOSHI_UNIT)
       }
 
       function fillSendableBalance () {
-        var sendableBalance = totalBalance(true)
-        $scope.send.data.amount = sendableBalance > 0 ? sendableBalance : 0
+        function setBalance (fee) {
+          var sendableBalance = getTotalBalance(fee)
+          $scope.send.data.amount = sendableBalance > 0 ? sendableBalance : 0
+        }
+        // set the balance immediately, so the user sees something
+        setBalance(accountService.defaultFees.send)
+        // now get the real fees and set it again if necessary
+        accountService.getFees(true).then((fees) => {
+          if (fees.send !== accountService.defaultFees.send) {
+            setBalance(fees.send)
+          }
+        })
       }
 
       const submit = () => {
@@ -285,8 +294,8 @@
         selectedContactChange: selectedContactChange,
         querySearch: querySearch,
         fillSendableBalance: fillSendableBalance,
-        totalBalance: totalBalance(false),
-        remainingBalance: totalBalance(false) // <-- initial value, this will change by directive
+        totalBalance: getTotalBalance(0),
+        remainingBalance: getTotalBalance(0) // <-- initial value, this will change by directive
       }
 
       $scope.onQrCodeForToAddressScanned = (address) => {

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -14,10 +14,10 @@
         accountCtrl: '=',
         addressBookCtrl: '='
       },
-      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'ARKTOSHI_UNIT', 'toastService', 'transactionBuilderService', AccountCardController]
+      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'ARKTOSHI_UNIT', 'toastService', 'transactionBuilderService', 'utilityService', AccountCardController]
     })
 
-  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, ARKTOSHI_UNIT, toastService, transactionBuilderService) {
+  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, ARKTOSHI_UNIT, toastService, transactionBuilderService, utilityService) {
     this.$onInit = () => {
       this.ul = this.accountCtrl
       this.ab = this.addressBookCtrl
@@ -205,7 +205,7 @@
       // }
       function getTotalBalance (fee) {
         var balance = selectedAccount.balance
-        return accountService.numberToFixed((fee ? balance - fee : balance) / ARKTOSHI_UNIT)
+        return utilityService.arktoshiToArk(fee ? balance - fee : balance)
       }
 
       function fillSendableBalance () {

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -136,7 +136,7 @@
     }
 
     this.submitTransaction = (selectedAccount, formData) => {
-      return accountService.createTransaction(0, {
+      return accountService.createSendTransaction({
         ledger: selectedAccount.ledger,
         publicKey: selectedAccount.publicKey,
         fromAddress: formData.fromAddress,

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -14,10 +14,10 @@
         accountCtrl: '=',
         addressBookCtrl: '='
       },
-      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'ARKTOSHI_UNIT', 'toastService', AccountCardController]
+      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'ARKTOSHI_UNIT', 'toastService', 'transactionBuilderService', AccountCardController]
     })
 
-  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, ARKTOSHI_UNIT, toastService) {
+  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, ARKTOSHI_UNIT, toastService, transactionBuilderService) {
     this.$onInit = () => {
       this.ul = this.accountCtrl
       this.ab = this.addressBookCtrl
@@ -136,7 +136,7 @@
     }
 
     this.submitTransaction = (selectedAccount, formData) => {
-      return accountService.createSendTransaction({
+      return transactionBuilderService.createSendTransaction({
         ledger: selectedAccount.ledger,
         publicKey: selectedAccount.publicKey,
         fromAddress: formData.fromAddress,

--- a/client/app/src/components/addressbook/addressbook.controller.js
+++ b/client/app/src/components/addressbook/addressbook.controller.js
@@ -3,9 +3,9 @@
 
   angular
     .module('arkclient.components')
-    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'accountService', 'ARKTOSHI_UNIT', AddressbookController])
+    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'accountService', 'utilityService', 'ARKTOSHI_UNIT', AddressbookController])
 
-  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, accountService, ARKTOSHI_UNIT) {
+  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, accountService, utilityService, ARKTOSHI_UNIT) {
     var self = this
     // var contacts
     self.trim = function (str) {
@@ -235,7 +235,7 @@
             return prev + el
           })
 
-          stats.income.amount = accountService.numberToFixed(incomeAmount / ARKTOSHI_UNIT).toFixed(2)
+          stats.income.amount = utilityService.arktoshiToArk(incomeAmount).toFixed(2)
         }
 
         if (expendTx.length > 0) {
@@ -245,7 +245,7 @@
             return prev + el
           })
 
-          stats.expend.amount = accountService.numberToFixed(expendAmount / ARKTOSHI_UNIT).toFixed(2)
+          stats.expend.amount = utilityService.arktoshiToArk(expendAmount).toFixed(2)
         }
       }
 

--- a/client/app/src/services/utility.service.js
+++ b/client/app/src/services/utility.service.js
@@ -1,0 +1,49 @@
+;(function () {
+  'use strict'
+
+  angular.module('arkclient.services')
+    .service('utilityService', ['networkService', 'ARKTOSHI_UNIT', UtilityService])
+
+  function UtilityService (networkService, ARKTOSHI_UNIT) {
+    function arktoshiToArk (amount, keepPrecise, appendTokenName) {
+      if (!amount) {
+        return 0
+      }
+
+      let ark = amount / ARKTOSHI_UNIT
+
+      if (!keepPrecise) {
+        ark = numberToFixed(ark)
+      }
+
+      if (appendTokenName) {
+        return ark + ' ' + networkService.getNetwork().token
+      }
+
+      return ark
+    }
+
+    function numberToFixed (x) {
+      var e
+      if (Math.abs(x) < 1.0) {
+        e = parseInt(x.toString().split('e-')[1])
+        if (e) {
+          x *= Math.pow(10, e - 1)
+          x = '0.' + (new Array(e)).join('0') + x.toString().substring(2)
+        }
+      } else {
+        e = parseInt(x.toString().split('+')[1])
+        if (e > 20) {
+          e -= 20
+          x /= Math.pow(10, e)
+          x += (new Array(e + 1)).join('0')
+        }
+      }
+      return x
+    }
+
+    return {
+      arktoshiToArk: arktoshiToArk
+    }
+  }
+})()

--- a/client/app/src/services/utility.service.js
+++ b/client/app/src/services/utility.service.js
@@ -24,7 +24,7 @@
     }
 
     function numberToFixed (x) {
-      var e
+      let e
       if (Math.abs(x) < 1.0) {
         e = parseInt(x.toString().split('e-')[1])
         if (e) {

--- a/test/accounts/account.controller.js
+++ b/test/accounts/account.controller.js
@@ -17,7 +17,8 @@ describe('AccountController', function () {
     storageServiceMock,
     ledgerServiceMock,
     timeServiceMock,
-    toastServiceMock
+    toastServiceMock,
+    transactionBuilderServiceMock
 
   let mdThemingProviderMock,
     mdThemingMock
@@ -60,8 +61,10 @@ describe('AccountController', function () {
         loadAllAccounts () { return ACCOUNTS },
         getActiveDelegates: angular.noop,
         getDelegateByUsername: angular.noop,
-        getFees: sinon.stub().resolves(),
-        createTransaction: sinon.stub().resolves()
+        getFees: sinon.stub().resolves()
+      }
+      transactionBuilderServiceMock = {
+        createSecondPassphraseCreationTransaction: sinon.stub().resolves()
       }
       networkServiceMock = {
         getLatestClientVersion () { return new Promise((resolve, reject) => resolve('0.0.0')) },
@@ -116,6 +119,7 @@ describe('AccountController', function () {
 
       // provide mocks to angular controller
       $provide.value('accountService', accountServiceMock)
+      $provide.value('transactionBuilderService', transactionBuilderServiceMock)
       $provide.value('networkService', networkServiceMock)
       $provide.value('pluginLoader', pluginLoaderMock)
       $provide.value('storageService', storageServiceMock)
@@ -283,7 +287,7 @@ describe('AccountController', function () {
   describe('adding second passphrase', () => {
     let requireNotMocked = require
     beforeEach( () => {
-      require = sinon.stub().returns(require('../node_modules/bip39'))
+      require = sinon.stub().returns(require(require('path').resolve(__dirname, '../node_modules/bip39')))
     })
     afterEach( () => {
       require = requireNotMocked
@@ -313,7 +317,7 @@ describe('AccountController', function () {
         $scope.createSecondPassphraseDialog.next()
         $scope.createSecondPassphraseDialog.data.secondPassphrase = $scope.createSecondPassphraseDialog.data.reSecondPassphrase
         $scope.createSecondPassphraseDialog.next()
-        sinon.assert.calledOnce(accountServiceMock.createTransaction)
+        sinon.assert.calledOnce(transactionBuilderServiceMock.createSecondPassphraseCreationTransaction)
       })
     })
   })

--- a/test/components/accounts/account-card.controller.js
+++ b/test/components/accounts/account-card.controller.js
@@ -14,11 +14,14 @@ describe('AccountCardController', function () {
   }
 
   const accountServiceMock = {
-    createTransaction: sinon.stub(),
     getUsername: sinon.stub(),
     setUsername: sinon.stub(),
     removeAccount: sinon.stub(),
     loadAllAccounts: sinon.stub()
+  }
+
+  const transactionBuilderServiceMock = {
+    createSendTransaction: sinon.stub()
   }
 
   const mdDialogMock = {
@@ -30,6 +33,7 @@ describe('AccountCardController', function () {
   beforeEach(() => {
     module('arkclient.components', $provide => {
       $provide.value('accountService', accountServiceMock)
+      $provide.value('transactionBuilderService', transactionBuilderServiceMock)
       $provide.value('$mdDialog', mdDialogMock)
       $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
@@ -144,20 +148,20 @@ describe('AccountCardController', function () {
 
   describe('submitTransaction()', () => {
     afterEach(function () {
-      accountServiceMock.createTransaction.reset()
+      transactionBuilderServiceMock.createSendTransaction.reset()
     })
 
     context('when the form amount is a float', () => {
       it('uses the right amount to create the transaction', function () {
-        accountServiceMock.createTransaction.resolves({})
-        const stub = accountServiceMock.createTransaction
+        transactionBuilderServiceMock.createSendTransaction.resolves({})
+        const stub = transactionBuilderServiceMock.createSendTransaction
 
         // @see https://github.com/ArkEcosystem/ark-desktop/issues/385
         ctrl.submitTransaction({}, { amount: 1.0440473 })
-        expect(stub.firstCall.args[1].amount).to.equal(104404730)
+        expect(stub.firstCall.args[0].amount).to.equal(104404730)
 
         ctrl.submitTransaction({}, { amount: 299.9 })
-        expect(stub.secondCall.args[1].amount).to.equal(29990000000)
+        expect(stub.secondCall.args[0].amount).to.equal(29990000000)
       })
     })
   })

--- a/test/components/addressbook/addressbook.controller.js
+++ b/test/components/addressbook/addressbook.controller.js
@@ -11,7 +11,8 @@ describe('AddressbookController', function () {
     storageServiceMock,
     getTextCatalogMock,
     accountServiceMock,
-    toastServiceMock
+    toastServiceMock,
+    utilityService
 
   beforeEach(() => {
     module('arkclient.components', $provide => {
@@ -37,6 +38,7 @@ describe('AddressbookController', function () {
         error: sinon.stub(),
         success: sinon.stub()
       }
+      utilityService = {}
 
       // provide mocks to angular controller
       $provide.value('$mdDialog', mdDialogMock)
@@ -45,6 +47,7 @@ describe('AddressbookController', function () {
       $provide.value('gettextCatalog', getTextCatalogMock)
       $provide.value('accountService', accountServiceMock)
       $provide.value('toastService', toastServiceMock)
+      $provide.value('utilityService', utilityService)
       $provide.value('ARKTOSHI_UNIT', Math.pow(10,8))
     })
 
@@ -106,7 +109,7 @@ describe('AddressbookController', function () {
       mdDialogHideStub = sinon.stub(mdDialogMock, 'hide')
       ctrl.getContacts = sinon.stub().returns([])
       ctrl.showToast = sinon.stub()
-    })
+})
 
     context('set up addressbook contact modal', () => {
       it('sets up address book modal', () => {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -34,6 +34,7 @@ module.exports = function (config) {
       // Subjects under test
       '../client/app/src/init.js',
       '../client/app/src/accounts/account.service.js',
+      '../client/app/src/accounts/transaction-builder.service.js',
       '../client/app/src/accounts/account.controller.js',
       '../client/app/src/addons/pluginLoader.addon.js',
       '../client/app/src/components/**/*.js',

--- a/test/services/transaction-builder.service.js
+++ b/test/services/transaction-builder.service.js
@@ -1,10 +1,8 @@
 'use strict'
 
-var chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-
 describe('transactionBuilderService',() => {
 
+  const tokenName = 'test-ark'
   let transactionBuilderService, accountService
   let configServiceMock, gettextCatalogMock, networkServiceMock, ledgerServiceMock, getAccountStub
   let intervalRef
@@ -63,7 +61,7 @@ describe('transactionBuilderService',() => {
       gettextCatalogMock = {getString: sinon.stub().returnsArg(0)}
       networkServiceMock = { listenNetworkHeight: sinon.stub(),
                           getPeer: sinon.stub().returns("127.0.0.1"),
-                          getNetwork: sinon.stub.returns({ version: 0x17, token: 'test-ark' })
+                          getNetwork: sinon.stub().returns({ version: 0x17, token: tokenName })
                         }
       ledgerServiceMock = {signTransaction: sinon.stub().resolves({})}
 
@@ -205,8 +203,9 @@ describe('transactionBuilderService',() => {
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
         }, err => {
+          expect(err).to.have.string(tokenName);
           done()
-        })
+        }).catch(err => done(err))
     })
   })
 
@@ -241,8 +240,9 @@ describe('transactionBuilderService',() => {
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
         }, err => {
+          expect(err).to.have.string(tokenName);
           done()
-        })
+        }).catch(err => done(err))
     })
   })
 
@@ -276,8 +276,9 @@ describe('transactionBuilderService',() => {
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
         }, err => {
+          expect(err).to.have.string(tokenName);
           done()
-        })
+        }).catch(err => done(err))
     })
 
     it('should work with ledger (additional field recipientId is correct)', (done) => {

--- a/test/services/transaction-builder.service.js
+++ b/test/services/transaction-builder.service.js
@@ -96,7 +96,7 @@ describe('transactionBuilderService',() => {
     afterEach(() => restoreGetAccount())
 
     it('should have correct type', (done) => {
-      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(0)
@@ -105,7 +105,7 @@ describe('transactionBuilderService',() => {
     })
 
     it('should have correct amount', (done) => {
-      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.amount).to.eql(1)
@@ -114,7 +114,7 @@ describe('transactionBuilderService',() => {
     })
 
     it('should have correct fee', (done) => {
-      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.fee).to.eql(fees.send)
@@ -125,7 +125,7 @@ describe('transactionBuilderService',() => {
     it('should work with ledger', (done) => {
       const config = createValidConfigObject();
       config.ledger = true
-      var sendPromise = transactionBuilderService.createSendTransaction(config)
+      const sendPromise = transactionBuilderService.createSendTransaction(config)
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(0)
@@ -138,7 +138,7 @@ describe('transactionBuilderService',() => {
     it('should fail when to address is invalid', (done) => {
       const config = createValidConfigObject();
       config.toAddress += "B"
-      var sendPromise = transactionBuilderService.createSendTransaction(config)
+      const sendPromise = transactionBuilderService.createSendTransaction(config)
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -150,7 +150,7 @@ describe('transactionBuilderService',() => {
     it('should fail when when passphrase is invalid', (done) => {
       const config = createValidConfigObject();
       config.masterpassphrase = "C"
-      var sendPromise = transactionBuilderService.createSendTransaction(config)
+      const sendPromise = transactionBuilderService.createSendTransaction(config)
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -162,7 +162,7 @@ describe('transactionBuilderService',() => {
     it('should fail when balance is too low', (done) => {
       const config = createValidConfigObject();
       config.amount = from.balance - 1
-      var sendPromise = transactionBuilderService.createSendTransaction(config)
+      const sendPromise = transactionBuilderService.createSendTransaction(config)
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -178,7 +178,7 @@ describe('transactionBuilderService',() => {
     afterEach(() => restoreGetAccount())
 
     it('should have correct type', (done) => {
-      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(1)
@@ -187,7 +187,7 @@ describe('transactionBuilderService',() => {
     })
 
     it('should have correct fee', (done) => {
-      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.fee).to.eql(fees.secondsignature)
@@ -198,7 +198,7 @@ describe('transactionBuilderService',() => {
     it('should fail when balance is too low', (done) => {
       restoreGetAccount()
       mockGetAccount(fees.secondsignature - 1)
-      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -215,7 +215,7 @@ describe('transactionBuilderService',() => {
     afterEach(() => restoreGetAccount())
 
     it('should have correct type', (done) => {
-      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(2)
@@ -224,7 +224,7 @@ describe('transactionBuilderService',() => {
     })
 
     it('should have correct fee', (done) => {
-      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.fee).to.eql(fees.delegate)
@@ -235,7 +235,7 @@ describe('transactionBuilderService',() => {
     it('should fail when balance is too low', (done) => {
       restoreGetAccount()
       mockGetAccount(fees.delegate - 1)
-      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -251,7 +251,7 @@ describe('transactionBuilderService',() => {
     afterEach(() => restoreGetAccount())
 
     it('should have correct type', (done) => {
-      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(3)
@@ -260,7 +260,7 @@ describe('transactionBuilderService',() => {
     })
 
     it('should have correct fee', (done) => {
-      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
         expect(transaction.fee).to.eql(fees.vote)
@@ -271,7 +271,7 @@ describe('transactionBuilderService',() => {
     it('should fail when balance is too low', (done) => {
       restoreGetAccount()
       mockGetAccount(fees.vote - 1)
-      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+      const sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
 
       sendPromise.then(transaction => {
           done("error: shouldn't be here!");
@@ -284,7 +284,7 @@ describe('transactionBuilderService',() => {
     it('should work with ledger (additional field recipientId is correct)', (done) => {
       const config = createValidConfigObject();
       config.ledger = true
-      var sendPromise = transactionBuilderService.createVoteTransaction(config)
+      const sendPromise = transactionBuilderService.createVoteTransaction(config)
 
       sendPromise.then(transaction => {
         expect(transaction.type).to.eql(3)

--- a/test/services/transaction-builder.service.js
+++ b/test/services/transaction-builder.service.js
@@ -1,0 +1,296 @@
+'use strict'
+
+var chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+
+describe('transactionBuilderService',() => {
+
+  let transactionBuilderService, accountService
+  let configServiceMock, gettextCatalogMock, networkServiceMock, ledgerServiceMock, getAccountStub
+  let intervalRef
+
+  const fees = {
+    send: 20000000,
+    vote: 300000000,
+    secondsignature: 400000000,
+    delegate: 500000000,
+    multisignature: 600000000
+  }
+
+  const from = {
+    username: "Luke Skywalker",
+    address: "AVjcAoo282db5Xgm7oaps1AEbKoC26eTyB",
+    masterpassphrase: "agent cube glass fade lonely salon border notable weekend expect image grunt",
+    secondpassphrase: "agent cube glass fade lonely salon border notable weekend expect image grunt",
+    balance: 600000000
+  }
+
+  const to = {
+    address: "AYxKh6vwACWicSGJATGE3rBreFK7whc7YA",
+    publicKey: "02dcb94d73fb54e775f734762d26975d57f18980314f3b67bc52beb393893bc705"
+  }
+
+  function createValidConfigObject() {
+    return {
+      amount: 1,
+      username: from.username,
+      fromAddress: from.address,
+      masterpassphrase: from.masterpassphrase,
+      secondpassphrase: from.masterpassphrase,
+      toAddress: to.address,
+      publicKeys: to.publicKey, // required for vote transaction
+      publicKey: to.publicKey // required for ledger
+    }
+  }
+
+  function mockGetAccount(balance) {
+    getAccountStub = sinon.stub(accountService, 'getAccount').returns({balance: balance})
+  }
+
+  function restoreGetAccount() {
+    if (getAccountStub) {
+      getAccountStub.restore()
+    }
+  }
+
+  beforeEach(module((_$exceptionHandlerProvider_) => {
+    _$exceptionHandlerProvider_.mode('log');
+   }));
+
+  beforeEach(() => {
+    module("arkclient.accounts", $provide => {
+      configServiceMock = { notice: sinon.stub(), getByGroupAndKey: sinon.stub() }
+      gettextCatalogMock = {getString: sinon.stub().returnsArg(0)}
+      networkServiceMock = { listenNetworkHeight: sinon.stub(),
+                          getPeer: sinon.stub().returns("127.0.0.1"),
+                          getNetwork: sinon.stub.returns({ version: 0x17, token: 'test-ark' })
+                        }
+      ledgerServiceMock = {signTransaction: sinon.stub().resolves({})}
+
+      // inject the mock services
+      $provide.value('configService', configServiceMock)
+      $provide.value('gettextCatalog', gettextCatalogMock)
+      $provide.value('networkService', networkServiceMock)
+      $provide.value('ledgerService', ledgerServiceMock)
+      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
+    })
+
+    inject(($injector, _$rootScope_) => {
+      transactionBuilderService = $injector.get('transactionBuilderService')
+
+      accountService =  $injector.get('accountService')
+      sinon.stub(accountService, 'getFees').resolves(fees)
+
+      // because the transactionBuilderService creates a deferred-promise via '$q.defer()' we have to apply the scope "all the time"
+      // the reason for this is, how $q.defer works: For a promise to really be resolved not only "resolve()" or "reject()" has to be called
+      // but also $scope.apply() has to be called AFTER the other methods, however since this resolve is called async, we cannot know when
+      // to call $scope.apply, therefore we just call it "all the time"
+      // see: https://github.com/angular/angular.js/issues/9954
+      intervalRef = setInterval(()=>  _$rootScope_.$apply(), 1)
+    })
+  })
+
+  afterEach(() => clearInterval(intervalRef))
+
+  describe('createSendTransaction', () => {
+
+    beforeEach(() => mockGetAccount(from.balance))
+    afterEach(() => restoreGetAccount())
+
+    it('should have correct type', (done) => {
+      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(0)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should have correct amount', (done) => {
+      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.amount).to.eql(1)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should have correct fee', (done) => {
+      var sendPromise = transactionBuilderService.createSendTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.fee).to.eql(fees.send)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should work with ledger', (done) => {
+      const config = createValidConfigObject();
+      config.ledger = true
+      var sendPromise = transactionBuilderService.createSendTransaction(config)
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(0)
+        expect(transaction.amount).to.eql(1)
+        expect(transaction.fee).to.eql(fees.send)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should fail when to address is invalid', (done) => {
+      const config = createValidConfigObject();
+      config.toAddress += "B"
+      var sendPromise = transactionBuilderService.createSendTransaction(config)
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+
+    it('should fail when when passphrase is invalid', (done) => {
+      const config = createValidConfigObject();
+      config.masterpassphrase = "C"
+      var sendPromise = transactionBuilderService.createSendTransaction(config)
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+
+    it('should fail when balance is too low', (done) => {
+      const config = createValidConfigObject();
+      config.amount = from.balance - 1
+      var sendPromise = transactionBuilderService.createSendTransaction(config)
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+  })
+
+  describe('createSecondPassphraseCreationTransaction', () => {
+
+    beforeEach(() => mockGetAccount(from.balance))
+    afterEach(() => restoreGetAccount())
+
+    it('should have correct type', (done) => {
+      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(1)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should have correct fee', (done) => {
+      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.fee).to.eql(fees.secondsignature)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should fail when balance is too low', (done) => {
+      restoreGetAccount()
+      mockGetAccount(fees.secondsignature - 1)
+      var sendPromise = transactionBuilderService.createSecondPassphraseCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+  })
+
+  describe('createDelegateCreationTransaction', () => {
+
+    beforeEach(() => mockGetAccount(from.balance))
+    afterEach(() => restoreGetAccount())
+
+    it('should have correct type', (done) => {
+      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(2)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should have correct fee', (done) => {
+      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.fee).to.eql(fees.delegate)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should fail when balance is too low', (done) => {
+      restoreGetAccount()
+      mockGetAccount(fees.delegate - 1)
+      var sendPromise = transactionBuilderService.createDelegateCreationTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+  })
+
+  describe('createVoteTransaction', () => {
+    beforeEach(() => mockGetAccount(from.balance))
+    afterEach(() => restoreGetAccount())
+
+    it('should have correct type', (done) => {
+      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(3)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should have correct fee', (done) => {
+      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+        expect(transaction.fee).to.eql(fees.vote)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+
+    it('should fail when balance is too low', (done) => {
+      restoreGetAccount()
+      mockGetAccount(fees.vote - 1)
+      var sendPromise = transactionBuilderService.createVoteTransaction(createValidConfigObject())
+
+      sendPromise.then(transaction => {
+          done("error: shouldn't be here!");
+        }, err => {
+          done()
+        })
+    })
+
+    it('should work with ledger (additional field recipientId is correct)', (done) => {
+      const config = createValidConfigObject();
+      config.ledger = true
+      var sendPromise = transactionBuilderService.createVoteTransaction(config)
+
+      sendPromise.then(transaction => {
+        expect(transaction.type).to.eql(3)
+        expect(transaction.fee).to.eql(fees.vote)
+        expect(transaction.recipientId).to.eql(config.fromAddress)
+        done()
+      }, err => done(err)).catch(err => done(err))
+    })
+  })
+})

--- a/test/services/utility.service.js
+++ b/test/services/utility.service.js
@@ -24,43 +24,43 @@ describe('utilityService',() => {
   describe('arktoshiToArk', () => {
 
     it('undefined arktoshi is 0 Ark', () => {
-      var ark = utilityService.arktoshiToArk()
+      const ark = utilityService.arktoshiToArk()
 
       expect(ark).to.eql(0)
     })
 
     it('0 arktoshi is 0 Ark', () => {
-      var ark = utilityService.arktoshiToArk(0)
+      const ark = utilityService.arktoshiToArk(0)
 
       expect(ark).to.eql(0)
     })
 
     it('1 arktoshi is 1 Ark', () => {
-      var ark = utilityService.arktoshiToArk(arktoshiUnit)
+      const ark = utilityService.arktoshiToArk(arktoshiUnit)
 
       expect(ark).to.eql(1)
     })
 
     it('1/2 arktoshi is 0.5 Ark', () => {
-      var ark = utilityService.arktoshiToArk(arktoshiUnit / 2)
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 2)
 
       expect(ark).to.eql(0.5)
     })
 
     it('1111111 part of arktoshi is human readable amount of Ark', () => {
-      var ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111)
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111)
 
       expect(ark).to.eq('0.000000900000090000009')
     })
 
     it('1111111 part of arktoshi is precise amount of Ark', () => {
-      var ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, true)
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, true)
 
       expect(ark).to.be.within(9.00000090000000e-7, 9.00000090000009e-7)
     })
 
     it('1 arktoshi is 1 test-ark (include network token)', () => {
-      var ark = utilityService.arktoshiToArk(arktoshiUnit, false, true)
+      const ark = utilityService.arktoshiToArk(arktoshiUnit, false, true)
 
       expect(ark).to.eql('1 ' + tokenName)
     })

--- a/test/services/utility.service.js
+++ b/test/services/utility.service.js
@@ -1,0 +1,68 @@
+'use strict'
+
+describe('utilityService',() => {
+
+  const tokenName = 'test-ark'
+  const arktoshiUnit = Math.pow(10, 8)
+  let utilityService
+  let networkServiceMock
+
+  beforeEach(() => {
+    module('arkclient.services', $provide => {
+      networkServiceMock = { getNetwork: sinon.stub().returns({version: 0x17, token: tokenName }) }
+
+      // inject the mock services
+      $provide.value('networkService', networkServiceMock)
+      $provide.value('ARKTOSHI_UNIT', arktoshiUnit)
+    })
+
+    inject(($injector, _$rootScope_) => {
+      utilityService = $injector.get('utilityService')
+    })
+  })
+
+  describe('arktoshiToArk', () => {
+
+    it('undefined arktoshi is 0 Ark', () => {
+      var ark = utilityService.arktoshiToArk()
+
+      expect(ark).to.eql(0)
+    })
+
+    it('0 arktoshi is 0 Ark', () => {
+      var ark = utilityService.arktoshiToArk(0)
+
+      expect(ark).to.eql(0)
+    })
+
+    it('1 arktoshi is 1 Ark', () => {
+      var ark = utilityService.arktoshiToArk(arktoshiUnit)
+
+      expect(ark).to.eql(1)
+    })
+
+    it('1/2 arktoshi is 0.5 Ark', () => {
+      var ark = utilityService.arktoshiToArk(arktoshiUnit / 2)
+
+      expect(ark).to.eql(0.5)
+    })
+
+    it('1111111 part of arktoshi is human readable amount of Ark', () => {
+      var ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111)
+
+      expect(ark).to.eq('0.000000900000090000009')
+    })
+
+    it('1111111 part of arktoshi is precise amount of Ark', () => {
+      var ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, true)
+
+      expect(ark).to.be.within(9.00000090000000e-7, 9.00000090000009e-7)
+    })
+
+    it('1 arktoshi is 1 test-ark (include network token)', () => {
+      var ark = utilityService.arktoshiToArk(arktoshiUnit, false, true)
+
+      expect(ark).to.eql('1 ' + tokenName)
+    })
+  })
+})


### PR DESCRIPTION
So I decided to tackle this guy! Took me quite a while to figure out the main problem :)

Main problem was:

In the desktop we already used the method `getFees` to get fees from the network, however we then used `arkjs` to create our transactions. `arkjs`  always uses the default values for all fees of all transaction types (see here for an example: https://github.com/ArkEcosystem/ark-js/blob/0b8d460a54657b24703e0b7fe59cf2067e00491b/lib/transactions/vote.js#L30 ) and we did never overwrite them.

So basically if a network had different fees for a transaction type, we ignored it and just used the default value...

Secon problem:
When clicking "Send all" in the send dialog, we used a hardcoded fee type, instead of the one from the network (however this is just a ui bug).

**NOTE:**
I will probably add a third commit to refactor this `createTransaction` method, which is imho, horribly big :P

Fixes: #453