### PR TITLE
Update fi.po

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -12,10 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "- This also can help to prove if a file has been tampered with if the SHA256 signature does not match with the one recorded on blockchain"
-msgstr "- Myös tämä voi auttaa todentamaan onko tiedostoa peukaloitu, jos tiedoston SHA256-allekirjoitus ei vastaa lohkoketjuuun kirjattua"
+msgstr "- Tämä voi myös auttaa todentamaan onko tiedostoa peukaloitu, jos tiedoston SHA256-allekirjoitus ei vastaa lohkoketjuun kirjattua"
 
 msgid "- This means that the owner of this account can prove that he had in hand this file at the block timestamp."
-msgstr "- Tämä tarkoittaa, että tämän tilin haltija voi todistaa, että kyseinen tiedosto oli hänen hallussaan lohkoketjun aikaleiman osoittamaan aikaan."
+msgstr "- Tämä tarkoittaa, että tämän tilin haltija voi todistaa kyseisen tiedoston olleen hänen hallussaan lohkoketjun aikaleiman osoittamaan aikaan."
 
 msgid "{{ category }}"
 msgstr "{{ kategoria }}"
@@ -48,7 +48,7 @@ msgid "Actions"
 msgstr "Toimet"
 
 msgid "Active delegates (forging)"
-msgstr "Aktiiviset (lohkoja muodostavat) edustajat"
+msgstr "Aktiiviset (lohkoja takovat) delegaatit"
 
 msgid "Add"
 msgstr "Lisää"
@@ -63,10 +63,10 @@ msgid "Add Address"
 msgstr "Lisää Osoite"
 
 msgid "Add Delegate"
-msgstr "Lisää Edustaja"
+msgstr "Lisää Delegaatti"
 
 msgid "Add Watch-Only Address"
-msgstr "Lisää Katseluosoite"
+msgstr "Lisää Katseltava Osoite"
 
 msgid "Address"
 msgstr "Osoite"
@@ -75,7 +75,7 @@ msgid "Address version"
 msgstr "Osoitteen versio"
 
 msgid "After creating the second passphrase if you are having issues with forms (second passphrase field not showing up) please restart your client."
-msgstr "Toisen tunnuslauseen luonnin jälkeen, jos sinulla on ongelmia (esim. toinen tunnuslause ei näy) ole hyvä ja käynnistä asiakasohjelma uudelleen."
+msgstr "Toisen tunnuslauseen luonnin jälkeen, jos sinulla on ongelmia (esim. toisen tunnuslauseen kenttä ei näy) ole hyvä ja käynnistä asiakasohjelma uudelleen."
 
 msgid "All your data, including created accounts, networks and contacts will be removed from the app and reset to default."
 msgstr "Oletusarvoja palautettaessa kaikki tietosi, mukaanlukien luodut tilit, verkot ja yhteystiedot POISTETAAN sovelluksesta."
@@ -84,10 +84,10 @@ msgid "Amount"
 msgstr "Määrä"
 
 msgid "Appearance"
-msgstr "Ulkonäkö"
+msgstr "Ulkoasu"
 
 msgid "Application"
-msgstr "Hakemus"
+msgstr "Sovellus"
 
 msgid "Amount (Ѧ)"
 msgstr "Määrä (Ѧ)"
@@ -96,7 +96,7 @@ msgid "Approval"
 msgstr "Hyväksyntä"
 
 msgid "Are you sure you want to remove this network and all data (accounts and settings) associated with it from your computer. Your accounts are still safe on the blockchain."
-msgstr "Haluatko varmasti poistaa tämän verkon ja kaikki siihen liittyvät tiedot (tilit ja asetukset) tietokoneeltasi? Huomaa että tilisi ovat edelleen  tallennettuna lohkoketjuun ja käytettävissä tunnuslauseen avulla."
+msgstr "Haluatko varmasti poistaa tämän verkon ja kaikki siihen liittyvät tiedot (tilit ja asetukset) tietokoneeltasi? Tilisi ovat silti edelleen turvassa lohkoketjussa."
 
 msgid "Arab"
 msgstr "Arabia"
