### PR TITLE
Show error messages when a transaction fails

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1550,6 +1550,8 @@
         })
       }
 
+      const transactionLabel = accountService.getTransactionLabel(transaction)
+
       function send () {
         $mdDialog.hide()
 
@@ -1569,8 +1571,13 @@
               cb(transaction)
             }
           },
-          formatAndToastError
-        )
+         (error) => {
+           formatAndToastError({
+             message: gettextCatalog.getString('Failed to execute your \'{{ transactionLabel }}\' transaction!',
+                                               {transactionLabel: transactionLabel}),
+             error: error
+           })
+         })
       }
 
       $scope.validate = {
@@ -1578,7 +1585,7 @@
         send,
         cancel,
         transaction,
-        label: accountService.getTransactionLabel(transaction),
+        label: transactionLabel,
         // to avoid small transaction to be displayed as 1e-8
         humanAmount: utilityService.arktoshiToArk(transaction.amount),
         totalAmount: utilityService.arktoshiToArk(parseFloat(transaction.amount) + transaction.fee, true)

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -275,7 +275,7 @@
         } else {
           deferred.reject(resp.data)
         }
-      })
+      }, (error) => deferred.reject(error))
       return deferred.promise
     }
 


### PR DESCRIPTION
The error is only shown if the transaction to the peer fails.

If any further broadcasts fail we show nothing.
I wonder if we should do something in this case?
Log somewhere (console :P)

@doublehelix24 If you want you can test it and give feedback :)

fixes: #518