### PR TITLE
Make it possible to access contacts / Read-Only accounts from Dashboard

### DIFF
--- a/client/app/assets/app.css
+++ b/client/app/assets/app.css
@@ -314,6 +314,19 @@ account-box {
   overflow: hidden;
   opacity: 0.9;
 }
+
+account-box h2 .md-select-value {
+  border-bottom-width: 0;
+}
+
+account-box h2 md-select.md-default-theme:not([disabled]):focus .md-select-value, md-select:not([disabled]):focus .md-select-value {
+  color: white;
+}
+
+account-box .md-toolbar-tools .md-button  {
+  margin-bottom: 6px;
+}
+
 #home-box-accounts {
     min-height: 180px;
 }

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -58,13 +58,13 @@
     </div>
   </div>
 
-  <div ng-cloak="" style="height: 100%" layout="column">
+  <div ng-cloak="" style="height: 100%" layout="column" ng-controller="AddressbookController as ab" >
 
     <main-navbar account-ctrl="ul"></main-navbar>
 
-    <dashboard account-ctrl="ul" id="dashboard" layout="column" layout-align="space-around center" ng-if="! ul.selected" flex></dashboard>
+    <dashboard account-ctrl="ul" addressbook-ctrl="ab" id="dashboard" layout="column" layout-align="space-around center" ng-if="!ul.selected" flex></dashboard>
 
-    <div class="account-view" ng-if="ul.selected" ng-controller="AddressbookController as ab" layout="column" flex>
+    <div class="account-view" ng-if="ul.selected" layout="column" flex>
       <md-content flex layout="row">
 
         <md-sidenav ng-click="ul.toggleList()" md-is-locked-open="$mdMedia('gt-md')" md-component-id="left" class="md-whiteframe-z2">

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -163,53 +163,6 @@
       })
     }
 
-    self.createRefreshState = (successMessage, errorMessage) => {
-      var stateObject = {}
-
-      stateObject.states = []
-
-      stateObject.isRefreshing = false
-
-      stateObject.create = () => {
-        var state = { isFinished: false, hasError: false }
-        stateObject.states.push(state)
-        return state
-      }
-
-      stateObject.shouldRefresh = () => {
-        if (stateObject.isRefreshing) {
-          return false
-        }
-
-        stateObject.isRefreshing = true
-        return true
-      }
-
-      stateObject.updateRefreshState = (showToast) => {
-        var areAllFinished = stateObject.states.every(state => state.isFinished)
-        var hasAnyError = stateObject.states.some(state => state.hasError)
-
-        if (!areAllFinished) {
-          return
-        }
-
-        stateObject.isRefreshing = false
-        stateObject.states = []
-
-        if (!showToast) {
-          return
-        }
-
-        if (!hasAnyError) {
-          toastService.success(successMessage, 3000)
-        } else {
-          toastService.error(errorMessage, 3000)
-        }
-      }
-
-      return stateObject
-    }
-
     self.clientVersion = require(_path.resolve(__dirname, '../../package.json')).version
     self.latestClientVersion = self.clientVersion
     self.openExplorer = openExplorer
@@ -221,8 +174,7 @@
     self.accounts = []
     self.selectAccount = selectAccount
     self.refreshCurrentAccount = refreshCurrentAccount
-    self.accountRefreshState = self.createRefreshState('Account refreshed', 'Could not refresh account')
-    self.accountsRefreshState = self.createRefreshState('Accounts refreshed', 'Could not refresh accounts')
+    self.accountRefreshState = utilityService.createRefreshState('Account refreshed', 'Could not refresh account')
     self.gotoAddress = gotoAddress
     self.getAllDelegates = getAllDelegates
     self.addWatchOnlyAddress = addWatchOnlyAddress
@@ -349,7 +301,6 @@
             toastService.error('Network disconnected!')
           } else if (self.connectedPeer.isConnected && !self.isNetworkConnected) {
             self.isNetworkConnected = true
-            self.refreshAccountBalances()
             toastService.success('Network connected and healthy!')
           }
         }, 500)
@@ -679,7 +630,7 @@
         })
         .finally(() => {
           accountState.isFinished = true
-          self.accountRefreshState.updateRefreshState(showToast)
+          self.accountRefreshState.updateRefreshState(showToast ? toastService : null)
         })
       accountService
         .getTransactions(myaccount.address)