@@ -120,34 +120,34 @@ msgid "Cancel"
 msgstr "Peruuta"
 
 msgid "Cannot find delegate:"
-msgstr "Edustajaa ei voitu löytää:"
+msgstr "Delegaattia ei löydy:"
 
 msgid "Cannot find delegates from this term:"
-msgstr "Edustajaa ei voitu löytää kyseisellä hakusanalla:"
+msgstr "Delegaatteja ei löydy tällä haulla:"
 
 msgid "Cannot find delegates on this peer:"
-msgstr "Edustajaa ei voitu löytää tältä vertaiskäyttäjältä:"
+msgstr "Delegaatteja ei löydy tältä vertaistaholta:"
 
 msgid "Cannot get registered delegates"
-msgstr "Rekisteröityjä edustajia ei voitu saada"
+msgstr "Rekisteröityjä delegaatteja ei voitu hakea"
 
 msgid "Cannot get sponsors"
-msgstr "Sponsoreita ei voitu saada"
+msgstr "Sponsoreita ei voitu hakea"
 
 msgid "Cannot get transactions"
-msgstr "Tilitapahtumia ei voitu saada"
+msgstr "Tilitapahtumia ei voitu hakea"
 
 msgid "Cannot get voted delegates"
-msgstr "Äänestettyjä edustajia ei voitu saada"
+msgstr "Äänestettyjä delegaatteja ei voitu hakea"
 
 msgid "Cannot state if account is a delegate"
-msgstr "Ei voida varmistua onko kyseinen tili edustaja"
+msgstr "Ei voida todeta onko kyseinen tili delegaatti"
 
 msgid "Change 1h/7h/7d"
-msgstr "Muutos 1h / 7h / 7 d"
+msgstr "Muutos 1h/7h/7d"
 
 msgid "Client"
-msgstr "Asiakas"
+msgstr "Asiakasohjelma"
 
 msgid "Close"
 msgstr "Sulje"
@@ -159,13 +159,13 @@ msgid "Confirm"
 msgstr "Vahvista"
 
 msgid "Network disconnected!"
-msgstr "Verkko irroitettu"
+msgstr "Verkkoyhteys Katkennut!"
 
 msgid "Passphrase is not saved on this computer."
-msgstr "Tunnuslausetta ei ole tallennettu tälle tietokoneelle."
+msgstr "Tunnuslausetta ei tallenneta tälle tietokoneelle."
 
 msgid "Watch-Only Addresses"
-msgstr "Katseluosoitteet"
+msgstr "Katseltavat Osoitteet"
 
 msgid "Confirmations"
 msgstr "Vahvistukset"
@@ -204,10 +204,10 @@ msgid "Delay"
 msgstr "Viive"
 
 msgid "Delegate"
-msgstr "Edustaja (delegate)"
+msgstr "Delegaatti"
 
 msgid "Delegate name"
-msgstr "Edustajan nimi"
+msgstr "Delegaatin nimi"
 
 msgid "Delete"
 msgstr "Poista"
@@ -219,7 +219,7 @@ msgid "Delete permanently this account"
 msgstr "Poista tämä tili pysyvästi"
 
 msgid "Destination Address"
-msgstr "Vastaanottajan Osoite"
+msgstr "Kohteen Osoite"
 
 msgid "Dutch"
 msgstr "Hollanti"
@@ -228,19 +228,19 @@ msgid "Edit Contact"
 msgstr "Muokkaa Kontaktia"
 
 msgid "Enable Signing"
-msgstr "Ota Käyttöön Allekirjoitukset"
+msgstr "Ota Allekirjoittaminen Käyttöön"
 
 msgid "Enable Virtual Folders"
-msgstr "Ota Käyttöön Virtuaaliset Kansiot"
+msgstr "Ota Virtuaalikansiot Käyttöön"
 
 msgid "Enable Votes"
