### PR TITLE
Show the label of the account on the menu and the sending ARK dialog

### DIFF
--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -121,9 +121,10 @@
       }
 
       $scope.bs = {
+        label: selectedAccount.username,
         address: selectedAccount.address,
-        answer: answer,
-        items: items
+        answer,
+        items
       }
 
       $mdBottomSheet.show({
@@ -162,6 +163,7 @@
       let data = {
         ledger: selectedAccount.ledger,
         fromAddress: selectedAccount ? selectedAccount.address : '',
+        fromLabel: selectedAccount ? selectedAccount.username : null,
         secondSignature: selectedAccount ? selectedAccount.secondSignature : '',
         passphrase: passphrases[0] ? passphrases[0] : '',
         secondpassphrase: passphrases[1] ? passphrases[1] : ''

--- a/client/app/src/components/account/templates/account-menu.html
+++ b/client/app/src/components/account/templates/account-menu.html
@@ -1,6 +1,7 @@
 <md-bottom-sheet class="md-grid" layout="column">
   <div layout="row" layout-align="center center" ng-cloak>
-    <h2>{{bs.address}}</h2>
+    <h2 ng-if="bs.label">{{bs.label}} ({{bs.address}})</h2>
+    <h2 ng-if="! bs.label">{{bs.address}}</h2>
   </div>
   <div ng-cloak>
     <md-list flex layout="row" layout-align="center center">

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -2,7 +2,8 @@
   <form name="sendArkForm" ng-submit="send.submit()">
     <md-toolbar>
       <div class="md-toolbar-tools">
-        <h2><span>{{'Send'|translate}} {{ac.network.token}} {{'from'|translate}}</span>&nbsp;{{send.data.fromAddress}}</h2>
+        <h2 ng-if="send.data.fromLabel"><span>{{'Send'|translate}} {{ac.network.token}} {{'from'|translate}}</span>&nbsp;{{send.data.fromLabel}} ({{send.data.fromAddress}})</h2>
+        <h2 ng-if="! send.data.fromLabel"><span>{{'Send'|translate}} {{ac.network.token}} {{'from'|translate}}</span>&nbsp;{{send.data.fromAddress}}</h2>
         <span flex></span>
         <md-button class="md-icon-button" ng-click="send.cancel()">
           <md-icon md-font-library="material-icons">clear</md-icon>


### PR DESCRIPTION
  Currently the address is displayed, but it would be more human-friendly showing the label of that address too.