@@ -720,30 +671,8 @@
         })
         .finally(() => {
           transactionsState.isFinished = true
-          self.accountRefreshState.updateRefreshState(showToast)
+          self.accountRefreshState.updateRefreshState(showToast ? toastService : null)
         })
-    }
-
-    self.refreshAccountBalances = (showToast) => {
-      const accounts = self.getAllAccounts()
-
-      if (!accounts.length || !self.accountsRefreshState.shouldRefresh()) {
-        return
-      }
-
-      networkService.getPrice()
-
-      accounts.forEach(account => {
-        var state = self.accountsRefreshState.create()
-        accountService
-          .refreshAccount(account)
-          .then(updated => { account.balance = updated.balance })
-          .catch(() => { state.hasError = true })
-          .finally(() => {
-            state.isFinished = true
-            self.accountsRefreshState.updateRefreshState(showToast)
-          })
-      })
     }
 
     self.toggleRefreshAccountsAutomatically = function () {

--- a/client/app/src/components/addressbook/addressbook.controller.js
+++ b/client/app/src/components/addressbook/addressbook.controller.js
@@ -15,6 +15,7 @@
     self.getContacts = function () {
       self.contacts = storageService.get('contacts')
       if (self.contacts == null || self.contacts === undefined) self.contacts = []
+      return self.contacts
     }
 
     self.getContacts()
@@ -60,7 +61,7 @@
       }
     }
 
