### PR TITLE
Unify passphrase input in the whole app

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -142,6 +142,7 @@
   <script src="src/components/qr-scanner/qr-scanner.directive.js"></script>
   <script src="src/components/addressbook/addressbook.controller.js"></script>
   <script src="src/components/emptystate/empty-state.controller.js"></script>
+  <script src="src/components/passphrase-field/passphrase-field.controller.js"></script>
 
   <script src="app.js"></script>
 

--- a/client/app/src/accounts/view/createDelegate.html
+++ b/client/app/src/accounts/view/createDelegate.html
@@ -24,20 +24,8 @@
           <label translate>Username</label>
           <input ng-model="createDelegate.data.username" type="text" ng-required="true" md-autofocus>
         </md-input-container>
-        <md-input-container class="md-block" ng-if="!send.data.ledger">
-          <label translate>Passphrase</label>
-          <input ng-model="createDelegate.data.passphrase" type="password" ng-required="true" ng-attr-type="{{ send.showPassphrase ? 'text' : 'password' }}">
-          <md-icon style="cursor: pointer;outline: none" ng-click="send.showPassphrase = !send.showPassphrase" md-font-library="material-icons">
-            {{ send.showPassphrase ? 'visibility_off' : 'visibility' }}
-          </md-icon>
-        </md-input-container>
-        <md-input-container class="md-block" ng-if="createDelegate.data.secondSignature">
-          <label translate>Second Passphrase</label>
-          <input ng-model="createDelegate.data.secondpassphrase" type="password" ng-required="true" ng-attr-type="{{ send.showSecondPassphrase ? 'text' : 'password' }}">
-          <md-icon style="cursor: pointer;outline: none" ng-click="send.showSecondPassphrase = !send.showSecondPassphrase" md-font-library="material-icons">
-            {{ send.showSecondPassphrase ? 'visibility_off' : 'visibility' }}
-          </md-icon>
-        </md-input-container>
+        <passphrase-field ng-if="!send.data.ledger" ng-model="createDelegate.data.passphrase" label="Passphrase"></passphrase-field>
+        <passphrase-field ng-if="createDelegate.data.secondSignature" ng-model="createDelegate.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/accounts/view/createSecondPassphrase.html
+++ b/client/app/src/accounts/view/createSecondPassphrase.html
@@ -25,16 +25,12 @@
         <div ng-if="createSecondPassphraseDialog.data.showRepassphrase" translate>
           Please paste the original and second passphrase to validate the creation.
         </div>
-        <md-input-container ng-if="createSecondPassphraseDialog.data.showRepassphrase" class="md-block">
-          <label translate>Original Passphrase</label>
-          <input ng-model="createSecondPassphraseDialog.data.passphrase" type="password" ng-required="true" />
+        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.passphrase" label="Original Passphrase"></passphrase-field>
+        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.secondPassphrase" label="Second Passphrase"></passphrase-field>
+        <md-input-container class="md-block" ng-if="!createSecondPassphraseDialog.data.showRepassphrase">
+            <label translate>Second Passphrase</label>
+            <input ng-model="createSecondPassphraseDialog.data.secondPassphrase" type="text" readonly="readonly" md-autofocus />
         </md-input-container>
-        <md-input-container class="md-block">
-          <label translate>Second Passphrase</label>
-          <input ng-if="!createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.secondPassphrase" type="text" readonly="readonly" md-autofocus/>
-          <input ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.secondPassphrase" type="text" ng-required="true" md-autofocus/>
-        </md-input-container>
-
         <div ng-if="createSecondPassphraseDialog.data.showWrongRepassphrase" translate>
           The second passphrase does not match the one you just got.
         </div>

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -19,15 +19,7 @@
           </md-card-title-text>
         </md-card-title>
       </md-card>
-      <div layout="row" flex layout-align="start start">
-        <md-input-container flex="5">
-          <qr-scanner input-callback="passphrase"></qr-scanner>
-        </md-input-container>
-        <md-input-container class="md-block" md-no-float class="md-block" flex="95">
-          <label translate>Passphrase</label>
-          <input ng-model="send.data.passphrase" ng-required="true" type="text" md-autofocus>
-        </md-input-container>
-      </div>
+      <passphrase-field ng-model="send.data.passphrase" label="Passphrase" auto-focus="true"></passphrase-field>
       <!--<md-input-container md-no-float class="md-block">
         <label>Second Passphrase</label>
         <input ng-model="send.data.secondpassphrase" type="text">

--- a/client/app/src/accounts/view/signMessage.html
+++ b/client/app/src/accounts/view/signMessage.html
@@ -15,10 +15,7 @@
           <label translate>Address</label>
           <input ng-model="sign.selectedAccount.address" ng-disabled="true" ng-required="true" type="text">
         </md-input-container>
-        <md-input-container class="md-block" ng-if="!sign.selectedAccount.ledger">
-          <label translate>Passphrase</label>
-          <input ng-model="sign.passphrase" type="password" ng-required="true" type="text">
-        </md-input-container>
+        <passphrase-field ng-if="!sign.selectedAccount.ledger" ng-model="sign.passphrase" label="Passphrase"></passphrase-field>
         <md-input-container class="md-block">
           <label translate>Message</label>
           <input ng-model="sign.message" ng-required="true" type="text">

