### PR TITLE
Move utility functions to utility services, minor bug fixes

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1668,9 +1668,9 @@
                 let secondPhraseArktoshiVal = fees['secondsignature']
                 var secondPhraseArkVal = secondPhraseArktoshiVal / ARKTOSHI_UNIT
                 var confirm = $mdDialog.confirm({
-                  title: gettextCatalog.getString('Second Passphrase') + ' ' + gettextCatalog.getString('Fee (Ѧ)'),
+                  title: gettextCatalog.getString('Second Passphrase') + ' ' + gettextCatalog.getString('Fee') + ' (' + networkService.getNetwork().symbol + ')',
                   secondPhraseArkVal: secondPhraseArkVal,
-                  textContent: gettextCatalog.getString('WARNING! Second passphrase creation costs ' + secondPhraseArkVal + ' Ark.'),
+                  textContent: gettextCatalog.getString('WARNING! Second passphrase creation costs ' + secondPhraseArkVal + ' ' + networkService.getNetwork().token + '.'),
                   ok: gettextCatalog.getString('Continue'),
                   cancel: gettextCatalog.getString('Cancel')
                 })

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -23,7 +23,6 @@
       '$mdThemingProvider',
       '$mdTheming',
       '$window',
-      'ARKTOSHI_UNIT',
       '$rootScope',
       'transactionBuilderService',
       'utilityService',
@@ -57,7 +56,6 @@
     $mdThemingProvider,
     $mdTheming,
     $window,
-    ARKTOSHI_UNIT,
     $rootScope,
     transactionBuilderService,
     utilityService
