### PR TITLE
Fix peer forcing.

### DIFF
--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -232,6 +232,10 @@
 
     function broadcastTransaction (transaction, max) {
       var peers = storageService.get('peers')
+      if (network.forcepeer) {
+      	var forcedPeer = network.peerseed.match(/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\:?([0-9]{1,5})?/)
+      	peers = [{'ip':forcedPeer[1],'port':forcedPeer[2]}]
+      }
       if (!peers) {
         return
       }

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -297,7 +297,7 @@
             }
           }, () => findGoodPeer(storageService.get('peers'), 0))
       } else {
-      	peer = network.peerseed
+      	peer.ip = network.peerseed
       }
     }
 

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -296,6 +296,8 @@
               findGoodPeer(storageService.get('peers'), 0)
             }
           }, () => findGoodPeer(storageService.get('peers'), 0))
+      } else {
+      	peer = network.peerseed
       }
     }
 

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -233,8 +233,8 @@
     function broadcastTransaction (transaction, max) {
       var peers = storageService.get('peers')
       if (network.forcepeer) {
-      	var forcedPeer = network.peerseed.match(/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\:?([0-9]{1,5})?/)
-      	peers = [{'ip':forcedPeer[1],'port':forcedPeer[2]}]
+        var forcedPeer = network.peerseed.match(/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):?([0-9]{1,5})?/)
+        peers = [{'ip': forcedPeer[1], 'port': forcedPeer[2]}]
       }
       if (!peers) {
         return
@@ -301,7 +301,7 @@
             }
           }, () => findGoodPeer(storageService.get('peers'), 0))
       } else {
-      	peer.ip = network.peerseed
+        peer.ip = network.peerseed
       }
     }
 


### PR DESCRIPTION
When the client data is reset or initialized for the first time, peers are gathered and cached from the seed nodes. If you change the Seed Server, it will overwrite that data with new peers after a client restart.

After various frustrations in testing relays using the "force" option, I realized it doesn't actually work. If force is enabled, the peer list is not called or refreshed, which I would assume is intended. The problem however, is the specified IP is not "forced". If force is selected, the client will simply avoid calling for a fresh list of peers, but never "forces" the desired IP as the seed node. When you use force and attempt to use the client, it will still use its previous peer list. The "force" option essentially acts as a "don't update peers anymore" checkbox and nothing more.

This fixes it by forcing the peer ip to the one set.