### PR TITLE
Fix button icons being off-center

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -243,7 +243,7 @@ md-bottom-sheet {
 }
 
 md-bottom-sheet md-icon {
-    margin-right: 20px;
+    margin-right: 10px;
 }
 
 span.name {


### PR DESCRIPTION
The icons for the buttons in the 3-dotted menu were off-centered.