### PR TITLE
Improve Contact information

### DIFF
--- a/client/app/src/components/account/templates/main-sidenav.html
+++ b/client/app/src/components/account/templates/main-sidenav.html
@@ -35,7 +35,7 @@
     <span style="white-space: nowrap;">
       <md-icon md-font-library="material-icons">account_circle</md-icon>
       {{contact.name}}
-      <md-icon ng-if="$ctrl.ul.selected" style="pointer-events: auto" ng-click="" ng-mouseover="stats = $ctrl.ab.getStats($ctrl.ul.selected.address, contact.address)" aria-label="Stats" class="md-secondary" md-menu-align-target>
+      <md-icon ng-if="$ctrl.ul.selected && contact.address !== $ctrl.ul.selected.address" style="pointer-events: auto" ng-click="" ng-mouseover="stats = $ctrl.ab.getStats($ctrl.ul.selected.address, contact.address)" aria-label="Stats" class="md-secondary" md-menu-align-target>
         info_outline
         <md-tooltip md-direction="bottom" class="tooltip-multiline">
           {{'Income' | translate}}: {{$ctrl.ul.network.symbol}}{{stats.income.amount}} ({{stats.income.transactions}} {{'Transactions' | translate | lowercase}})


### PR DESCRIPTION
The commit fixes that the contact information icon is not shown if the selected account is the contact itself, since it was very confusing.

----


Also I'd like to start a small discussion to this:
![image](https://user-images.githubusercontent.com/1086065/35470440-ddc7ee94-0349-11e8-9374-df5760d54138.png)

I never really understood the information here. Actually I thought they were wrong and started to fix them before I realized what they are.
For those who don't know:
- Income
   - Transactions which were sent FROM the contact TO the currently selected account (in my case from `delphin` to `Delphin` (sorry for the similar names :P )
- Expense
  - Transactions which were sent TO the contact FROM the currently selected account (`Delphin` to `delphin`)

I wonder if it would help if we would just change:
- `Income` => `Received From`
- `Expense` => `Sent To`

Though I'm not sure if this would make it clearer?
Maybe we should add a dialog which display the information on-click (we could write clearer there what's the meaning of this all).
Or maybe I'm the only one who finds this confusing anyway?