### PR TITLE
Fix bug 'Cannot set property 'scrollTop' of undefined'

### DIFF
--- a/client/app/src/accounts/account-transactions.controller.js
+++ b/client/app/src/accounts/account-transactions.controller.js
@@ -24,7 +24,10 @@
     $scope.$on('account:onSelect', function (evt, account) {
       vm.address = account.address
       reset()
-      angular.element(document.querySelector('.tx-list-container'))[0].scrollTop = 0
+      const txListContainerElement = angular.element(document.querySelector('.tx-list-container'))[0]
+      if (txListContainerElement) {
+        txListContainerElement.scrollTop = 0
+      }
       updateTransactions(account.transactions)
     })
 


### PR DESCRIPTION
Happens when you create / import a new account which has no transactions.

![image](https://user-images.githubusercontent.com/1086065/34909391-3094a946-f8a0-11e7-8740-050fbde09802.png)
