### PR TITLE
Resolve contacts in send form & optimizations

### DIFF
--- a/client/app/src/accounts/account-transactions.controller.js
+++ b/client/app/src/accounts/account-transactions.controller.js
@@ -84,11 +84,11 @@
 
       const mergeTransactions = [...transactions, ...vm.transactions]
       // remove duplicates
-      const uniqueTransactions = mergeTransactions.filter((obj, pos, arr) => {
+      const singleTransactions = mergeTransactions.filter((obj, pos, arr) => {
         return arr.map(obj => obj['id']).indexOf(obj['id']) === pos
       }).sort((a, b) => b.timestamp - a.timestamp)
 
-      vm.transactions = uniqueTransactions
+      vm.transactions = singleTransactions
       storageService.set(`transactions-${vm.address}`, vm.transactions, true)
     }
   }

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -326,7 +326,7 @@
       }
     )
 
-    self.getAccountIcon = (account) => {
+    function getAccountIcon (account) {
       if (account.delegate) {
         return 'security'
       }
@@ -445,6 +445,9 @@
         return !!account.virtual
       }).sort((a, b) => {
         return b.balance - a.balance
+      }).map(account => {
+        account.icon = getAccountIcon(account)
+        return account
       })
     }
 
@@ -716,7 +719,7 @@
 
       const accounts = self.getAllAccounts()
         .map(acc => {
-          return {name: acc.username, address: acc.address, type: gettext('Account'), icon: self.getAccountIcon(acc)}
+          return {name: acc.username, address: acc.address, type: gettext('Account'), icon: acc.icon}
         })
       let contacts = (storageService.get('contacts') || [])
         .map(c => {

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -326,6 +326,18 @@
       }
     )
 