-    self.addAddressbookContact = function () {
+    self.addAddressbookContact = function (successCallback) {
       $scope.addAddressbookContact = {
         add: add,
         cancel: cancel
@@ -110,6 +111,9 @@
         self.contacts.push(newContact)
         self.save()
         self.showToast(`Contact '${name}' with address '${address}' added successfully`)
+        if (successCallback) {
+          successCallback()
+        }
         cancel()
       }
 

--- a/client/app/src/components/dashboard/account-box.controller.js
+++ b/client/app/src/components/dashboard/account-box.controller.js
@@ -10,41 +10,113 @@
     .component('accountBox', {
       templateUrl: 'src/components/dashboard/account-box.html',
       bindings: {
-        accountCtrl: '='
+        accountCtrl: '=',
+        addressbookCtrl: '='
       },
-      controller: ['$scope', 'networkService', 'accountService', 'utilityService', AccountBoxController]
+      controller: ['$scope', 'networkService', 'accountService', 'utilityService', 'gettextCatalog', 'toastService', '$timeout', AccountBoxController]
     })
 
-  function AccountBoxController ($scope, networkService, accountService, utilityService) {
+  function AccountBoxController ($scope, networkService, accountService, utilityService, gettextCatalog, toastService, $timeout) {
     this.$onInit = () => {
       // Alias that is used on the template
       this.ac = this.accountCtrl
+
+      this.myAccountsType = this.createAccountType('My Accounts',
+                                                   this.ac.myAccounts,
+                                                   this.ac.getAllAccounts,
+                                                   utilityService.createRefreshState('Accounts refreshed', 'Could not refresh accounts'),
+                                                   this.ac.createAccount,
+                                                   'Create Account',
+                                                   this.ac.importAccount,
+                                                   'Import Account')
+
+      this.contactsType = this.createAccountType('Contacts',
+                                                 this.addressbookCtrl.getContacts,
+                                                 this.addressbookCtrl.getContacts,
+                                                 utilityService.createRefreshState('Contacts refreshed', 'Could not refresh contacts'),
+                                                 () => this.addressbookCtrl.addAddressbookContact(() => this.refreshAccounts()),
+                                                 'Add Contact')
+
+      if (this.myAccountsType.getAccountsToRefresh().length || !this.contactsType.getAccountsToRefresh().length) {
+        this.selectedAccountType = this.myAccountsType
+      } else {
+        this.selectedAccountType = this.contactsType
+      }
+
+      this.accountTypes = [this.myAccountsType, this.contactsType]
+
+      let didInitialRefresh = false
+      networkService.getConnection()
+        .then(() => {},
+              () => {},
+              (connectedPeer) => {
+                if (connectedPeer.isConnected && !didInitialRefresh) {
+                  $timeout(this.refreshAccounts, 500)
+                  didInitialRefresh = true
+                }
+              })
     }
 
-    this.myAccountsBalance = () => {
-      const total = this.accountCtrl.getAllAccounts().reduce((sum, account) => {
+    this.createAccountType = (title,
+                              getDisplayAccountsFunc,
+                              getAccountsToRefreshFunc,
+                              refreshState,
+                              createAccountFunc,
+                              createAccountText,
+                              importAccountFunc,
+                              importAccountText) => {
+      return {
+        title: gettextCatalog.getString(title),
+        getDisplayAccounts: getDisplayAccountsFunc,
+        getAccountsToRefresh: getAccountsToRefreshFunc,
+        createAccount: createAccountFunc,
+        createAccountText: gettextCatalog.getString(createAccountText),
+        importAccount: importAccountFunc,
+        importAccountText: gettextCatalog.getString(importAccountText),
+        refreshState: refreshState
+      }
+    }
+
+    this.refreshAccounts = (showToast) => {
+      this.refreshAccountBalances(showToast,
+                                  this.selectedAccountType.getAccountsToRefresh(),
+                                  this.selectedAccountType.refreshState)
+    }
+
+    this.refreshAccountBalances = (showToast, accounts, refreshState) => {
+      if (!accounts.length || !refreshState.shouldRefresh()) {
+        return
+      }
+
+      networkService.getPrice()
+
+      accounts.forEach(account => {
+        var state = refreshState.create()
+        accountService
+          .refreshAccount(account)
+          .then(updated => { account.balance = updated.balance })
+          .catch(() => { state.hasError = true })
+          .finally(() => {
+            state.isFinished = true
+            refreshState.updateRefreshState(showToast ? toastService : null)
+          })
+      })
+    }
+
+    this.getTotalBalance = (accountType) => {
+      const total = accountType.getAccountsToRefresh().reduce((sum, account) => {
         return sum + parseInt(account.balance || 0)
       }, 0)
 
       return utilityService.arktoshiToArk(total, true, 2)
     }
 
-    this.myAccountsCurrencyBalance = (bitcoinToggleIsActive) => {
+    this.currencyBalance = (accountType) => {
       const market = this.accountCtrl.connectedPeer.market
-      const currencyName = bitcoinToggleIsActive && this.accountCtrl.btcValueActive ? 'btc' : this.accountCtrl.currency.name
+      const currencyName = this.accountCtrl.btcValueActive ? 'btc' : this.accountCtrl.currency.name
       const price = market && market.price ? market.price[currencyName] : 0
 
-      return this.myAccountsBalance() * price
-    }
-
-    this.refreshAccountBalances = () => {
-      networkService.getPrice()
-
-      this.accountCtrl.getAllAccounts().forEach(account => {
-        accountService
-          .refreshAccount(account)
-          .then((updated) => { account.balance = updated.balance })
-      })
+      return this.getTotalBalance(accountType) * price
     }
   }
 })()

--- a/client/app/src/components/dashboard/account-box.html
+++ b/client/app/src/components/dashboard/account-box.html
@@ -1,40 +1,52 @@
 <md-toolbar layout="row" md-scroll-shrink>
   <div class="md-toolbar-tools">
-    <h2>
-      <translate>My Accounts</translate>
-      {{$ctrl.ac.network.symbol}} {{$ctrl.myAccountsBalance()}}
-      <span ng-show="$ctrl.ac.showExchangeRate()">/ {{$ctrl.myAccountsCurrencyBalance(true) | formatCurrency:$ctrl.ac:true}}</span>
+    <h2 md-no-underline>
+      <md-select ng-model="$ctrl.selectedAccountType" ng-change="$ctrl.refreshAccounts()" aria-label="Select type of accounts to display">
+        <md-option ng-value="type"
+                   ng-repeat="type in $ctrl.accountTypes">
+          {{type.title}}
+          {{$ctrl.ac.network.symbol}} {{$ctrl.getTotalBalance(type)}}
+          <span ng-show="$ctrl.ac.showExchangeRate()">/ {{$ctrl.currencyBalance(type) | formatCurrency:$ctrl.ac:true}}</span>
+        </md-option>
+      </md-select>
     </h2>
     <span flex></span>
 
-    <md-button class="md-small bitcoin-toggle" ng-click="$ctrl.ac.toggleBitcoinCurrency()" ng-hide="$ctrl.ac.currency.name === 'btc'" ng-if="$ctrl.accountCtrl.connectedPeer.market.available_supply">
+    <md-button class="md-small bitcoin-toggle"
+               ng-click="$ctrl.ac.toggleBitcoinCurrency()"
+               ng-hide="$ctrl.ac.currency.name === 'btc'"
+               ng-if="$ctrl.accountCtrl.connectedPeer.market.available_supply">
       <md-tooltip md-direction="top">
         {{'Toggle' | translate}} {{$ctrl.ac.toggleCurrency.name | uppercase}}
       </md-tooltip>
       <md-icon md-svg-icon="bitcoin_toggle"></md-icon>
     </md-button>
-    <md-button ng-class="{'rotate-360': $ctrl.ac.accountsRefreshState.isRefreshing}" class="share" ng-click="$ctrl.ac.refreshAccountBalances(true)" aria-label="Refresh balances">
+    <md-button ng-class="{'rotate-360': $ctrl.selectedAccountType.refreshState.isRefreshing}"
+               class="share"
+               ng-click="$ctrl.refreshAccounts(true)"
+               aria-label="Refresh balances">
       <md-icon md-font-library="material-icons">cached</md-icon>
     </md-button>
   </div>
 </md-toolbar>
-<div style="min-height: 100px; max-height: 300px; height: auto; border-radius:0 0 10px 10px" layout="column">
+<div style="min-height: 100px; max-height: 300px; height: auto; border-radius:0 0 10px 10px" layout="column" >
   <md-toolbar class="md-hue-2">
     <div class="md-toolbar-tools">
-      <md-button ng-click="$ctrl.ac.importAccount()">
+      <md-button ng-click="$ctrl.selectedAccountType.importAccount()" ng-if="$ctrl.selectedAccountType.importAccount">
         <md-icon>file_download</md-icon>
-        <translate>Import Account</translate>
+        {{$ctrl.selectedAccountType.importAccountText}}
       </md-button>
 
-      <md-button ng-click="$ctrl.ac.createAccount()">
+      <md-button ng-click="$ctrl.selectedAccountType.createAccount()">
         <md-icon>account_box</md-icon>
-        <translate>Create Account</translate>
+        {{$ctrl.selectedAccountType.createAccountText}}
       </md-button>
     </div>
   </md-toolbar>
+
   <md-content style="min-height: 70px;" flex>
     <md-list md-no-ink>
-      <md-list-item ng-click="$ctrl.ac.selectLedgerAccount()" ng-if="$ctrl.ac.ledger.connected">
+      <md-list-item ng-click="$ctrl.ac.selectLedgerAccount()" ng-if="$ctrl.ac.ledger.connected" ng-if="$ctrl.selectedAccountType === $ctrl.myAccountsType">
         <span>
           <md-icon md-svg-icon="ledger"></md-icon>
           Ledger Nano S
@@ -45,17 +57,31 @@
         </span>
       </md-list-item>
 
-      <md-list-item ng-click="$ctrl.ac.selectAccount(it)" ng-repeat="it in $ctrl.ac.myAccounts() track by $index">
+      <md-list-item ng-click="$ctrl.ac.selectAccount(it)"
+                    ng-repeat="it in $ctrl.selectedAccountType.getDisplayAccounts() track by $index"
+                    ng-if="$ctrl.selectedAccountType === $ctrl.myAccountsType">
         <span ng-class="{'selected' : it.address === $ctrl.ac.selected.address }">
           <md-icon ng-if="!it.delegate&&!it.cold" md-font-library="material-icons">account_balance</md-icon>
           <md-icon ng-if="!it.delegate&&it.cold" md-font-library="material-icons">cloud_off</md-icon>
           <md-icon ng-if="it.delegate" md-font-library="material-icons">security</md-icon>
-          {{it.username||it.address}}  <span ng-if="it.delegate">({{it.delegate.rate}})</span>
+          {{it.username || it.address}}  <span ng-if="it.delegate">({{it.delegate.rate}})</span>
         </span>
         <span class="md-secondary">
           {{$ctrl.ac.network.symbol}} {{it.balance | convertToArkValue}}
         </span>
       </md-list-item>
+
+      <md-list-item ng-click="$ctrl.ac.selectAccount(it)"
+                    ng-repeat="it in $ctrl.selectedAccountType.getDisplayAccounts() track by $index"
+                    ng-if="$ctrl.selectedAccountType === $ctrl.contactsType">
+          <span ng-class="{'selected' : it.address === $ctrl.ac.selected.address }">
+              <md-icon md-font-library="material-icons">account_circle</md-icon>
+            {{it.name || it.address}}
+          </span>
+          <span class="md-secondary">
+            {{$ctrl.ac.network.symbol}} {{it.balance | convertToArkValue}}
+          </span>
+        </md-list-item>
     </md-list>
   </md-content>
 </div>

--- a/client/app/src/components/dashboard/dashboard.controller.js
+++ b/client/app/src/components/dashboard/dashboard.controller.js
@@ -6,7 +6,8 @@
     .component('dashboard', {
       templateUrl: 'src/components/dashboard/templates/dashboard.html',
       bindings: {
-        accountCtrl: '='
+        accountCtrl: '=',
+        addressbookCtrl: '='
       },
       controller: [
         '$scope', '$mdToast', 'toastService', 'feedService', 'storageService', DashboardController

--- a/client/app/src/components/dashboard/templates/dashboard.html
+++ b/client/app/src/components/dashboard/templates/dashboard.html
@@ -1,4 +1,4 @@
-<account-box account-ctrl="$ctrl.accountCtrl" id="home-box-accounts" md-whiteframe="3"></account-box>
+<account-box account-ctrl="$ctrl.accountCtrl" addressbook-ctrl="$ctrl.addressbookCtrl" id="home-box-accounts" md-whiteframe="3"></account-box>
 
 <div id="home-box-row" layout="row" layout-align="space-between stretch">
   <market-box account-ctrl="$ctrl.accountCtrl" ng-if="$ctrl.accountCtrl.connectedPeer.market.available_supply"></market-box>

--- a/client/app/src/services/utility.service.js
+++ b/client/app/src/services/utility.service.js
@@ -83,6 +83,53 @@
       return new Date((arkRelativeTimeStamp + arkLaunchTime) * 1000)
     }
 
+    function createRefreshState (successMessage, errorMessage) {
+      var stateObject = {}
+
+      stateObject.states = []
+
+      stateObject.isRefreshing = false
+
+      stateObject.create = () => {
+        var state = { isFinished: false, hasError: false }
+        stateObject.states.push(state)
+        return state
+      }
+
+      stateObject.shouldRefresh = () => {
+        if (stateObject.isRefreshing) {
+          return false
+        }
+
+        stateObject.isRefreshing = true
+        return true
+      }
+
+      stateObject.updateRefreshState = (toastService) => {
+        var areAllFinished = stateObject.states.every(state => state.isFinished)
+        var hasAnyError = stateObject.states.some(state => state.hasError)
+
+        if (!areAllFinished) {
+          return
+        }
+
+        stateObject.isRefreshing = false
+        stateObject.states = []
+
+        if (!toastService) {
+          return
+        }
+
+        if (!hasAnyError) {
+          toastService.success(successMessage, 3000)
+        } else {
+          toastService.error(errorMessage, 3000)
+        }
+      }
+
+      return stateObject
+    }
+
     function numberToFixed (x) {
       let e
       if (Math.abs(x) < 1.0) {
@@ -108,7 +155,9 @@
       numberStringToFixed: numberStringToFixed,
 
       dateToArkStamp: dateToArkStamp,
-      arkStampToDate: arkStampToDate
+      arkStampToDate: arkStampToDate,
+
+      createRefreshState: createRefreshState
     }
   }
 })()

--- a/test/components/dashboard/account-box.controller.js
+++ b/test/components/dashboard/account-box.controller.js
@@ -3,7 +3,7 @@
 describe('AccountBoxController', function () {
   const expect = chai.expect
 
-  let ctrl, ARKTOSHI_UNIT, accounts, bindings
+  let ctrl, ARKTOSHI_UNIT, accounts, bindings, accountType, accountService
 
   beforeEach(module('arkclient.constants'));
 
@@ -11,7 +11,7 @@ describe('AccountBoxController', function () {
     module('arkclient.components', $provide => {
     })
 
-    inject((_$componentController_, _ARKTOSHI_UNIT_) => {
+    inject((_$componentController_, _ARKTOSHI_UNIT_, $injector) => {
 
       ARKTOSHI_UNIT = _ARKTOSHI_UNIT_
       accounts = [
@@ -38,19 +38,26 @@ describe('AccountBoxController', function () {
       }
 
       ctrl = _$componentController_('accountBox', null, bindings)
+      const utilityService = $injector.get('utilityService')
+      accountService = $injector.get('accountService')
+
+      accountType = ctrl.createAccountType('Test Accounts Type',
+                                           bindings.accountCtrl.getAllAccounts,
+                                           bindings.accountCtrl.getAllAccounts,
+                                           utilityService.createRefreshState('Contacts refreshed', 'Could not refresh contacts'))
     })
   })
 
-  describe('myAccountsBalance()', () => {
+  describe('getTotalBalance()', () => {
     it('sums the balance (in ARK, formatted) of all accounts', function () {
-      expect(ctrl.myAccountsBalance()).to.equal('30.00')
+      expect(ctrl.getTotalBalance(accountType)).to.equal('30.00')
     })
   })
 
-  describe('myAccountsCurrencyBalance()', () => {
+  describe('currencyBalance()', () => {
     context('when it is connected to a maket', () => {
       it('sums the balance (in the configured currency, formatted) of all accounts', function () {
-        expect(ctrl.myAccountsCurrencyBalance()).to.equal(3)
+        expect(ctrl.currencyBalance(accountType)).to.equal(3)
       })
     })
 
@@ -60,24 +67,32 @@ describe('AccountBoxController', function () {
       })
 
       it('returns 0', function () {
-        expect(ctrl.myAccountsCurrencyBalance()).to.equal(0)
+        expect(ctrl.currencyBalance(accountType)).to.equal(0)
       })
     })
   })
 
-  // TODO: Implement with accountController refreshAccountBalances method
-  xdescribe('refreshAccountBalances()', () => {
+  describe('refreshAccountBalances()', () => {
     context('when the balance of an account changes', () => {
       it('updates the balance', function () {
-        expect(ctrl.myAccountsBalance()).to.equal('30.00')
-        sinon.stub(bindings.accountCtrl, 'getAllAccounts').returns([
-          { balance: 1 * ARKTOSHI_UNIT },
-          { balance: 17 * ARKTOSHI_UNIT },
-          { balance: 1 * ARKTOSHI_UNIT },
-          { balance: 1 * ARKTOSHI_UNIT }
-        ])
-        ctrl.accountCtrl.refreshAccountBalances()
-        expect(ctrl.myAccountsBalance()).to.equal('20.00')
+        expect(ctrl.getTotalBalance(accountType)).to.equal('30.00')
+        accountService.refreshAccount = (account) => {
+          if (account.balance) {
+            account.balance = account.balance / 2
+          }
+          // we need to create a bluebirdpromise, because on a normal promise there is no finally
+          const bluebirdpromise = {}
+          bluebirdpromise.then = (resolve) => {
+            resolve(account)
+            return bluebirdpromise
+          }
+          bluebirdpromise.catch = () => bluebirdpromise
+          bluebirdpromise.finally = () => bluebirdpromise
+
+          return bluebirdpromise
+        }
+        ctrl.refreshAccountBalances(false, accountType.getAccountsToRefresh(), accountType.refreshState)
+        expect(ctrl.getTotalBalance(accountType)).to.equal('15.00')
       })
     })
   })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1086065/34690205-84c7e032-f4b8-11e7-9d9f-bbf91e76d364.png)

In the current version of the client it's not possible to...
- ... create a contact (read only account) WITHOUT having to import a generate a "real account" first (ok that's a lie, you can do it via the menu, but you don't see the contact anywhere after that)
- ... go directly to a contact (read only account) (you have to select a "real account" first and can only then select a contact on the left side)

This really ~~hurts my feelings~~ bothers me when I want to install the wallet and only add read-only accounts (for example on an "unsafe computer").

I'd like to implement this and gave this some thoughts on how to integrate it smoothly in the UI.
I don't think adding another box would be a good idea, since the space is, both in the horiztonal and in the vertical, not enough.

The only good solution I came up with is using a `md-dropdown` (only a prototype yet, we can add the same total value, same actions to the contacts, etc.).

The big advantage of this is, that the old, clean UI, can stay almost exactly as it is, except for one "arrow" icon :)

![demoold](https://user-images.githubusercontent.com/1086065/34690360-19948530-f4b9-11e7-9348-e48c8c7fc904.gif)

=> if there are no real accounts and only contacts, we can directly set the contacts tab as active.

- Does anyone have a better idea?
- Do you think this feature is even wanted by anyone other than me?
  
  
  