-msgstr "Ota Käyttöön Äänet"
+msgstr "Ota Äänestys Käyttöön"
 
 msgid "English"
 msgstr "Englanti"
 
 msgid "Error in signature processing"
-msgstr "Virhe allekirjoituksen käsittelyssä"
+msgstr "Virhe allekijoituksen käsittelyssä"
 
 msgid "Error when trying to login:"
 msgstr "Virhe yritettäessä kirjautua sisään:"
@@ -252,13 +252,13 @@ msgid "Exchange"
 msgstr "Valuutanvaihto"
 
 msgid "Explorer"
-msgstr "Selain"
+msgstr "Selaaja"
 
 msgid "File"
 msgstr "Tiedosto"
 
 msgid "Fee (Ѧ)"
-msgstr "Kulut (Ѧ)"
+msgstr "Kulu (Ѧ)"
 
 msgid "Folder Name"
 msgstr "Kansion Nimi"
@@ -297,13 +297,13 @@ msgid "Id"
 msgstr "ID"
 
 msgid "If you own this account, you can enable Message Signing"
-msgstr "Jos omistat tämän tilin voit ottaa käyttöön Viestien Varmennuksen."
+msgstr "Jos omistat tämän tilin voit ottaa käyttöön Viestien Allekirjoittamisen."
 
 msgid "If you own this account, you can enable Voting"
 msgstr "Jos omistat tämän tilin, voit ottaa käyttöön Äänestämisen"
 
 msgid "If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br> Moreover, this account will move under\n                          the \"My Accounts\" list."
-msgstr "Jos omistat tämän tilin, voit ottaa käyttöön virtuaaliset kansiot. Virtuaaliset kansiot ovat yksinkertaisia alatilejä, joiden avulla voit tehokkaamin järjestää rahasi ilman, että sinun tarvitsee lähettää sitä ja maksaa välitysmaksuja.  <br> Virtuaalikansiot luodaan \"Omat Tilini\" luottelon alle."
+msgstr "Jos omistat tämän tilin, voit ottaa käyttöön virtuaaliset kansiot. Virtuaaliset kansiot ovat yksinkertaisia alatilejä, joiden avulla voit tehokkaamin järjestää rahasi ilman tarvetta tehdä oikeaa lähetystä ja maksaa välitysmaksua.  <br> Virtuaalikansiot luodaan \"Omat Tilini\" luottelon alle."
 
 msgid "Import"
 msgstr "Tuo..."
@@ -312,7 +312,7 @@ msgid "Import Account"
 msgstr "Tuo Tili ..."
 
 msgid "If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br>\n                          Moreover, this account will move under the \"My Accounts\" list."
-msgstr "Jos omistat tämän tilin, voit ottaa käyttöön virtuaaliset kansiot. Virtuaaliset kansiot ovat yksinkertaisia alatilejä, joiden avulla voit tehokkaamin järjestää rahasi ilman, että sinun tarvitsee lähettää sitä ja maksaa välitysmaksuja.  <br> \nVirtuaalikansiot luodaan \"Omat Tilini\" luottelon alle."
+msgstr "Jos omistat tämän tilin, voit ottaa käyttöön virtuaaliset kansiot. Virtuaaliset kansiot ovat yksinkertaisia alatilejä, joiden avulla voit tehokkaamin järjestää rahasi ilman tarvetta tehdä oikeaa lähetystä ja maksaa välitysmaksua.  <br> \nVirtuaalikansiot luodaan \"Omat Tilini\" luottelon alle."
 
 msgid "Indonesian"
 msgstr "Indonesia"
@@ -321,22 +321,22 @@ msgid "Italian"
 msgstr "Italia"
 
 msgid "Label"
-msgstr "Nimilappu"
+msgstr "Nimeä"
 
 msgid "Label set"
-msgstr "Nimilaput"
+msgstr "Nimetty"
 
 msgid "Language"
 msgstr "Kieli"
 
 msgid "Last checked"
-msgstr "Viimeksi Tarkistettu"
+msgstr "Viimeksi tarkistettu"
 
 msgid "Ledger Nano S"
 msgstr "Ledger Nano S"
 
 msgid "List full or delegate already voted."