@@ -522,7 +520,7 @@
     }
 
     self.saveFolder = function (account, folder) {
-      accountService.setToFolder(account.address, folder, account.virtual.uservalue(folder)() * ARKTOSHI_UNIT)
+      accountService.setToFolder(account.address, folder, utilityService.arkToArktoshi(account.virtual.uservalue(folder)()))
     }
 
     self.deleteFolder = function (account, foldername) {
@@ -1666,7 +1664,7 @@
         accountService.getFees(true).then(
               function (fees) {
                 let secondPhraseArktoshiVal = fees['secondsignature']
-                var secondPhraseArkVal = secondPhraseArktoshiVal / ARKTOSHI_UNIT
+                var secondPhraseArkVal = utilityService.arktoshiToArk(secondPhraseArktoshiVal, true)
                 var confirm = $mdDialog.confirm({
                   title: gettextCatalog.getString('Second Passphrase') + ' ' + gettextCatalog.getString('Fee') + ' (' + networkService.getNetwork().symbol + ')',
                   secondPhraseArkVal: secondPhraseArkVal,

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -241,7 +241,7 @@
       var label = gettextCatalog.getString(self.TxTypes[transaction.type])
 
       if (recipientAddress && transaction.recipientId === recipientAddress && transaction.type === 0) {
-        label = gettextCatalog.getString('Receive Ark')
+        label = gettextCatalog.getString('Receive') + ' ' + networkService.getNetwork().token
       }
 
       return label

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -37,7 +37,7 @@
     self.peer = networkService.getPeer().ip
 
     function showTimestamp (timestamp) { // eslint-disable-line no-unused-vars
-      const date = utilityService.getDate(timestamp)
+      const date = utilityService.arkStampToDate(timestamp)
 
       var currentTime = new Date().getTime()
       var diffTime = (currentTime - date.getTime()) / 1000
@@ -245,7 +245,7 @@
 
     function formatTransaction (transaction, recipientAddress) {
       transaction.label = getTransactionLabel(transaction, recipientAddress)
-      transaction.date = utilityService.getDate(transaction.timestamp)
+      transaction.date = utilityService.arkStampToDate(transaction.timestamp)
       if (transaction.recipientId === recipientAddress) {
         transaction.total = transaction.amount
       // if (transaction.type == 0) {
@@ -314,8 +314,8 @@
 
     // this methods only works correctly, as long as getAllTransactions returns the transactions ordered by new to old!
     function getRangedTransactions (address, startDate, endDate, onUpdate) {
-      const startStamp = utilityService.getArkRelativeTimeStamp(!startDate ? ARK_LAUNCH_DATE : startDate)
-      const endStamp = utilityService.getArkRelativeTimeStamp(!endDate ? new Date(new Date().setHours(23, 59, 59, 59)) : endDate)
+      const startStamp = utilityService.dateToArkStamp(!startDate ? ARK_LAUNCH_DATE : startDate)
+      const endStamp = utilityService.dateToArkStamp(!endDate ? new Date(new Date().setHours(23, 59, 59, 59)) : endDate)
 
       const deferred = $q.defer()
 

--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -2,7 +2,7 @@
   'use strict'
 
   angular.module('arkclient.accounts')
-    .service('accountService', ['$q', '$http', 'networkService', 'storageService', 'ledgerService', 'gettextCatalog', 'utilityService', 'ARKTOSHI_UNIT', AccountService])
+    .service('accountService', ['$q', '$http', 'networkService', 'storageService', 'ledgerService', 'gettextCatalog', 'utilityService', AccountService])
 
   /**
    * Accounts DataService
@@ -12,7 +12,7 @@
    * @returns {{loadAll: Function}}
    * @constructor
    */
-  function AccountService ($q, $http, networkService, storageService, ledgerService, gettextCatalog, utilityService, ARKTOSHI_UNIT) {
+  function AccountService ($q, $http, networkService, storageService, ledgerService, gettextCatalog, utilityService) {
     var self = this
     var ark = require(require('path').resolve(__dirname, '../node_modules/arkjs'))
 
@@ -693,10 +693,10 @@
                 if (value === null) {
                   virtual[folder].amount = null
                 } else {
-                  virtual[folder].amount = value * ARKTOSHI_UNIT
+                  virtual[folder].amount = utilityService.arkToArktoshi(value)
                 }
               } else {
-                return virtual[folder].amount === null ? '' : virtual[folder].amount / ARKTOSHI_UNIT
+                return virtual[folder].amount === null ? '' : utilityService.arktoshiToArk(virtual[folder].amount, true)
               }
             }
           }

--- a/client/app/src/accounts/export-account.controller.js
+++ b/client/app/src/accounts/export-account.controller.js
@@ -13,10 +13,11 @@
       'gettextCatalog',
       'account',
       'theme',
+      'ARK_LAUNCH_DATE',
       ExportAccountController
     ])
 
-  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, utilityService, gettextCatalog, account, theme) {
+  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, utilityService, gettextCatalog, account, theme, ARK_LAUNCH_DATE) {
     $scope.vm = {}
     $scope.vm.account = account
     $scope.vm.theme = theme
@@ -24,8 +25,7 @@
     $scope.vm.hasStarted = false
     $scope.vm.isFinished = false
 
-    // todo: move to utililityService once merged back
-    $scope.vm.minDate = new Date(Date.UTC(2017, 2, 21, 13, 0, 0, 0))
+    $scope.vm.minDate = ARK_LAUNCH_DATE
 
     $scope.vm.startDate = new Date()
     $scope.vm.startDate.setMonth($scope.vm.startDate.getMonth() - 1)

--- a/client/app/src/accounts/export-account.controller.js
+++ b/client/app/src/accounts/export-account.controller.js
@@ -9,14 +9,14 @@
       '$mdDialog',
       'accountService',
       'toastService',
+      'utilityService',
       'gettextCatalog',
       'account',
       'theme',
-      'ARKTOSHI_UNIT',
       ExportAccountController
     ])
 
-  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, gettextCatalog, account, theme, ARKTOSHI_UNIT) {
+  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, utilityService, gettextCatalog, account, theme) {
     $scope.vm = {}
     $scope.vm.account = account
     $scope.vm.theme = theme
@@ -96,9 +96,8 @@
       $scope.vm.isFinished = true
       var eol = require('os').EOL
 
-      // todo: use utilityService once merged back for the ark calculation
       $scope.fileContent = 'Account:,' + account.address + eol +
-                           'Balance:,' + accountService.numberToFixed(account.balance / ARKTOSHI_UNIT) + eol +
+                           'Balance:,' + utilityService.arktoshiToArk(account.balance) + eol +
                            'Transactions' + (isInComplete ? ' (INCOMPLETE):' : ':') + eol +
                            'ID,Confirmations,Date,Type,Amount,From,To,Smartbridge' + eol
       transactions.forEach(trns => {

--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -77,7 +77,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.secondsignature) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                          ', ' + gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.secondsignature, false, true) + ' to create a second passphrase'))
+                          ', ' + gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.secondsignature) + ' to create a second passphrase'))
           return
         }
 
@@ -92,7 +92,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.delegate) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress + ', ' +
-                          gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.delegate, false, true) + ' to register delegate'))
+                          gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.delegate) + ' to register delegate'))
           return
         }
 
@@ -107,7 +107,7 @@
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.vote) {
           deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                           ', ' + gettextCatalog.getString('you need at least ' + utilityService.arktoshiToArk(fees.vote, false, true) + ' to vote'))
+                           ', ' + gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.vote) + ' to vote'))
           return
         }
 
@@ -117,6 +117,10 @@
                           () => ark.vote.createVote(config.masterpassphrase, config.publicKeys.split(','), config.secondpassphrase),
                           (transaction) => { transaction.recipientId = config.fromAddress })
       })
+    }
+
+    function arktoshiToArk (value) {
+      return utilityService.arktoshiToArk(value) + ' ' + networkService.getNetwork().token
     }
 
     return {

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -14,10 +14,10 @@
         accountCtrl: '=',
         addressBookCtrl: '='
       },
-      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'ARKTOSHI_UNIT', 'toastService', 'transactionBuilderService', 'utilityService', AccountCardController]
+      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'storageService', 'toastService', 'transactionBuilderService', 'utilityService', AccountCardController]
     })
 