+    self.getAccountIcon = (account) => {
+      if (account.delegate) {
+        return 'security'
+      }
+
+      if (!account.cold) {
+        return 'account_balance'
+      }
+
+      return 'cloud_off'
+    }
+
     // get themes colors to show in manager appearance
     function reloadThemes () {
       const currentThemes = $mdThemingProvider.$get().THEMES
@@ -704,7 +716,7 @@
 
       const accounts = self.getAllAccounts()
         .map(acc => {
-          return {name: acc.username, address: acc.address, type: gettext('Account'), icon: 'account_balance_wallet'}
+          return {name: acc.username, address: acc.address, type: gettext('Account'), icon: self.getAccountIcon(acc)}
         })
       let contacts = (storageService.get('contacts') || [])
         .map(c => {

--- a/client/app/src/accounts/view/validateTransactionDialog.html
+++ b/client/app/src/accounts/view/validateTransactionDialog.html
@@ -22,7 +22,18 @@
             <b translate>From</b><span class="md-secondary">{{validate.transaction.senderId}}</span>
           </md-list-item>
           <md-list-item ng-if="validate.transaction.type==0">
-            <b translate>To</b><span class="md-secondary">{{validate.transaction.recipientId}}</span>
+            <b translate>To</b>
+            <span class="md-secondary">
+              <span style="vertical-align: middle;">
+              {{validate.transaction.recipientId}}
+              </span>
+              <md-icon md-font-library="material-icons" ng-if="validate.resolvedAccount && validate.resolvedAccount.name">
+                {{validate.resolvedAccount.icon}}
+                <md-tooltip>
+                    <b>{{validate.resolvedAccount.type | translate}}</b>: {{validate.resolvedAccount.name}}
+                </md-tooltip>
+              </md-icon>
+              </span>
           </md-list-item>
           <md-list-item ng-if="validate.transaction.username">
             <b translate>Username</b><span class="md-secondary">{{validate.transaction.username}}</span>

--- a/client/app/src/components/account/templates/main-sidenav.html
+++ b/client/app/src/components/account/templates/main-sidenav.html
@@ -20,7 +20,7 @@
   </md-list-item>
   <md-list-item md-ink-ripple="0" md-colors="{background: (it.address === $ctrl.ul.selected.address ? 'primary' : 'background')}" ng-click="$ctrl.ul.selectAccount(it)" ng-repeat="it in $ctrl.ul.myAccounts() track by $index">
     <span style="white-space: nowrap;">
-          <md-icon md-font-library="material-icons">{{ $ctrl.ul.getAccountIcon(it) }}</md-icon>
+          <md-icon md-font-library="material-icons">{{ it.icon }}</md-icon>
           {{it.address|accountLabel}}
         </span>
   </md-list-item>

--- a/client/app/src/components/account/templates/main-sidenav.html
+++ b/client/app/src/components/account/templates/main-sidenav.html
@@ -20,9 +20,7 @@
   </md-list-item>
   <md-list-item md-ink-ripple="0" md-colors="{background: (it.address === $ctrl.ul.selected.address ? 'primary' : 'background')}" ng-click="$ctrl.ul.selectAccount(it)" ng-repeat="it in $ctrl.ul.myAccounts() track by $index">
     <span style="white-space: nowrap;">
-          <md-icon ng-if="!it.delegate&&!it.cold" md-font-library="material-icons">account_balance</md-icon>
-          <md-icon ng-if="!it.delegate&&it.cold" md-font-library="material-icons">cloud_off</md-icon>
-          <md-icon ng-if="it.delegate" md-font-library="material-icons">security</md-icon>
+          <md-icon md-font-library="material-icons">{{ $ctrl.ul.getAccountIcon(it) }}</md-icon>
           {{it.address|accountLabel}}
         </span>
   </md-list-item>

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -15,12 +15,12 @@
   <md-dialog-content>
     <md-tabs md-dynamic-height ng-keyup="$event.keyCode == 13 && submit(tab)">
 
-      <md-tab md-on-select="selectTab('unique')">
+      <md-tab md-on-select="selectTab('single')">
         <md-tab-label>
-          <translate>Unique</translate>
+          <translate>Single</translate>
         </md-tab-label>
         <md-tab-body>
-          <form name="uniqueForm" class="md-dialog-content">
+          <form name="singleForm" class="md-dialog-content">
 
             <div layout="row" flex layout-align="start start">
               <md-input-container flex="5" ng-if="!receiverValidation.resolvedAccount || !receiverValidation.resolvedAccount.icon">
@@ -140,7 +140,7 @@
 
     <md-button type="submit"
                ng-click="submit(tab)"
-               ng-disabled="(tab == 'unique' && uniqueForm.$invalid || receiverValidation.failType === 'error' || !data.toAddress) || (tab == 'multiple' && multipleForm.$invalid)"
+               ng-disabled="(tab == 'single' && singleForm.$invalid || receiverValidation.failType === 'error' || !data.toAddress) || (tab == 'multiple' && multipleForm.$invalid)"
                tabIndex="6">
       <translate ng-if="!data.ledger">Next</translate>
       <translate ng-if="data.ledger">Sign with Ledger</translate>

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -48,7 +48,12 @@
                                ng-blur="onAddressFieldBlur()">
                 <md-item-template>
                   <span class="item-title">
-                      <md-icon md-font-library="material-icons">{{contact.icon}}</md-icon>
+                      <md-icon md-font-library="material-icons">
+                        {{contact.icon}}
+                        <md-tooltip>
+                            {{contact.type | translate}}
+                        </md-tooltip>
+                      </md-icon>
                       <span ng-if="contact.name"> {{contact.name}} -</span>
                       <span>{{contact.address}}</span>
                   </span>

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -1,14 +1,14 @@
 <md-dialog aria-label="{{'Send'|translate}} {{network.token}}" ng-cloak md-theme="ac.currentTheme">
   <md-toolbar>
     <div class="md-toolbar-tools">
-			<h2 ng-if="data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromLabel}} ({{data.fromAddress}})</h2>
-			<h2 ng-if="! data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromAddress}}</h2>
+      <h2 ng-if="data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromLabel}} ({{data.fromAddress}})</h2>
+      <h2 ng-if="! data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromAddress}}</h2>
 
-			<span flex></span>
+      <span flex></span>
 
-			<md-button class="md-icon-button" ng-click="cancel()">
-				<md-icon md-font-library="material-icons">clear</md-icon>
-			</md-button>
+      <md-button class="md-icon-button" ng-click="cancel()">
+        <md-icon md-font-library="material-icons">clear</md-icon>
+      </md-button>
     </div>
   </md-toolbar>
 
@@ -23,25 +23,43 @@
           <form name="uniqueForm" class="md-dialog-content">
 
             <div layout="row" flex layout-align="start start">
-              <md-input-container flex="5">
+              <md-input-container flex="5" ng-if="!receiverValidation.resolvedAccount || !receiverValidation.resolvedAccount.icon">
                 <qr-scanner input-callback-func="onQrCodeForToAddressScanned(qr)"></qr-scanner>
               </md-input-container>
 
-              <md-autocomplete flex="95" md-selected-item="data.selectedAddress" md-selected-item-change="selectedContactChange(contact)" md-search-text-change="searchTextChange(searchText)" md-search-text="searchText"
-                md-items="contact in querySearch(searchText)" md-item-text="(contact.name || contact.username) ? ((contact.name || contact.username) + ' - ' + contact.address) : contact.address" md-min-length="0" md-autofocus="true" ng-attr-md-floating-label="{{'Type an address or a name'|translate}}" tabIndex="1">
+              <md-icon flex="5" md-font-library="material-icons" ng-if="receiverValidation.resolvedAccount && receiverValidation.resolvedAccount.icon">
+                {{receiverValidation.resolvedAccount.icon}}
+                <md-tooltip>
+                    {{receiverValidation.resolvedAccount.type | translate}}
+                </md-tooltip>
+              </md-icon>
+
+              <md-autocomplete flex="95"
+                               tabIndex="1"
+                               md-selected-item="data.selectedAddress"
+                               md-selected-item-change="selectedContactChange(contact)"
+                               md-search-text-change="searchTextChange(searchText)"
+                               md-search-text="searchText"
+                               md-items="contact in searchContactOrAccount(searchText)"
+                               md-item-text="contact.name ? (contact.name + ' - ' + contact.address) : contact.address"
+                               md-min-length="0"
+                               md-autofocus="true"
+                               ng-attr-md-floating-label="{{'Type an address or a name'|translate}}"
+                               ng-blur="onAddressFieldBlur()">
                 <md-item-template>
                   <span class="item-title">
-                      <span ng-if="contact.name || contact.username"> {{contact.name || contact.username}} - </span>
-                      <span> {{contact.address}} </span>
+                      <md-icon md-font-library="material-icons">{{contact.icon}}</md-icon>
+                      <span ng-if="contact.name"> {{contact.name}} -</span>
+                      <span>{{contact.address}}</span>
                   </span>
                 </md-item-template>
               </md-autocomplete>
             </div>
 
-						<div layout="row" flex layout-align="start center" ng-if="receiverValidation.failType">
-							<md-icon flex="5" md-font-library="material-icons">{{receiverValidation.failType}}</md-icon>
-							<div flex="95">{{receiverValidation.message}}</div>
-						</div>
+            <div layout="row" flex layout-align="start center" ng-if="receiverValidation.failType">
+              <md-icon flex="5" md-font-library="material-icons">{{receiverValidation.failType}}</md-icon>
+              <div flex="95">{{receiverValidation.message}}</div>
+            </div>
 
             <div layout="row" layout-align="space-between start">
               <md-input-container class="md-block" style="width: 100%">
@@ -115,7 +133,10 @@
     </div>
     <span flex></span>
 
-    <md-button type="submit" ng-click="submit(tab)" ng-disabled="(tab == 'unique' && uniqueForm.$invalid || receiverValidation.failType === 'error') || (tab == 'multiple' && multipleForm.$invalid)" tabIndex="6">
+    <md-button type="submit"
+               ng-click="submit(tab)"
+               ng-disabled="(tab == 'unique' && uniqueForm.$invalid || receiverValidation.failType === 'error' || !data.toAddress) || (tab == 'multiple' && multipleForm.$invalid)"
+               tabIndex="6">
       <translate ng-if="!data.ledger">Next</translate>
       <translate ng-if="data.ledger">Sign with Ledger</translate>
     </md-button>

--- a/client/app/src/components/dashboard/account-box.html
+++ b/client/app/src/components/dashboard/account-box.html
@@ -46,7 +46,7 @@
 
   <md-content style="min-height: 70px;" flex>
     <md-list md-no-ink>
-      <md-list-item ng-click="$ctrl.ac.selectLedgerAccount()" ng-if="$ctrl.ac.ledger.connected" ng-if="$ctrl.selectedAccountType === $ctrl.myAccountsType">
+      <md-list-item ng-click="$ctrl.ac.selectLedgerAccount()" ng-if="$ctrl.ac.ledger.connected && ctrl.selectedAccountType === $ctrl.myAccountsType">
         <span>
           <md-icon md-svg-icon="ledger"></md-icon>
           Ledger Nano S
@@ -61,9 +61,7 @@
                     ng-repeat="it in $ctrl.selectedAccountType.getDisplayAccounts() track by $index"
                     ng-if="$ctrl.selectedAccountType === $ctrl.myAccountsType">
         <span ng-class="{'selected' : it.address === $ctrl.ac.selected.address }">
-          <md-icon ng-if="!it.delegate&&!it.cold" md-font-library="material-icons">account_balance</md-icon>
-          <md-icon ng-if="!it.delegate&&it.cold" md-font-library="material-icons">cloud_off</md-icon>
-          <md-icon ng-if="it.delegate" md-font-library="material-icons">security</md-icon>
+          <md-icon md-font-library="material-icons">{{ $ctrl.ac.getAccountIcon(it) }}</md-icon>
           {{it.username || it.address}}  <span ng-if="it.delegate">({{it.delegate.rate}})</span>
         </span>
         <span class="md-secondary">

--- a/client/app/src/components/dashboard/account-box.html
+++ b/client/app/src/components/dashboard/account-box.html
@@ -61,7 +61,7 @@
                     ng-repeat="it in $ctrl.selectedAccountType.getDisplayAccounts() track by $index"
                     ng-if="$ctrl.selectedAccountType === $ctrl.myAccountsType">
         <span ng-class="{'selected' : it.address === $ctrl.ac.selected.address }">
-          <md-icon md-font-library="material-icons">{{ $ctrl.ac.getAccountIcon(it) }}</md-icon>
+          <md-icon md-font-library="material-icons">{{ it.icon }}</md-icon>
           {{it.username || it.address}}  <span ng-if="it.delegate">({{it.delegate.rate}})</span>
         </span>
         <span class="md-secondary">

--- a/client/app/src/services/transaction-sender.service.js
+++ b/client/app/src/services/transaction-sender.service.js
@@ -96,7 +96,7 @@
 
         dialogService.hide()
 
-        if (tab === 'unique') {
+        if (tab === 'single') {
           data.toAddress = $scope.data.toAddress.trim()
           data.amount = Number(utilityService.arkToArktoshi(parseFloat($scope.data.amount), 0))
           data.smartbridge = $scope.data.smartbridge
@@ -113,7 +113,7 @@
         }
       }
 
-      $scope.tab = 'unique'
+      $scope.tab = 'single'
       $scope.data = {
         ledger: selectedAccount.ledger,
         fromAddress: selectedAccount ? selectedAccount.address : '',

--- a/test/accounts/account.controller.js
+++ b/test/accounts/account.controller.js
@@ -25,7 +25,8 @@ describe('AccountController', () => {
 
   let mdDialogMock,
     mdToastMock,
-    getTextCatalogMock
+    getTextCatalogMock,
+    gettextMock
 
   const ACCOUNTS = ['userAccount1', 'userAccount2']
 
@@ -92,6 +93,7 @@ describe('AccountController', () => {
         getString: sinon.stub().returns('!'),
         setCurrentLanguage: sinon.stub()
       }
+      gettextMock = sinon.stub().returnsArg(0)
 
       // provide mocks to angular controller
       $provide.value('accountService', accountServiceMock)
@@ -109,6 +111,7 @@ describe('AccountController', () => {
       $provide.value('$mdDialog', mdDialogMock)
       $provide.value('$mdToast', mdToastMock)
       $provide.value('gettextCatalog', getTextCatalogMock)
+      $provide.value('gettext', gettextMock)
     })
 
     inject((_$compile_, _$rootScope_, _$controller_) => {

--- a/test/accounts/account.service.js
+++ b/test/accounts/account.service.js
@@ -2,7 +2,7 @@
 
 describe('accountService', () => {
   let accountService
-  let gettextCatalogMock, networkServiceMock
+  let gettextCatalogMock, gettextMock, networkServiceMock
   let intervalRef
 
   function mockGetFromPeer (transactionsArray) {
@@ -41,12 +41,14 @@ describe('accountService', () => {
   beforeEach(() => {
     module('arkclient.accounts', $provide => {
       gettextCatalogMock = {getString: sinon.stub().returnsArg(0)}
+      gettextMock = sinon.stub().returnsArg(0)
       networkServiceMock = { listenNetworkHeight: sinon.stub(),
         getPeer: sinon.stub().returns('127.0.0.1'),
         getNetwork: sinon.stub().returns({ version: 0x17 }) }
 
       // inject the mock services
       $provide.value('gettextCatalog', gettextCatalogMock)
+      $provide.value('gettext', gettextMock)
       $provide.value('networkService', networkServiceMock)
     })
 

--- a/test/services/transaction-sender.service.js
+++ b/test/services/transaction-sender.service.js
@@ -20,7 +20,8 @@ describe('transactionSenderService', () => {
 
     let mdDialogMock,
       mdToastMock,
-      getTextCatalogMock
+      getTextCatalogMock,
+      gettextMock
 
     const transactionBuilderServiceMock = {
       createSendTransaction: sinon.stub()
@@ -89,6 +90,7 @@ describe('transactionSenderService', () => {
           getString: sinon.stub().returns('!'),
           setCurrentLanguage: sinon.stub()
         }
+        gettextMock = sinon.stub().returnsArg(0)
 
         // provide mocks to angular controller
         $provide.value('accountService', accountServiceMock)
@@ -105,6 +107,7 @@ describe('transactionSenderService', () => {
         $provide.value('$mdDialog', mdDialogMock)
         $provide.value('$mdToast', mdToastMock)
         $provide.value('gettextCatalog', getTextCatalogMock)
+        $provide.value('gettext', gettextMock)
       })
 
       module('arkclient.services', $provide => {

--- a/test/services/transaction-sender.service.js
+++ b/test/services/transaction-sender.service.js
@@ -125,8 +125,8 @@ describe('transactionSenderService', () => {
       transactionBuilderServiceMock.createSendTransaction.reset()
     })
 
-    context('unique transaction', () => {
-      const tab = 'unique'
+    context('single transaction', () => {
+      const tab = 'single'
 
       const fillValidForm = ({ amount }) => {
         $scope[`${tab}Form`] = { $valid: true }


### PR DESCRIPTION
This does the following:
- On type in address field now also works for wallet labels (did only work for contacts before)
- Form cannot be sent if address is empty
- Known addresses (contacts & wallet labels) are now always resolved and displayed below the field (it always bothered me, that you selected a contact, but didn't know which one it was after you did so, because only the address was displayed). I'm not yet sure if it's optimal from a UX standpoint:
 ![capture](https://user-images.githubusercontent.com/1086065/34961858-581a8254-fa41-11e7-89ee-06184ebf8a07.PNG)
- Contacts & wallets can now be resolved without explicitly clicking on it in the dropdown (this only works if you type it 100% correctly, also it only works if the contact is non-ambiguous). Also while you're still typing the `Invalid Address` error is not shown if you're typing the name of a contact.
  ![resolve](https://user-images.githubusercontent.com/1086065/34961886-8546f3f2-fa41-11e7-97a7-a97da1009e99.gif)
  - If the contact is ambiguous for some reason (case insensitive!) an error is shown:
     ![ambiguous](https://user-images.githubusercontent.com/1086065/34961914-ac364c06-fa41-11e7-8a33-cbba60379132.gif)


Fixes: #520 