### PR TITLE
Only use ellipses if string is long enough

### DIFF
--- a/client/app/src/filters/filters.js
+++ b/client/app/src/filters/filters.js
@@ -63,6 +63,6 @@
   }])
 
   function smallId (fullId) {
-    return fullId.slice(0, 5) + '...' + fullId.slice(-5)
+    return (fullId.length > 10) ? fullId.slice(0, 5) + '...' + fullId.slice(-5) : fullId
   }
 })()


### PR DESCRIPTION
The change simply ensures that the full ID is at least longer than the two individual slices so that there is no text overlap.