-msgstr "Lista täynnä tai edustaja on jo äännestänyt."
+msgstr "Lista täynnä tai delegaattia on jo äänestetty."
 
 msgid "Login"
 msgstr "Kirjaudu"
@@ -345,7 +345,7 @@ msgid "Manage Networks"
 msgstr "Hallitse Verkkoja"
 
 msgid "Market"
-msgstr "Markkinat"
+msgstr "Markkina"
 
 msgid "Market Cap."
 msgstr "Markkina-arvo:"
@@ -381,25 +381,25 @@ msgid "New version available!"
 msgstr "Uusi versio saatavilla!"
 
 msgid "Network connected and healthy!"
-msgstr "Verkko yhdistetty ja terve!"
+msgstr "Verkko yhdistetty ja kunnossa!"
 
 msgid "Network disconected!"
-msgstr "Verkkoyhteys katkaistu!"
+msgstr "Verkkoyhteys katkennut!"
 
 msgid "Next"
 msgstr "Seuraava"
 
 msgid "No difference from original delegate list"
-msgstr "Ei eroa alkuperäisestä edustajalistasta"
+msgstr "Ei eroa alkuperäisestä delegaattilistasta"
 
 msgid "No publicKey"
-msgstr "Ei julkistaAvainta"
+msgstr "Ei julkista Avainta"
 
 msgid "No search term"
 msgstr "Ei hakusanaa"
 
 msgid "Not enough ARK on your account"
-msgstr "Tililläsi ei ole tarpeeksi ARK'ia"
+msgstr "Tililläsi ei ole tarpeeksi ARK:ia"
 
 msgid "OffChain"
 msgstr "OffChain"
@@ -408,7 +408,7 @@ msgid "Ok"
 msgstr "OK"
 
 msgid "Open Delegate Monitor"
-msgstr "Avaa Edustajaineuranta"
+msgstr "Avaa Delegaattiseuranta"
 
 msgid "Open File"
 msgstr "Avaa Tiedosto"
@@ -420,7 +420,7 @@ msgid "Chinese traditional"
 msgstr "Kiina (perinteinen)"
 
 msgid "Open in explorer"
-msgstr "Avaa selaimessa"
+msgstr "Avaa selaajassa"
 
 msgid "Optional"
 msgstr "Valinnainen"
@@ -435,13 +435,13 @@ msgid "Passphrase"
 msgstr "Tunnuslause"
 
 msgid "Passphrase does not match your address"
-msgstr "Tunnuslause ei vastaa sinun osoitetta"
+msgstr "Tunnuslause ei vastaa osoitettasi"
 
 msgid "Passphrase is not corresponding to account"
 msgstr "Tunnuslause ei vastaa tiliä"
 
 msgid "Passphrases are not secured with high standard. <br>\n              Use this feature only on safe computers and for accounts you can afford to lose balance."
-msgstr "Tunnuslauseita ei ole suojattu korkean standarin mukaisesti. <br>\nKäytä tätä toimintoa vain turvallisille tietokoneille ja tileille, joilla on varaa menettää tilin saldo."
+msgstr "Tunnuslauseita ei ole suojattu korkean standarin mukaisesti. <br>\nKäytä tätä toimintoa vain turvallisilla tietokoneilla ja tileillä, joiden saldon olet valmis menettämään."
 
 msgid "Passphrases deleted"
 msgstr "Tunnuslauseet poistettu"
@@ -450,31 +450,31 @@ msgid "Passphrases saved"
 msgstr "Tunnuslauseet tallennettu"
 
 msgid "Peer"
-msgstr "Vertainen"
+msgstr "Vertaistaho"
 
 msgid "Peer Status"
-msgstr "Vertaisten Tila"
+msgstr "Vertaistahon Tila"
 
 msgid "Please choose a file to be timestamped on the blockchain."