-  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, ARKTOSHI_UNIT, toastService, transactionBuilderService, utilityService) {
+  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, storageService, toastService, transactionBuilderService, utilityService) {
     this.$onInit = () => {
       this.ul = this.accountCtrl
       this.ab = this.addressBookCtrl
@@ -141,7 +141,7 @@
         publicKey: selectedAccount.publicKey,
         fromAddress: formData.fromAddress,
         toAddress: formData.toAddress,
-        amount: parseInt((formData.amount * ARKTOSHI_UNIT).toFixed(0)),
+        amount: parseInt(utilityService.arkToArktoshi(formData.amount, 0)),
         smartbridge: formData.smartbridge,
         masterpassphrase: formData.passphrase,
         secondpassphrase: formData.secondpassphrase

--- a/client/app/src/components/addressbook/addressbook.controller.js
+++ b/client/app/src/components/addressbook/addressbook.controller.js
@@ -3,9 +3,9 @@
 
   angular
     .module('arkclient.components')
-    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'accountService', 'utilityService', 'ARKTOSHI_UNIT', AddressbookController])
+    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'accountService', 'utilityService', AddressbookController])
 
-  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, accountService, utilityService, ARKTOSHI_UNIT) {
+  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, accountService, utilityService) {
     var self = this
     // var contacts
     self.trim = function (str) {
@@ -235,7 +235,7 @@
             return prev + el
           })
 
-          stats.income.amount = utilityService.arktoshiToArk(incomeAmount).toFixed(2)
+          stats.income.amount = utilityService.arktoshiToArk(incomeAmount, false, 2)
         }
 
         if (expendTx.length > 0) {
@@ -245,7 +245,7 @@
             return prev + el
           })
 
-          stats.expend.amount = utilityService.arktoshiToArk(expendAmount).toFixed(2)
+          stats.expend.amount = utilityService.arktoshiToArk(expendAmount, false, 2)
         }
       }
 

--- a/client/app/src/components/dashboard/account-box.controller.js
+++ b/client/app/src/components/dashboard/account-box.controller.js
@@ -12,10 +12,10 @@
       bindings: {
         accountCtrl: '='
       },
-      controller: ['$scope', 'networkService', 'accountService', 'ARKTOSHI_UNIT', AccountBoxController]
+      controller: ['$scope', 'networkService', 'accountService', 'utilityService', AccountBoxController]
     })
 
-  function AccountBoxController ($scope, networkService, accountService, ARKTOSHI_UNIT) {
+  function AccountBoxController ($scope, networkService, accountService, utilityService) {
     this.$onInit = () => {
       // Alias that is used on the template
       this.ac = this.accountCtrl
@@ -26,7 +26,7 @@
         return sum + parseInt(account.balance || 0)
       }, 0)
 
-      return (total / ARKTOSHI_UNIT).toFixed(2)
+      return utilityService.arktoshiToArk(total, true, 2)
     }
 
     this.myAccountsCurrencyBalance = (bitcoinToggleIsActive) => {

--- a/client/app/src/constants/constants.js
+++ b/client/app/src/constants/constants.js
@@ -4,4 +4,8 @@
   angular.module('arkclient.constants')
     // 1 ARK has 100000000 "arktoshi"
     .constant('ARKTOSHI_UNIT', Math.pow(10, 8))
+
+  angular.module('arkclient.constants')
+     // all ark timestamps start at 2017/3/21 13:00
+    .constant('ARK_LAUNCH_DATE', new Date(Date.UTC(2017, 2, 21, 13, 0, 0, 0)))
 })()

--- a/client/app/src/directives/valid-amount.directive.js
+++ b/client/app/src/directives/valid-amount.directive.js
@@ -2,8 +2,8 @@
   'use strict'
 
   angular.module('arkclient.directives')