--- a/client/app/src/accounts/view/timestampDocument.html
+++ b/client/app/src/accounts/view/timestampDocument.html
@@ -36,15 +36,8 @@
         <md-input-container md-no-float class="md-block">
           <span><b translate>SHA256 Signature</b> {{send.data.smartbridge}}</span>
         </md-input-container>
-
-        <md-input-container ng-if="!send.data.ledger" class="md-block">
-          <label translate>Passphrase</label>
-          <input ng-model="send.data.passphrase" type="password" ng-required="true">
-        </md-input-container>
-        <md-input-container ng-if="!send.data.ledger && send.data.secondSignature" class="md-block">
-          <label translate>Second Passphrase</label>
-          <input ng-model="send.data.secondpassphrase" type="password" ng-required="true">
-        </md-input-container>
+        <passphrase-field ng-if="!send.data.ledger" ng-model="send.data.passphrase" label="Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!send.data.ledger && send.data.secondSignature" ng-model="send.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row" style="padding-left: 20px">

--- a/client/app/src/accounts/view/vote.html
+++ b/client/app/src/accounts/view/vote.html
@@ -14,20 +14,8 @@
         <md-chips ng-model="voteDialog.data.votes" readonly="true">
           <md-chip-template>{{$chip.vote}}{{$chip.username}}</md-chip-template>
         </md-chips>
-        <md-input-container ng-if="!voteDialog.data.ledger" class="md-block">
-          <label translate>Passphrase</label>
-          <input ng-model="voteDialog.data.passphrase" type="password" ng-attr-type="{{ send.showPassphrase ? 'text' : 'password' }}" ng-required="true">
-          <md-icon style="cursor: pointer;outline: none" ng-click="send.showPassphrase = !send.showPassphrase" md-font-library="material-icons">
-            {{ send.showPassphrase ? 'visibility_off' : 'visibility' }}
-          </md-icon>
-        </md-input-container>
-        <md-input-container class="md-block" ng-if="voteDialog.data.secondSignature">
-          <label translate>Second Passphrase</label>
-          <input ng-model="voteDialog.data.secondpassphrase" type="password" ng-attr-type="{{ send.showSecondPassphrase ? 'text' : 'password' }}" ng-required="true">
-          <md-icon style="cursor: pointer;outline: none" ng-click="send.showSecondPassphrase = !send.showSecondPassphrase" md-font-library="material-icons">
-            {{ send.showSecondPassphrase ? 'visibility_off' : 'visibility' }}
-          </md-icon>
-        </md-input-container>
+        <passphrase-field ng-if="!voteDialog.data.ledger" ng-model="voteDialog.data.passphrase" label="Passphrase"></passphrase-field>
+        <passphrase-field ng-if="voteDialog.data.secondSignature" ng-model="voteDialog.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -45,32 +45,8 @@
           <label>{{'Smartbridge'|translate}} ({{'Optional'|translate}})</label>
           <input ng-model="send.data.smartbridge" type="text" ng-required="false" maxlength="64" tabIndex="3">
         </md-input-container>
-
-        <div layout="row" flex layout-align="start start">
-          <md-input-container flex="5" ng-if="!send.data.ledger">
-            <qr-scanner input-callback="passphrase"></qr-scanner>
-          </md-input-container>
-          <md-input-container flex="95" ng-if="!send.data.ledger" class="md-block">
-            <label translate>Passphrase</label>
-            <input ng-model="send.data.passphrase" type="password" ng-required="true" ng-attr-type="{{ send.showPassphrase ? 'text' : 'password' }}" tabIndex="4">
-            <md-icon style="cursor: pointer;outline: none" ng-click="send.showPassphrase = !send.showPassphrase" md-font-library="material-icons">
-              {{ send.showPassphrase ? 'visibility_off' : 'visibility' }}
-            </md-icon>
-          </md-input-container>
-        </div>
-
-        <div layout="row" flex layout-align="start start"  ng-if="send.data.secondSignature">
-          <md-input-container flex="5">
-            <qr-scanner input-callback="secondpassphrase"></qr-scanner>
-          </md-input-container>
-          <md-input-container flex="95" class="md-block">
-            <label translate>Second Passphrase</label>
-            <input ng-model="send.data.secondpassphrase" type="password" ng-required="true" ng-attr-type="{{ send.showSecondPassphrase ? 'text' : 'password' }}" tabIndex="5">
-            <md-icon style="cursor: pointer;outline: none" ng-click="send.showSecondPassphrase = !send.showSecondPassphrase" md-font-library="material-icons">
-              {{ send.showSecondPassphrase ? 'visibility_off' : 'visibility' }}
-            </md-icon>
-          </md-input-container>
-        </div>
+        <passphrase-field ng-if="!send.data.ledger" ng-model="send.data.passphrase" label="Passphrase" tab-index="4"></passphrase-field>
+        <passphrase-field ng-if="send.data.secondSignature"ng-model="send.data.secondpassphrase" label="Second Passphrase" tab-index="5"></passphrase-field>
       </div>
     </md-dialog-content>
 