-msgstr "Valitse tiedosto, jonkahaluat merkitä aikaleimata lohkoketjussa."
+msgstr "Valitse tiedosto, jonka haluat aikaleimata lohkoketjussa."
 
 msgid "Please backup securely the passphrase, this client does NOT store it and thus cannot recover your passphrase"
-msgstr "VARMUUSKOPIOI TUNNUSLAUSEESI! Tämä asiakasohjelma EI TALLENNA sitä, täten tunnuslausettasi ei voida palauttaa"
+msgstr "Ole hyvä ja tee varmuuskopio tunnuslauseestasi, Tämä asiakasohjelma EI TALLENNA sitä, eikä sitä täten voida palauttaa"
 
 msgid "Please enter a folder name."
 msgstr "Anna kansion nimi."
 
 msgid "Please enter a new address."
-msgstr "Lisä uusi osoite."
+msgstr "Lisää uusi osoite."
 
 msgid "Please enter a short label."
-msgstr "Anna lyhyt kuvaus."
+msgstr "Anna lyhyt nimike."
 
 msgid "Please enter this account passphrase to login."
 msgstr "Anna tämän tilin tunnuslause kirjautuaksesi sisään."
 
 msgid "Please backup securely the second passphrase, this client does NOT store it and thus cannot recover your it"
-msgstr "Ole hyvä ja varmuuskopioi toinen tunnuslauseesi, tämä asiakasohjelma ei sitä tallenna. Tunnuslauseen hukkuessa sitä ei voida palauttaa"
+msgstr "Ole hyvä ja varmuuskopioi toinen tunnuslauseesi, tämä asiakasohjelma EI TALLENNA sitä, eikä sitä täten voida palauttaa"
 
 msgid "Please paste the original and second passphrase to validate the creation."
 msgstr "Ole hyvä ja liitä alkuperäinen sekä toinen tunnuslause vahvistaaksesi tilin luonnin."
@@ -483,10 +483,10 @@ msgid "Please backup securely the second passphrase, this client does NOT store 
 msgstr "Ole hyvä ja tee varmuuskopio toisesta tunnuslauseestasi. Tämä asiakasohjelma EI TALLENNA tunnuslausettasi, joten sitä ei voi palauttaa."
 
 msgid "Please restart your client after the delegate registration has been put in a block to reflect the changes."
-msgstr "Muutosten voimaanastumista varten ole hyvä ja uudelleenkäynnistä ohjelmisto kun edustajaksi rekisteröintisi on kirjattu lohkoon."
+msgstr "Muutosten voimaanastumista varten ole hyvä ja uudelleenkäynnistä asiakasohjelma kun delekaatiksi rekisteröinti on kirjattu lohkoon."
 
 msgid "Please first BACKUP SECURELY THE PASSPHRASE, this client does NOT store it and thus cannot recover your passphrase"
-msgstr "Ole hyvä ja TEE TUNNUSLAUSEESTASI USEAMPI VARMUUSKOPIO ja SÄILYTÄ NIITÄ ERILLÄÄN TURVALLISISSA PAIKOISSA. Tämä ohjelma EI TALLENNA tunnuslausettasi. Hukkunutta tunnuslausetta EI VOIDA PALAUTTAA ARK'in toimesta."
+msgstr "Ole hyvä ja TEE TUNNUSLAUSEESTASI VARMUUSKOPIO, Tämä ohjelma EI TALLENNA tunnuslausettasi eikä sitä täten voida palauttaa"
 
 msgid "Please type word 3, 6 and 9 from your passphrase to validate the account creation."
 msgstr "Ole hyvä ja kirjoita tunnuslauseesi sanat 3, 6 ja 9 vahvistaaksesi tilisi luonnin."
@@ -513,19 +513,19 @@ msgid "Quit"
 msgstr "Poistu"
 
 msgid "Quit Ark Client?"
-msgstr "Sulje Ark Pääteohjelma?"
+msgstr "Sulje Ark Asiakasohelma?"
 
 msgid "Rank"
-msgstr "Asema"
+msgstr "Sija"
 
 msgid "Receive Ark"