-    .directive('validAmount', ['ARKTOSHI_UNIT',
-      function (ARKTOSHI_UNIT) {
+    .directive('validAmount', ['utilityService',
+      function (utilityService) {
         return {
           require: 'ngModel',
           link: function (scope, elem, attrs, ctrl) {
@@ -11,10 +11,10 @@
               if (typeof value === 'undefined' || value === 0) {
                 ctrl.$pristine = true
               }
-              var num = Number((value * ARKTOSHI_UNIT).toFixed(0)) // 1.1 = 110000000
-              var totalBalance = Number(scope.send.totalBalance * ARKTOSHI_UNIT)
-              var remainingBalance = ((totalBalance - num) / ARKTOSHI_UNIT)
-              scope.send.remainingBalance = isNaN(remainingBalance) ? totalBalance / ARKTOSHI_UNIT : remainingBalance
+              var num = Number(utilityService.arkToArktoshi(value, 0)) // 1.1 = 110000000
+              var totalBalance = Number(utilityService.arkToArktoshi(scope.send.totalBalance))
+              var remainingBalance = utilityService.arktoshiToArk(totalBalance - num, true)
+              scope.send.remainingBalance = isNaN(remainingBalance) ? utilityService.arktoshiToArk(totalBalance, true) : remainingBalance
 
               if (typeof num === 'number' && num > 0) {
                 if (num > Number.MAX_SAFE_INTEGER) {

--- a/client/app/src/filters/filters.js
+++ b/client/app/src/filters/filters.js
@@ -45,9 +45,9 @@
       }
     })
   // converts arktoshi into ark
-  .filter('convertToArkValue', ['ARKTOSHI_UNIT', function (ARKTOSHI_UNIT) {
+  .filter('convertToArkValue', ['utilityService', function (utilityService) {
     return function (val) {
-      return val / ARKTOSHI_UNIT
+      return utilityService.arktoshiToArk(val, true)
     }
   }])
   .filter('accountLabel', ['accountService', function (accountService) {

--- a/client/app/src/services/utility.service.js
+++ b/client/app/src/services/utility.service.js
@@ -62,7 +62,7 @@
       return splitted[0] + '.' + newDecimals
     }
 
-    function getArkRelativeTimeStamp (date) {
+    function dateToArkStamp (date) {
       if (!date) {
         return null
       }
@@ -73,7 +73,7 @@
       return timestamp < 0 ? null : timestamp
     }
 
-    function getDate (arkRelativeTimeStamp) {
+    function arkStampToDate (arkRelativeTimeStamp) {
       if (typeof arkRelativeTimeStamp !== 'number' || arkRelativeTimeStamp < 0) {
         return null
       }
@@ -107,8 +107,8 @@
       arkToArktoshi: arkToArktoshi,
       numberStringToFixed: numberStringToFixed,
 
-      getArkRelativeTimeStamp: getArkRelativeTimeStamp,
-      getDate: getDate
+      dateToArkStamp: dateToArkStamp,
+      arkStampToDate: arkStampToDate
     }
   }
 })()

--- a/client/app/src/services/utility.service.js
+++ b/client/app/src/services/utility.service.js
@@ -2,10 +2,10 @@
   'use strict'
 
   angular.module('arkclient.services')
-    .service('utilityService', ['ARKTOSHI_UNIT', UtilityService])
+    .service('utilityService', ['ARKTOSHI_UNIT', 'ARK_LAUNCH_DATE', UtilityService])
 
   // this service should not have any dependencies to other services!
-  function UtilityService (ARKTOSHI_UNIT) {
+  function UtilityService (ARKTOSHI_UNIT, ARK_LAUNCH_DATE) {
     function arktoshiToArk (amount, keepPrecise, numberOfDecimals) {
       if (!amount) {
         return 0
@@ -62,6 +62,27 @@
       return splitted[0] + '.' + newDecimals
     }
 
+    function getArkRelativeTimeStamp (date) {
+      if (!date) {
+        return null
+      }
+
+      date = new Date(date.toUTCString())
+
+      const timestamp = parseInt((date.getTime() - ARK_LAUNCH_DATE.getTime()) / 1000)
+      return timestamp < 0 ? null : timestamp
+    }
+
+    function getDate (arkRelativeTimeStamp) {
+      if (typeof arkRelativeTimeStamp !== 'number' || arkRelativeTimeStamp < 0) {
+        return null
+      }
+
+      var arkLaunchTime = parseInt(ARK_LAUNCH_DATE.getTime() / 1000)
+
+      return new Date((arkRelativeTimeStamp + arkLaunchTime) * 1000)
+    }
+
     function numberToFixed (x) {
       let e
       if (Math.abs(x) < 1.0) {
@@ -84,7 +105,10 @@
     return {
       arktoshiToArk: arktoshiToArk,
       arkToArktoshi: arkToArktoshi,
-      numberStringToFixed: numberStringToFixed
+      numberStringToFixed: numberStringToFixed,
+
+      getArkRelativeTimeStamp: getArkRelativeTimeStamp,
+      getDate: getDate
     }
   }
 })()

--- a/test/accounts/account.controller.js
+++ b/test/accounts/account.controller.js
@@ -55,6 +55,8 @@ describe('AccountController', function () {
     }
   }
 
+  beforeEach(module('arkclient.constants'));
+
   beforeEach(() => {
     module('arkclient.accounts', $provide => {
       accountServiceMock = {
@@ -133,7 +135,6 @@ describe('AccountController', function () {
       $provide.value('$mdDialog', mdDialogMock)
       $provide.value('$mdToast', mdToastMock)
       $provide.value('gettextCatalog', getTextCatalogMock)
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
 
     inject((_$compile_, _$rootScope_, _$controller_) => {

--- a/test/accounts/account.service.js
+++ b/test/accounts/account.service.js
@@ -35,6 +35,8 @@ describe('accountService',() => {
     return arr
    }
 
+   beforeEach(module('arkclient.constants'));
+
    beforeEach(module((_$exceptionHandlerProvider_) => {
     _$exceptionHandlerProvider_.mode('log');
    }));
@@ -49,7 +51,6 @@ describe('accountService',() => {
       // inject the mock services
       $provide.value('gettextCatalog', gettextCatalogMock)
       $provide.value('networkService', networkServiceMock)
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
 
     inject(($injector, _$rootScope_) => {

--- a/test/components/accounts/account-card.controller.js
+++ b/test/components/accounts/account-card.controller.js
@@ -30,12 +30,13 @@ describe('AccountCardController', function () {
     show: sinon.stub()
   }
 
+  beforeEach(module('arkclient.constants'));
+
   beforeEach(() => {
     module('arkclient.components', $provide => {
       $provide.value('accountService', accountServiceMock)
       $provide.value('transactionBuilderService', transactionBuilderServiceMock)
       $provide.value('$mdDialog', mdDialogMock)
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
 
     inject(_$componentController_ => {

--- a/test/components/addressbook/addressbook.controller.js
+++ b/test/components/addressbook/addressbook.controller.js
@@ -48,7 +48,6 @@ describe('AddressbookController', function () {
       $provide.value('accountService', accountServiceMock)
       $provide.value('toastService', toastServiceMock)
       $provide.value('utilityService', utilityService)
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10,8))
     })
 
     inject((_$compile_, _$rootScope_, _$controller_) => {
@@ -153,7 +152,7 @@ describe('AddressbookController', function () {
       it('is successful', () => {
           const name = 'test_name'
           const address = 'AThTtim37wR11D3hxGVtruS3UQTbsjsW3t'
-          
+
           ctrl.addAddressbookContact()
           const sizeBefore = Object.keys(ctrl.contacts).length
           $scope.addAddressbookContact.add(name, address)

--- a/test/components/dashboard/account-box.controller.js
+++ b/test/components/dashboard/account-box.controller.js
@@ -3,38 +3,40 @@
 describe('AccountBoxController', function () {
   const expect = chai.expect
 
-  let ctrl
+  let ctrl, ARKTOSHI_UNIT, accounts, bindings
 
-  const ARKTOSHI_UNIT = 100000000
-  const accounts = [
-    { balance: 10 * ARKTOSHI_UNIT },
-    { balance: 15 * ARKTOSHI_UNIT },
-    { balance: 5 * ARKTOSHI_UNIT },
-    {}
-  ]
-
-  const bindings = {
-    accountCtrl: {
-      getAllAccounts () { return accounts },
-      currency: {
-        name: 'btc'
-      },
-      connectedPeer: {
-        market: {
-          price: {
-            btc: '0.1' // Next year price? lol
-          }
-        }
-      }
-    }
-  }
+  beforeEach(module('arkclient.constants'));
 
   beforeEach(() => {
     module('arkclient.components', $provide => {
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
 
-    inject(_$componentController_ => {
+    inject((_$componentController_, _ARKTOSHI_UNIT_) => {
+
+      ARKTOSHI_UNIT = _ARKTOSHI_UNIT_
+      accounts = [
+        { balance: 10 * ARKTOSHI_UNIT },
+        { balance: 15 * ARKTOSHI_UNIT },
+        { balance: 5 * ARKTOSHI_UNIT },
+        {}
+      ]
+
+      bindings = {
+        accountCtrl: {
+          getAllAccounts () { return accounts },
+          currency: {
+            name: 'btc'
+          },
+          connectedPeer: {
+            market: {
+              price: {
+                btc: '0.1' // Next year price? lol
+              }
+            }
+          }
+        }
+      }
+
       ctrl = _$componentController_('accountBox', null, bindings)
     })
   })

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -33,6 +33,7 @@ module.exports = function (config) {
 
       // Subjects under test
       '../client/app/src/init.js',
+      '../client/app/src/constants/constants.js',
       '../client/app/src/accounts/account.service.js',
       '../client/app/src/accounts/transaction-builder.service.js',
       '../client/app/src/accounts/account.controller.js',

--- a/test/services/transaction-builder.service.js
+++ b/test/services/transaction-builder.service.js
@@ -51,6 +51,8 @@ describe('transactionBuilderService',() => {
     }
   }
 
+  beforeEach(module('arkclient.constants'));
+
   beforeEach(module((_$exceptionHandlerProvider_) => {
     _$exceptionHandlerProvider_.mode('log');
    }));
@@ -70,7 +72,6 @@ describe('transactionBuilderService',() => {
       $provide.value('gettextCatalog', gettextCatalogMock)
       $provide.value('networkService', networkServiceMock)
       $provide.value('ledgerService', ledgerServiceMock)
-      $provide.value('ARKTOSHI_UNIT', Math.pow(10, 8))
     })
 
     inject(($injector, _$rootScope_) => {

--- a/test/services/utility.service.js
+++ b/test/services/utility.service.js
@@ -2,17 +2,12 @@
 
 describe('utilityService',() => {
 
-  const tokenName = 'test-ark'
   const arktoshiUnit = Math.pow(10, 8)
   let utilityService
-  let networkServiceMock
 
   beforeEach(() => {
     module('arkclient.services', $provide => {
-      networkServiceMock = { getNetwork: sinon.stub().returns({version: 0x17, token: tokenName }) }
-
       // inject the mock services
-      $provide.value('networkService', networkServiceMock)
       $provide.value('ARKTOSHI_UNIT', arktoshiUnit)
     })
 
@@ -35,34 +30,126 @@ describe('utilityService',() => {
       expect(ark).to.eql(0)
     })
 
-    it('1 arktoshi is 1 Ark', () => {
+    it('1 arktoshiUnit is 1 Ark', () => {
       const ark = utilityService.arktoshiToArk(arktoshiUnit)
 
       expect(ark).to.eql(1)
     })
 
-    it('1/2 arktoshi is 0.5 Ark', () => {
+    it('1/2 arktoshiUnit is 0.5 Ark', () => {
       const ark = utilityService.arktoshiToArk(arktoshiUnit / 2)
 
       expect(ark).to.eql(0.5)
     })
 
-    it('1111111 part of arktoshi is human readable amount of Ark', () => {
+    it('1111111 part of arktoshiUnit is human readable amount of Ark', () => {
       const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111)
 
       expect(ark).to.eq('0.000000900000090000009')
     })
 
-    it('1111111 part of arktoshi is precise amount of Ark', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, true)
+    it('1111111 part of arktoshiUnit is human readable amount of Ark, 0 decimals', () => {
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, false, 0)
 
-      expect(ark).to.be.within(9.00000090000000e-7, 9.00000090000009e-7)
+      expect(ark).to.eq('0')
     })
 
-    it('1 arktoshi is 1 test-ark (include network token)', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit, false, true)
+    it('1111111 part of arktoshiUnit is human readable amount of Ark, 7 decimals', () => {
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, false, 7)
 
-      expect(ark).to.eql('1 ' + tokenName)
+      expect(ark).to.eq('0.0000009')
+    })
+
+    it('11111111 part of arktoshi is precise amount of Ark', () => {
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true)
+
+      expect(ark).to.be.within(9.00000009000000e-8, 9.00000009000002e-8)
+    })
+
+    it('11111111 part of arktoshi is precise amount of Ark, 0 decimals', () => {
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true, 0)
+
+      expect(ark).to.eq('0')
+    })
+
+    it('11111111 part of arktoshi is precise amount of Ark, 7 decimals', () => {
+      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true, 7)
+
+      expect(ark).to.eq('0.0000001')
+    })
+  })
+
+  describe('arkToArktoshi', () => {
+    it('undefined Ark is 0 arktoshi', () => {
+      const ark = utilityService.arkToArktoshi()
+
+      expect(ark).to.eql(0)
+    })
+
+    it('0 Ark is 0 arktoshi', () => {
+      const ark = utilityService.arkToArktoshi(0)
+
+      expect(ark).to.eql(0)
+    })
+
+    it('1 Ark is 1 arktoshiUnit', () => {
+      const ark = utilityService.arkToArktoshi(1)
+
+      expect(ark).to.eql(arktoshiUnit)
+    })
+
+    it('0.5 Ark is 0.5 arktoshiUnit', () => {
+      const ark = utilityService.arkToArktoshi(0.5)
+
+      expect(ark).to.eql(arktoshiUnit / 2)
+    })
+
+    it('11.11111111111 ark is correct arktoshi amount', () => {
+      const ark = utilityService.arkToArktoshi(11.11111111111)
+
+      expect(ark).to.eq(1111111111.111)
+    })
+
+    it('11.11111111111 ark is correct arktoshi amount, 0 decimals', () => {
+      const ark = utilityService.arkToArktoshi(11.11111111111, 0)
+
+      expect(ark).to.eq('1111111111')
+    })
+
+    it('11.11111111111 ark is correct arktoshi amount, 2 decimals', () => {
+      const ark = utilityService.arkToArktoshi(11.11111111111, 2)
+
+      expect(ark).to.eq('1111111111.11')
+    })
+  })
+
+  describe('numberStringToFixed', () => {
+    it('input is not a string, returns input value', () => {
+      expect(utilityService.numberStringToFixed()).to.eq()
+      expect(utilityService.numberStringToFixed(null)).to.eq(null)
+      expect(utilityService.numberStringToFixed(1)).to.eq(1)
+      const obj = {}
+      expect(utilityService.numberStringToFixed(obj)).to.eq(obj)
+    })
+
+    it('12.345, no value for decimals, returns input', () => {
+      expect(utilityService.numberStringToFixed('12.345')).to.eq('12.345')
+    })
+
+    it('12.345, 0 decimals, returns 12', () => {
+      expect(utilityService.numberStringToFixed('12.345', 0)).to.eq('12')
+    })
+
+    it('12.345, 2 decimals, returns 12.34', () => {
+      expect(utilityService.numberStringToFixed('12.345', 2)).to.eq('12.34')
+    })
+
+    it('12.345, 4 decimals, returns 12.3450', () => {
+      expect(utilityService.numberStringToFixed('12.345', 4)).to.eq('12.3450')
+    })
+
+    it('12, 2 decimals, returns 12.00', () => {
+      expect(utilityService.numberStringToFixed('12', 2)).to.eq('12.00')
     })
   })
 })

--- a/test/services/utility.service.js
+++ b/test/services/utility.service.js
@@ -2,17 +2,17 @@
 
 describe('utilityService',() => {
 
-  const arktoshiUnit = Math.pow(10, 8)
-  let utilityService
+  let utilityService, ARK_LAUNCH_DATE, ARKTOSHI_UNIT
+
+  beforeEach(module('arkclient.constants'));
 
   beforeEach(() => {
-    module('arkclient.services', $provide => {
-      // inject the mock services
-      $provide.value('ARKTOSHI_UNIT', arktoshiUnit)
-    })
+    module('arkclient.services')
 
-    inject(($injector, _$rootScope_) => {
+    inject(($injector, _$rootScope_, _ARK_LAUNCH_DATE_, _ARKTOSHI_UNIT_) => {
       utilityService = $injector.get('utilityService')
+      ARK_LAUNCH_DATE = _ARK_LAUNCH_DATE_
+      ARKTOSHI_UNIT = _ARKTOSHI_UNIT_
     })
   })
 
@@ -31,49 +31,49 @@ describe('utilityService',() => {
     })
 
     it('1 arktoshiUnit is 1 Ark', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT)
 
       expect(ark).to.eql(1)
     })
 
     it('1/2 arktoshiUnit is 0.5 Ark', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 2)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 2)
 
       expect(ark).to.eql(0.5)
     })
 
     it('1111111 part of arktoshiUnit is human readable amount of Ark', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 1111111)
 
       expect(ark).to.eq('0.000000900000090000009')
     })
 
     it('1111111 part of arktoshiUnit is human readable amount of Ark, 0 decimals', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, false, 0)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 1111111, false, 0)
 
       expect(ark).to.eq('0')
     })
 
     it('1111111 part of arktoshiUnit is human readable amount of Ark, 7 decimals', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 1111111, false, 7)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 1111111, false, 7)
 
       expect(ark).to.eq('0.0000009')
     })
 
     it('11111111 part of arktoshi is precise amount of Ark', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 11111111, true)
 
       expect(ark).to.be.within(9.00000009000000e-8, 9.00000009000002e-8)
     })
 
     it('11111111 part of arktoshi is precise amount of Ark, 0 decimals', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true, 0)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 11111111, true, 0)
 
       expect(ark).to.eq('0')
     })
 
     it('11111111 part of arktoshi is precise amount of Ark, 7 decimals', () => {
-      const ark = utilityService.arktoshiToArk(arktoshiUnit / 11111111, true, 7)
+      const ark = utilityService.arktoshiToArk(ARKTOSHI_UNIT / 11111111, true, 7)
 
       expect(ark).to.eq('0.0000001')
     })
@@ -95,13 +95,13 @@ describe('utilityService',() => {
     it('1 Ark is 1 arktoshiUnit', () => {
       const ark = utilityService.arkToArktoshi(1)
 
-      expect(ark).to.eql(arktoshiUnit)
+      expect(ark).to.eql(ARKTOSHI_UNIT)
     })
 
     it('0.5 Ark is 0.5 arktoshiUnit', () => {
       const ark = utilityService.arkToArktoshi(0.5)
 
-      expect(ark).to.eql(arktoshiUnit / 2)
+      expect(ark).to.eql(ARKTOSHI_UNIT / 2)
     })
 
     it('11.11111111111 ark is correct arktoshi amount', () => {
@@ -150,6 +150,53 @@ describe('utilityService',() => {
 
     it('12, 2 decimals, returns 12.00', () => {
       expect(utilityService.numberStringToFixed('12', 2)).to.eq('12.00')
+    })
+  })
+
+  describe('getArkRelativeTimeStamp', () => {
+    it('input ist not defined, returns null', () => {
+      expect(utilityService.getArkRelativeTimeStamp()).to.eq(null)
+      expect(utilityService.getArkRelativeTimeStamp(null)).to.eq(null)
+    })
+
+    it('input is ark launch time, returns 0', () => {
+      expect(utilityService.getArkRelativeTimeStamp(ARK_LAUNCH_DATE)).to.eq(0)
+    })
+
+    it('input is BEFORE ark launch time, returns null', () => {
+      expect(utilityService.getArkRelativeTimeStamp(new Date(Date.UTC(2017, 2, 21, 12, 59, 59, 59)))).to.eq(null)
+    })
+
+    it('input is a utc date, returns correct timestamp', () => {
+      expect(utilityService.getArkRelativeTimeStamp(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)))).to.eq(20206800)
+    })
+
+    it('input is a local date, returns correct timestamp', () => {
+      // since this is plus 1, this means that in UTC, it's currently 09:00, therefore the timestamphas to be 1 hour shorter than the one above
+      const localDate = new Date("Fri Nov 10 2017 10:00:00 GMT+0100 (Romance Standard Time)")
+      const oneHourInSeconds = 60 * 60
+      expect(utilityService.getArkRelativeTimeStamp(localDate)).to.eq(20206800 - oneHourInSeconds)
+    })
+  })
+
+  describe('getDate', () => {
+    it('input ist not a number, returns null', () => {
+      expect(utilityService.getDate()).to.eq(null)
+      expect(utilityService.getDate(null)).to.eq(null)
+      expect(utilityService.getDate('abc')).to.eq(null)
+      expect(utilityService.getDate({})).to.eq(null)
+    })
+
+    it('input is 0, returns ark launch date', () => {
+      expect(utilityService.getDate(0).getTime()).to.eq(ARK_LAUNCH_DATE.getTime())
+    })
+
+    it('input is lower than 0, returns null', () => {
+      expect(utilityService.getDate(-1)).to.eq(null)
+    })
+
+    it('input is a normal timestamp, returns correct date', () => {
+      expect(utilityService.getDate(20206800).getTime()).to.eq(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)).getTime())
     })
   })
 })

--- a/test/services/utility.service.js
+++ b/test/services/utility.service.js
@@ -153,50 +153,50 @@ describe('utilityService',() => {
     })
   })
 
-  describe('getArkRelativeTimeStamp', () => {
+  describe('dateToArkStamp', () => {
     it('input ist not defined, returns null', () => {
-      expect(utilityService.getArkRelativeTimeStamp()).to.eq(null)
-      expect(utilityService.getArkRelativeTimeStamp(null)).to.eq(null)
+      expect(utilityService.dateToArkStamp()).to.eq(null)
+      expect(utilityService.dateToArkStamp(null)).to.eq(null)
     })
 
     it('input is ark launch time, returns 0', () => {
-      expect(utilityService.getArkRelativeTimeStamp(ARK_LAUNCH_DATE)).to.eq(0)
+      expect(utilityService.dateToArkStamp(ARK_LAUNCH_DATE)).to.eq(0)
     })
 
     it('input is BEFORE ark launch time, returns null', () => {
-      expect(utilityService.getArkRelativeTimeStamp(new Date(Date.UTC(2017, 2, 21, 12, 59, 59, 59)))).to.eq(null)
+      expect(utilityService.dateToArkStamp(new Date(Date.UTC(2017, 2, 21, 12, 59, 59, 59)))).to.eq(null)
     })
 
     it('input is a utc date, returns correct timestamp', () => {
-      expect(utilityService.getArkRelativeTimeStamp(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)))).to.eq(20206800)
+      expect(utilityService.dateToArkStamp(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)))).to.eq(20206800)
     })
 
     it('input is a local date, returns correct timestamp', () => {
       // since this is plus 1, this means that in UTC, it's currently 09:00, therefore the timestamphas to be 1 hour shorter than the one above
       const localDate = new Date("Fri Nov 10 2017 10:00:00 GMT+0100 (Romance Standard Time)")
       const oneHourInSeconds = 60 * 60
-      expect(utilityService.getArkRelativeTimeStamp(localDate)).to.eq(20206800 - oneHourInSeconds)
+      expect(utilityService.dateToArkStamp(localDate)).to.eq(20206800 - oneHourInSeconds)
     })
   })
 
-  describe('getDate', () => {
+  describe('arkStampToDate', () => {
     it('input ist not a number, returns null', () => {
-      expect(utilityService.getDate()).to.eq(null)
-      expect(utilityService.getDate(null)).to.eq(null)
-      expect(utilityService.getDate('abc')).to.eq(null)
-      expect(utilityService.getDate({})).to.eq(null)
+      expect(utilityService.arkStampToDate()).to.eq(null)
+      expect(utilityService.arkStampToDate(null)).to.eq(null)
+      expect(utilityService.arkStampToDate('abc')).to.eq(null)
+      expect(utilityService.arkStampToDate({})).to.eq(null)
     })
 
     it('input is 0, returns ark launch date', () => {
-      expect(utilityService.getDate(0).getTime()).to.eq(ARK_LAUNCH_DATE.getTime())
+      expect(utilityService.arkStampToDate(0).getTime()).to.eq(ARK_LAUNCH_DATE.getTime())
     })
 
     it('input is lower than 0, returns null', () => {
-      expect(utilityService.getDate(-1)).to.eq(null)
+      expect(utilityService.arkStampToDate(-1)).to.eq(null)
     })
 
     it('input is a normal timestamp, returns correct date', () => {
-      expect(utilityService.getDate(20206800).getTime()).to.eq(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)).getTime())
+      expect(utilityService.arkStampToDate(20206800).getTime()).to.eq(new Date(Date.UTC(2017, 10, 10, 10, 0, 0, 0)).getTime())
     })
   })
 })


### PR DESCRIPTION
- Fixes harcoded 'Ark' and 'Ѧ' values (only seen by accident)
- Move all Arktoshi calculations to `utilityService` and use the service everywhere
- Remove `networkService` dependency from `utilityService`
- Introduce constant for ark launch date
- Move all ark relative date calculations to utility service
- Improve all tests (instead of having to define `ARKTOSHI_UNIT` everytime, just inject our constants and use them if needed)