### PR TITLE
Validate passphrase when importing account

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1590,6 +1590,15 @@
         if (!$scope.importAccountForm.$valid) {
           return
         }
+        
+        if (!$scope.send.data.customPassphrase && !isBIP39($scope.send.data.passphrase)) {
+          toastService.error(
+            gettextCatalog.getString('Not valid 12 words passphrase! Please check all words and spaces.')
+            , null
+            , true
+          )
+          return
+        }
 
         accountService.createAccount($scope.send.data.passphrase)
           .then(
@@ -1804,5 +1813,12 @@
         clickOutsideToClose: false
       })
     }
+    
+    function isBIP39(mnemonic) {
+      var bip39 = require('bip39')
+      let valid = bip39.validateMnemonic(mnemonic)
+      return valid
+    }
+    
   }
 })()

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1590,7 +1590,7 @@
         if (!$scope.importAccountForm.$valid) {
           return
         }
-        
+
         if (!$scope.send.data.customPassphrase && !isBIP39($scope.send.data.passphrase)) {
           toastService.error(
             gettextCatalog.getString('Not valid 12 words passphrase! Please check all words and spaces.')
@@ -1813,12 +1813,11 @@
         clickOutsideToClose: false
       })
     }
-    
-    function isBIP39(mnemonic) {
+
+    function isBIP39 (mnemonic) {
       var bip39 = require('bip39')
       let valid = bip39.validateMnemonic(mnemonic)
       return valid
     }
-    
   }
 })()

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -20,10 +20,7 @@
         </md-card-title>
       </md-card>
       <passphrase-field ng-model="send.data.passphrase" label="Passphrase" auto-focus="true"></passphrase-field>
-      <!--<md-input-container md-no-float class="md-block">
-        <label>Second Passphrase</label>
-        <input ng-model="send.data.secondpassphrase" type="text">
-      </md-input-container>-->
+      <md-switch ng-model="send.data.customPassphrase" aria-label="custom passphrase" class="md-primary" md-no-ink style="margin-top:-15px;">{{'custom passphrase' | translate}}</md-switch>
     </div>
     <md-dialog-actions layout="row">
       <md-button type="submit" ng-disabled="importAccountForm.$invalid">

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -20,7 +20,14 @@
         </md-card-title>
       </md-card>
       <passphrase-field ng-model="send.data.passphrase" label="Passphrase" auto-focus="true"></passphrase-field>
-      <md-switch ng-model="send.data.customPassphrase" aria-label="custom passphrase" class="md-primary" md-no-ink style="margin-top:-15px;">{{'custom passphrase' | translate}}</md-switch>
+      <div layout="row" flex style="margin-top: -20px;">
+        <md-switch ng-model="send.data.customPassphrase" aria-label="Use a custom (non-BIP39) passphrase" class="md-primary" md-no-ink style="margin: 8px 8px 8px 0;">
+          <translate>Use a custom (non-BIP39) passphrase</translate>
+        </md-switch>
+        <md-button class="md-raised" md-colors="{background:'primary'}" open-external="'https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki'">
+          <translate>more info</translate>
+        </md-button>
+      </div>
     </div>
     <md-dialog-actions layout="row">
       <md-button type="submit" ng-disabled="importAccountForm.$invalid">

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -21,7 +21,7 @@
       </md-card>
       <passphrase-field ng-model="send.data.passphrase" label="Passphrase" auto-focus="true"></passphrase-field>
       <div layout="row" flex style="margin-top: -20px;">
-        <md-switch ng-model="send.data.customPassphrase" aria-label="Use a custom (non-BIP39) passphrase" class="md-primary" md-no-ink style="margin: 8px 8px 8px 0;">
+        <md-switch ng-model="send.data.customPassphrase" aria-label="Use a custom (non-BIP39) passphrase" class="md-primary" md-no-ink style="margin: 4px 0;">
           <translate>Use a custom (non-BIP39) passphrase</translate>
         </md-switch>
         <md-button class="md-icon-button" open-external="'https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki'">

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -24,8 +24,8 @@
         <md-switch ng-model="send.data.customPassphrase" aria-label="Use a custom (non-BIP39) passphrase" class="md-primary" md-no-ink style="margin: 8px 8px 8px 0;">
           <translate>Use a custom (non-BIP39) passphrase</translate>
         </md-switch>
-        <md-button class="md-raised" md-colors="{background:'primary'}" open-external="'https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki'">
-          <translate>more info</translate>
+        <md-button class="md-icon-button" open-external="'https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki'">
+          <md-icon md-font-library="material-icons">help</md-icon>
         </md-button>
       </div>
     </div>


### PR DESCRIPTION
People all the time mistyped their passphrase when importing account and then panic when see an empty wallet. This PR should fix this:
- after clicking IMPORT I'm checking if the passphrase is a valid BIP39 mnemonic, if not, toast an error message: "Not valid 12 words passphrase! Please check all words and spaces."
- added a switch "custom passphrase", so you still can import with custom passphrase