### PR TITLE
Fix wrong display of amount in transaction list (if sender==receiver)

### DIFF
--- a/client/app/src/components/account/templates/transaction-tab.html
+++ b/client/app/src/components/account/templates/transaction-tab.html
@@ -34,7 +34,7 @@
           </td>
           <td md-cell>{{it.date | date: 'short'}}</td>
           <td ng-if="it.recipientId==it.senderId && it.type==0" md-cell>
-            <span class="md-button selectable-text" md-colors="{'background' : 'default-blue-grey-600' }">{{ '+' + ((it.amount | convertToArkValue)) + ' / -' + (it.fee | convertToArkValue) }}</span>
+            <span class="md-button selectable-text" md-colors="{'background' : 'default-blue-grey-600' }">-{{it.amount + it.fee | convertToArkValue}} / +{{it.amount | convertToArkValue}}</span>
           </td>
           <td ng-if="it.type>0" md-cell>
             <span class="md-button selectable-text" md-colors="{'background' : 'default-blue-grey-600' }">{{it.humanTotal}}</span>


### PR DESCRIPTION
A minor thing I saw when testing:

If you send yourself something (which obviously apart from the darknet nobody does) the transaction explorer showed it like this:

![image](https://user-images.githubusercontent.com/1086065/34338805-688fb126-e96c-11e7-84ae-3c48ade4b774.png)

However this is wrong, since you did not magically get `+3` ark and only lost the fee cost.

Correct would either be to show only the fee as a negative value or - and that's what I've done - show it like this:

![image](https://user-images.githubusercontent.com/1086065/34338790-30dd7cd6-e96c-11e7-8511-c169d2e6e518.png)

I wonder if the background-color shouldn't be "negative" (`default-red-200`)?