-msgstr "Vastaanota Ark'ia"
+msgstr "Ark Vastaanotto"
 
 msgid "Register Delegate"
-msgstr "Rekisteröi Edustajaksi"
+msgstr "Rekisteröi Delegaatti"
 
 msgid "Register delegate for"
-msgstr "Rekisteröi edustaja..."
+msgstr "Rekisteröi delegaatti..."
 
 msgid "Remove"
 msgstr "Poista"
@@ -561,7 +561,7 @@ msgid "Russian"
 msgstr "Venäjä"
 
 msgid "SHA256 Signature"
-msgstr "SHA256 Signeeraus"
+msgstr "SHA256 Allekirjoitus"
 
 msgid "Save"
 msgstr "Tallenna"
@@ -573,7 +573,7 @@ msgid "Second Passphrase"
 msgstr "Toinen Tunnuslause"
 
 msgid "Seed Server"
-msgstr "Siemenarvopalvelin"
+msgstr "Siemenpalvelin"
 
 msgid "Send"
 msgstr "Lähetä"
@@ -582,10 +582,10 @@ msgid "Send All"
 msgstr "Lähetä Kaikki"
 
 msgid "Send Ark"
-msgstr "Lähetä Ark'ia"
+msgstr "Ark Lähetys"
 
 msgid "Send Ark from"
-msgstr "Lähetä Ark'ia ..."
+msgstr "Lähetä Ark:ia ..."
 
 msgid "Set"
 msgstr "Määritä"
@@ -594,19 +594,19 @@ msgid "Settings"
 msgstr "Asetukset"
 
 msgid "Sign"
-msgstr "Kirjaudu"
+msgstr "Kuittaa"
 
 msgid "Sign / Verify Message"
-msgstr "Vahvista / Signeeraa Viesti"
+msgstr "Kuittaa / Vahvista Viesti"
 
 msgid "Sign Message"
-msgstr "Vahvista Viesti"
+msgstr "Kuittaa Viesti"
 
 msgid "Sign with Ledger"
-msgstr "Kirjaudu sisään käyttäen Ledger'iä"
+msgstr "Kuittaa Ledgerillä"
 
 msgid "Signature"
-msgstr "Allekirjoitus / Signeeraus"
+msgstr "Allekirjoitus"
 
 msgid "Slovenian"
 msgstr "Slovenia"
@@ -624,7 +624,7 @@ msgid "Switch Network"
 msgstr "Vaihda Verkkoa"
 
 msgid "Symbol"
-msgstr "Yksikkö"
+msgstr "Symboli"
 
 msgid "The destination address"
 msgstr "Kohdeosoite"
@@ -639,7 +639,7 @@ msgid "Second Passphrase added successfully:"
 msgstr "Toinen Tunnuslause lisätty onnistuneesti:"
 
 msgid "The second passphrase does not match the one you just got."
-msgstr "Toinen tunnuslause ei vastaa äsken saamaasi tunnuslausettasi."
+msgstr "Toinen tunnuslause ei vastaa äsken saamaasi tunnuslausetta."
 
 msgid "The words does not match the original passphrase."
 msgstr "Sanat eivät vastaa alkuperäistä tunnuslausetta."
@@ -654,7 +654,7 @@ msgid "This account already has a second passphrase:"
 msgstr "Tällä tilillä on jo toinen tunnuslause:"
 
 msgid "This signature can't be forged."
-msgstr "Tätä allekirjoitusta ei voi taata."
+msgstr "Tätä allekirjoitusta ei voi takoa lohkoon."
 
 msgid "This will save the SHA256 signature in a transaction of this account."
 msgstr "Tämä tallentaa SHA256-allekirjoituksen tämän tilin tapahtumaksi."
@@ -669,7 +669,7 @@ msgid "This account has never interacted with the network. This is a cold wallet
 msgstr "Tämä tili ei ole koskaan ollut vuorovaikutuksessa verkon kanssa. Tämä on kylmä lompakko."
 
 msgid "To"
