### PR TITLE
Make ark client work if main peerseed is down on fresh-install

### DIFF
--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -324,7 +324,7 @@
         peers = tryGetPeersFromArkJs()
         isStaticPeerList = true
       } else if (index === 0) {
-        peers = peers.sort((a, b) => b.height - a.height || a.delay - b.delay)
+        peers = peers.sort((a, b) => b.height - a.height || a.delay - b.delay).filter(p => p.ip !== '127.0.0.1')
       }
 
       // check again or we may have an exception in the case when we couldn't get the static peer list from arkjs

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -218,28 +218,77 @@
       }
     },
     "arkjs": {
-      "version": "git://github.com/ArkEcosystem/ark-js.git#1adcf70ecdebec7e5f902b96b2f45290c327781a",
+      "version": "git://github.com/ArkEcosystem/ark-js.git#d3ea6724849813c24c9e83edc57371ca5c0a98da",
       "requires": {
         "bigi": "1.4.2",
         "bip66": "1.1.5",
         "browserify-bignum": "1.3.0-2",
-        "bs58check": "1.3.4",
-        "buffer": "4.9.1",
+        "bs58check": "2.1.1",
+        "buffer": "5.0.8",
         "bytebuffer": "5.0.1",
+        "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
-        "crypto-browserify": "3.11.0",
+        "crypto-browserify": "3.12.0",
         "ecdsa": "0.7.0",
         "ecurve": "1.0.6",
-        "js-nacl": "github:tonyg/js-nacl#6dc1417057cd81381d332b370e82ceab1f2416af",
-        "mocha": "3.1.0",
+        "js-nacl": "1.2.2",
         "randombytes": "2.0.5",
         "secp256k1": "3.4.0",
         "typeforce": "1.12.0",
         "wif": "2.0.6"
       },
       "dependencies": {
-        "js-nacl": {
-          "version": "github:tonyg/js-nacl#6dc1417057cd81381d332b370e82ceab1f2416af"
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "requires": {
+            "base-x": "3.0.4"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
+          "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
+          "requires": {
+            "bs58": "4.0.1",
+            "create-hash": "1.1.3"
+          }
+        },
+        "buffer": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
+          "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+          "requires": {
+            "base64-js": "1.2.1",
+            "ieee754": "1.1.8"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+          "requires": {
+            "browserify-cipher": "1.0.0",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.0",
+            "create-hash": "1.1.3",
+            "create-hmac": "1.1.6",
+            "diffie-hellman": "5.0.2",
+            "inherits": "2.0.3",
+            "pbkdf2": "3.0.14",
+            "public-encrypt": "4.0.0",
+            "randombytes": "2.0.5",
+            "randomfill": "1.0.3"
+          }
         }
       }
     },
@@ -513,11 +562,6 @@
         }
       }
     },
-    "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
-    },
     "browserify": {
       "version": "14.5.0",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
@@ -690,16 +734,6 @@
       "requires": {
         "bs58": "3.1.0",
         "create-hash": "1.1.3"
-      }
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
       }
     },
     "buffer-equal": {
@@ -999,6 +1033,7 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
+      "dev": true,
       "requires": {
         "browserify-cipher": "1.0.0",
         "browserify-sign": "4.0.4",
@@ -1046,14 +1081,6 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
-    },
-    "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "requires": {
-        "ms": "0.7.1"
-      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1119,11 +1146,6 @@
           "dev": true
         }
       }
-    },
-    "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -2357,11 +2379,6 @@
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2392,11 +2409,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -2775,6 +2787,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
       "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ=="
     },
+    "js-nacl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/js-nacl/-/js-nacl-1.2.2.tgz",
+      "integrity": "sha1-xGM9v6Z9xi9rcwM+URjlZOWruYc="
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2842,11 +2859,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2978,35 +2990,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -3021,36 +3004,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -3251,24 +3204,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mocha": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.0.tgz",
-      "integrity": "sha1-EvJW/qiF4WoeYnoXHWi+7w8tYYw=",
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.0.5",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      }
-    },
     "module-deps": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
@@ -3291,11 +3226,6 @@
         "through2": "2.0.3",
         "xtend": "4.0.1"
       }
-    },
-    "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "nan": {
       "version": "2.8.0",
@@ -3909,6 +3839,15 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "randomfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz",
+      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+      "requires": {
+        "randombytes": "2.0.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "read-chunk": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
@@ -4437,14 +4376,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "requires": {
-        "has-flag": "1.0.0"
       }
     },
     "symbol-tree": {

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
     "angular-messages": "^1.5.5",
     "angular-qrcode": "^7.2.0",
     "ark-qrcode": "0.0.6",
-    "arkjs": "git://github.com/ArkEcosystem/ark-js.git#mainnet",
+    "arkjs": "git://github.com/ArkEcosystem/ark-js.git#master",
     "bip39": "^2.2.0",
     "jsqr": "^0.2.2",
     "ng-infinite-scroll": "^1.3.0",


### PR DESCRIPTION
Implemented as follows:

- The mainnet (ark) and the devnet (dark) networks are now created with the values from `ark-js`. 
  - Because of this the `peerseed` of the mainnet (`http://5.39.9.240:4001` => `http://node1.arknet.cloud:4001` ) and the peerseed of the devnet  (`http://167.114.29.55:4002` => `104.238.165.129:4002` ) are now different!
    -   I did not come up with these values myself, they are the same as we use in `ark-ts`
  - ~I used the `pubKeyHash` as the `version`. I'm not sure if this correct :P For `Ark` it appears to be the same value, but for `DARK` it changed from `30` to `0x52`. Sorry if this is wrong, I think I don't even fully understand what the difference between these values is (if there is any). But it's not the same, I think it wold be good to add the version to the network config in `ark-js` and `ark-ts`~.
    - Ok found out it's not the same. Still two questions: Can someone explain me `pubKeyHash` vs `version` (and why it's the same value in Ark) and also should the `version` als be added to `ark-js`? 
- If the app is started, the peerseed is down and there is no peer list in the storage, the peer list from `ark-js` is taken. If one of these peers could be reached, then the real peer list, of the newly picked peer is loaded and stored in the storage. So on the next run it will work without the static peer list from `ark-js`
- I do never change the `activePeerSeed` in the storage / network config. Basically this means if the activePeerSeed is down forever the first request will always fail (it's the same way, as it was before). I guess this is correct? Or should it be updated to a working peer once we got any?

ToDos:
 - [x] Increase ark-js package version / use newer ark-js version

Depends on: https://github.com/ArkEcosystem/ark-js/pull/48
Fixes: #516