### PR TITLE
Add missing space in confirm dialog

### DIFF
--- a/client/app/src/accounts/view/validateTransactionDialog.html
+++ b/client/app/src/accounts/view/validateTransactionDialog.html
@@ -45,7 +45,7 @@
       </md-button>
       <span flex></span>
       <md-button class="md-raised md-primary" ng-click="validate.send()">
-        <span translate>Send</span> {{ul.network.symbol}}{{validate.totalAmount}} <span translate>now!</span>
+        <span translate>Send</span> {{ul.network.symbol}} {{validate.totalAmount}} <span translate>now!</span>
       </md-button>
       <md-button ng-click="validate.cancel()" style="margin-right:20px;">
         <translate>Cancel</translate>

--- a/client/app/src/components/account/templates/main-sidenav.html
+++ b/client/app/src/components/account/templates/main-sidenav.html
@@ -38,9 +38,9 @@
       <md-icon ng-if="$ctrl.ul.selected" style="pointer-events: auto" ng-click="" ng-mouseover="stats = $ctrl.ab.getStats($ctrl.ul.selected.address, contact.address)" aria-label="Stats" class="md-secondary" md-menu-align-target>
         info_outline
         <md-tooltip md-direction="bottom" class="tooltip-multiline">
-          {{'Income' | translate}}: {{$ctrl.ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate | lowercase}})
+          {{'Income' | translate}}: {{$ctrl.ul.network.symbol}} {{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate | lowercase}})
           <br>
-          {{'Expense' | translate}}: {{$ctrl.ul.network.symbol}}{{stats.expend.amount}} ({{stats.expend.transactions}} {{'Transactions' | translate | lowercase}})
+          {{'Expense' | translate}}: {{$ctrl.ul.network.symbol}} {{stats.expend.amount}} ({{stats.expend.transactions}} {{'Transactions' | translate | lowercase}})
         </md-tooltip>
       </md-icon>
     </span>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1086065/34649407-e12809fc-f3ae-11e7-9af4-d2d81374c3f8.png)

After:
![image](https://user-images.githubusercontent.com/1086065/34649409-f668c694-f3ae-11e7-9353-110486ea5bfd.png)

Obviously no need for the PR reward for this, just bothered me for a while :P
  
Edit:
Or ist this even wanted? Just saw that there's also no space for other currencies in the client... well if that's the case, it can be closed obviously.
  