### PR TITLE
Make screenshot protection configurable

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,6 +208,10 @@ function configureReload () {
   })
 }
 
+function shouldDisableScreenshotProtection (arugments) {
+  return arugments && arugments.some(v => v && typeof v === 'string' && v.toLowerCase() === '--disablescreenshotprotection')
+}
+
 app.setAsDefaultProtocolClient('ark', process.execPath, ['--'])
 
 // This method will be called when Electron has finished
@@ -219,6 +223,10 @@ app.on('ready', () => {
 
   if (process.env.LIVE_RELOAD) {
     configureReload()
+  }
+
+  if (shouldDisableScreenshotProtection(process.argv)) {
+    updateScreenshotProtectionItem()
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "cd client && npm install && npm run bundle && cd .. && electron-builder install-app-deps && npm run rebuild",
     "rebuild": "electron-rebuild --force --module_dir . -w node-hid ",
     "electron": "electron --version",
-    "start": "electron main.js",
+    "start": "electron main.js -- --disableScreenshotProtection",
     "live-reload": "cross-env LIVE_RELOAD=true electron main.js",
     "pack": "build --dir",
     "dist": "npm run dist:win && npm run dist:macos && npm run dist:linux && npm run dist:win32",


### PR DESCRIPTION
Find it a good input and it annoyed me anyhow that the protection was always enabled while developing, so I used this opportunity to disable it by default when developing.

Since having this disabled is a quite special / technical requirement, I did it via an argument which has to be passed to the client. This way no one can accidentally disable the screenshot protection on his machine.

Resolves: #540