### PR TITLE
Fixes voting with second passphrase enabled

### DIFF
--- a/client/app/src/components/account/votes-tab/templates/vote.dialog.html
+++ b/client/app/src/components/account/votes-tab/templates/vote.dialog.html
@@ -26,7 +26,7 @@
         </md-input-container>
 
         <passphrase-field ng-if="!$dialog.account.ledger" ng-model="$dialog.passphrases.first" label="Passphrase"></passphrase-field>
-        <passphrase-field ng-if="$dialog.passphrases.second" ng-model="$dialog.passphrases.second" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="$dialog.passphrases.second || $dialog.hasSecondPassphrase" ng-model="$dialog.passphrases.second" label="Second Passphrase"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/components/account/votes-tab/vote.dialog.controller.js
+++ b/client/app/src/components/account/votes-tab/vote.dialog.controller.js
@@ -8,6 +8,7 @@
     this.activeDelegates = activeDelegates
     this.delegate = {}
     this.theme = currentTheme
+    this.hasSecondPassphrase = this.account.secondSignature
     this.passphrases = {
       first: passphrasesArr[0] ? passphrasesArr[0] : '',
       second: passphrasesArr[1] ? passphrasesArr[1] : ''


### PR DESCRIPTION
I wonder why does the  method `accountService.getPassphrases` even exist? It's a little confusing, because apparently it just get's the passphrase from the store, but we (hopefully) never store them anyway.

Ok just checked:
There are methods for saving the passphrases, but they are not used anymore.
Wonder if we should remove these methods altogether (in a separate PR maybe)


@perryhoffman Maybe you have any feedback on this, since you know this voting-area well ;)

fixes: #526 
fixes: #525 