--- a/client/app/src/components/passphrase-field/passphrase-field.controller.js
+++ b/client/app/src/components/passphrase-field/passphrase-field.controller.js
@@ -1,0 +1,45 @@
+;(function () {
+  'use strict'
+
+  angular
+    .module('arkclient.components')
+    .component('passphraseField', {
+      templateUrl: 'src/components/passphrase-field/passphrase-field.html',
+      bindings: {
+        label: '@?',
+        isOptional: '<?',
+        tabIndex: '<?',
+        autoFocus: '<?'
+      },
+      controller: PassphraseFieldController,
+      controllerAs: '$pwc',
+      require: {
+        model: 'ngModel'
+      }
+    })
+
+  function PassphraseFieldController ($scope) {
+    this.$onInit = () => {
+      const self = this
+      this.model.$render = () => {
+        self.value = self.model.$viewValue
+      }
+      this.tabIndex = typeof this.tabIndex === 'number' ? this.tabIndex : null
+      this.autoFocus = typeof this.autoFocus === 'undefined' ? false : this.autoFocus
+    }
+
+    this.updateModel = () => {
+      this.model.$setValidity('required', this.isOptional || this.value !== '')
+      this.model.$setViewValue(this.value)
+    }
+
+    this.onQrCodeScanned = (passPhrase) => {
+      this.value = passPhrase
+      this.updateModel()
+    }
+
+    this.onChange = () => {
+      this.updateModel()
+    }
+  }
+})()

--- a/client/app/src/components/passphrase-field/passphrase-field.html
+++ b/client/app/src/components/passphrase-field/passphrase-field.html
@@ -1,0 +1,22 @@
+<div layout="row" flex layout-align="start start">
+  <md-input-container flex="5">
+    <qr-scanner input-callback-func="$pwc.onQrCodeScanned(qr)"></qr-scanner>
+  </md-input-container>
+  <md-input-container class="md-block" flex="95">
+    <label ng-if="$pwc.label" translate ng-class="{'md-required': !$pwc.isOptional}">
+      {{$pwc.label}}
+    </label>
+    <input type="password"
+           ng-model="$pwc.value"
+           ng-required="!$pwc.isOptional"
+           ng-change="$pwc.onChange()"
+           tabIndex="{{$pwc.tabIndex}}"
+           md-autofocus="$pwc.autoFocus"
+           ng-attr-type="{{ $pwc.showPassword ? 'text' : 'password' }}" />
+    <md-icon style="cursor: pointer;outline: none"
+             ng-click="$pwc.showPassword = !$pwc.showPassword"
+             md-font-library="material-icons">
+      {{ $pwc.showPassword ? 'visibility_off' : 'visibility' }}
+    </md-icon>
+  </md-input-container>
+</div>

--- a/client/app/src/components/qr-scanner/qr-scanner.directive.js
+++ b/client/app/src/components/qr-scanner/qr-scanner.directive.js
@@ -21,7 +21,13 @@
           toastService.success(`The ${result.type} ${result.qr} has been successfully scanned.`)
         }
 
-        $scope.$parent.send.data[$scope.inputCallback] = result.qr
+        if ($scope.inputCallback) {
+          $scope.$parent.send.data[$scope.inputCallback] = result.qr
+        }
+
+        if ($scope.inputCallbackFunc) {
+          $scope.inputCallbackFunc({qr: result.qr})
+        }
 
         $timeout(function () {
           $mdDialog.hide()
@@ -63,7 +69,8 @@
         onSuccess: '&',
         onError: '&',
         onVideoError: '&',
-        inputCallback: '@'
+        inputCallback: '@',
+        inputCallbackFunc: '&'
       },
       controller: controller,
       replace: true,


### PR DESCRIPTION
While doing "a little" testing for my other PR I saw that the input (password) field of the passphrases is different depending on where you are:
 - sometimes you can toggle "view password" (eye icon)
 - sometimes there is a qr-scanner symbol

Also the same code was duplicated throughout the solution.

I extracted the logic into an own component and used this in the whole app.
Now everytime the user has to input the first or the second passphrase.
The field with the visibility togglet button and the qrcode scanner is displayed.

While doing that I one question came up:
 - Somehow the `md-required` class was not set automatically anymore on the label (because it's an own component now). So I did this manually. I don't understand why it is not set anymore and I wonder if I'm doing something wrong...

While doing the refactor I also detected 2 anonmalies which may or may not be bugs:
 -  In the `timestampDocument.html` class the secondpasphrase field is only shown if there is no ledger (`!send.data.ledger && send.data.secondSignature`). However in ALL other places, the ledger check is only added to the normal passphrase field.
- Signing messages only requires the first passphrase (it's the only "action" in the app) - is this correct? (it works though I've tested it)

I tested ALL actions where I replaced this field on the DARKNET.

Note:
Also hadd to do some changes in the `qr-scanner.directive.js`. Since I also have changes there on another PR (#456) I adjusted the file so that it's identical on both PR's and should hopefully not give any conflicts :)