-msgstr "Minne"
+msgstr "Mihin"
 
 msgid "Toggle Full Screen"
 msgstr "Kokoruututila"
@@ -717,7 +717,7 @@ msgid "Votes"
 msgstr "Äänet"
 
 msgid "Voting is an optional, but important mechanism that keeps the Ark network secure. The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks. This page can be used to cast your vote for\n                a delegate that you support."
-msgstr "Äänestäminen on valinnainen mutta tärkeä mekanismi, joka pitää Ark-verkon turvattuna. Verkoston 51 eniten ääniä saanutta edustajaa (delegaattia) ovat vastuussa tilitapahtumien tarkastamisesta sekä tapahtumien tallentamisesta uusiin lohkoihin. Tällä sivulla voit antaa äänesi tukemalle edustajallesi."
+msgstr "Äänestäminen on valinnainen mutta tärkeä mekanismi, joka pitää Ark-verkon turvattuna. Verkoston 51 eniten ääniä saanutta delegaattia ovat vastuussa tilitapahtumien tarkastamisesta sekä tapahtumien takomisesta uusiin lohkoihin. Tällä sivulla voit\n                 antaa äänesi tukemallesi delegaatille."
 
 msgid "Word"
 msgstr "Sana"
@@ -735,7 +735,7 @@ msgid "folder name"
 msgstr "kansion nimi"
 
 msgid "from"
-msgstr "mistä"
+msgstr "osoitteesta"
 
 msgid "is erroneous"
 msgstr "on virheellinen"
@@ -744,7 +744,7 @@ msgid "is not recognised"
 msgstr "ei tunnistettu"
 
 msgid "label"
-msgstr "etiketti"
+msgstr "nimike"
 
 msgid "missed blocks"
 msgstr "menetetyt lohkot"
@@ -765,14 +765,14 @@ msgid "sent with success!"
 msgstr "lähetetty onnistuneesti!"
 
 msgid "you need at least 1 ARK to vote"
-msgstr "tarvitset vähintään 1.0 ARK'ia äänestääksesi"
+msgstr "tarvitset vähintään 1 ARK:ia äänestääksesi"
 
 msgid "you need at least 25 ARK to register delegate"
-msgstr "tarvitset vähintään 25 ARK'ia rekisteröityäksesi edustajaksi"
+msgstr "tarvitset vähintään 25 ARK:ia delegaatin rekisteröintiin"
 
 msgid "Voting is an optional, but important mechanism that keeps the Ark network secure.\n                The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks.\n                This page can be used to cast your vote for a delegate that you support."
-msgstr "Äänestäminen on valinnainen mutta tärkeä mekanismi, joka pitää Ark-verkon turvattuna.\nVerkoston 51 eniten ääniä saanutta edustajaa (delegaattia) ovat vastuussa tilitapahtumien tarkastamisesta sekä tapahtumien tallentamisesta uusiin lohkoihin.\nTällä sivulla voit antaa äänesi tukemalle edustajallesi."
+msgstr "Äänestäminen on valinnainen mutta tärkeä mekanismi, joka pitää Ark-verkon turvattuna.\n                Verkoston 51 eniten ääniä saanutta delegaattia ovat vastuussa tilitapahtumien takomisesta sekä tapahtumien tallentamisesta uusiin lohkoihin.\n                Tällä sivulla voit antaa äänen tukemallesi delegaatille."
 
 msgid "you need at least 5 ARK to create a second passphrase"
-msgstr "tarvitset vähintään 5 ARK'ia luodaksesi toisen tunnuslauseen"
+msgstr "tarvitset vähintään 5 ARK:ia luodaksesi toisen tunnuslauseen"
 


### PR DESCRIPTION
Started to make changes/corrections to this before realizing that the translations were made on a dedicated platform. I think that there are allot of 'out of context' translations on the original that doesn't make sense.

Anyway these are the ones that didn't seem right to me. 
For example for "a delegate" there is a Finnish word "delegaatti" or even "valtuutettu" which means basically the same, instead of "edustaja" which means "a representative".

