### PR TITLE
Fix issues in translations

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -108,8 +108,8 @@
         const qrcodeElement = document.querySelector('ark-qrcode')
         const scheme = qrcodeElement.deserializeURI(uri)
 
-        if (!scheme) return toastService.error('Invalid URI')
-        if (scheme && !self.selected) return toastService.error('Select an account and open the URI again')
+        if (!scheme) return toastService.error(gettext('Invalid URI'))
+        if (scheme && !self.selected) return toastService.error(gettext('Select an account and open the URI again'))
         if (scheme && self.selected) return $scope.$broadcast('app:onURI', scheme)
       }, 0)
     })
@@ -193,7 +193,7 @@
     self.accounts = []
     self.selectAccount = selectAccount
     self.refreshCurrentAccount = refreshCurrentAccount
-    self.accountRefreshState = utilityService.createRefreshState('Account refreshed', 'Could not refresh account')
+    self.accountRefreshState = utilityService.createRefreshState(gettext('Account refreshed'), gettext('Could not refresh account'))
     self.gotoAddress = gotoAddress
     self.getAllDelegates = getAllDelegates
     self.addWatchOnlyAddress = addWatchOnlyAddress
@@ -317,10 +317,10 @@
         $timeout(() => {
           if (!self.connectedPeer.isConnected && self.isNetworkConnected) {
             self.isNetworkConnected = false
-            toastService.error('Network disconnected!')
+            toastService.error(gettext('Network disconnected!'))
           } else if (self.connectedPeer.isConnected && !self.isNetworkConnected) {
             self.isNetworkConnected = true
-            toastService.success('Network connected and healthy!')
+            toastService.success(gettext('Network connected and healthy!'))
           }
         }, 500)
       }
@@ -372,7 +372,7 @@
       } else if (typeof error.message === 'string') {
         basicMessage = error.message
       }
-      const errorMessage = gettextCatalog.getString('Error: ') + basicMessage.replace('Error: ', '')
+      const errorMessage = gettextCatalog.getString('Error:') + ' ' + basicMessage.replace('Error: ', '')
       console.error(errorMessage, '\n', error)
       return errorMessage
     }
@@ -380,23 +380,6 @@
     function formatAndToastError (error, hideDelay = 5000) {
       toastService.error(formatErrorMessage(error), hideDelay, true)
     }
-
-    // TODO: deprecated
-    // function showToast (msg, hideDelay, isError) {
-    //   if (!hideDelay) {
-    //     hideDelay = 5000
-    //   }
-
-    //   var toast = $mdToast.simple()
-    //     .hideDelay(hideDelay)
-    //     .textContent(gettextCatalog.getString(msg))
-
-    //   if (isError) {
-    //     toast.theme('error')
-    //   }
-
-    //   $mdToast.show(toast)
-    // }
 
     self.selectAllLanguages = function () {
       return languages
@@ -512,9 +495,9 @@
     }
 
     self.manageFolder = function (account, currentFolderName) {
-      const titleText = (!currentFolderName ? 'Create' : 'Rename') + ' Virtual Folder'
-      const buttonText = (!currentFolderName ? 'Add' : 'Save')
-      const confirmText = 'Virtual folder ' + (!currentFolderName ? 'added' : 'saved') + '!'
+      const titleText = !currentFolderName ? gettext('Create Virtual Folder') : gettext('Rename Virtual Folder')
+      const buttonText = !currentFolderName ? gettext('Add') : gettext('Save')
+      const confirmText = !currentFolderName ? gettext('Virtual folder added!') : gettext('Virtual folder saved!')
       const currentValue = (!currentFolderName ? null : currentFolderName)
       let confirm
 
@@ -525,7 +508,7 @@
           .textContent(gettextCatalog.getString('Please enter a folder name.'))
           .placeholder(gettextCatalog.getString('Folder name'))
           .initialValue(currentValue)
-          .ariaLabel(gettextCatalog.getString('Folder Name'))
+          .ariaLabel(gettextCatalog.getString('Folder name'))
           .ok(gettextCatalog.getString(buttonText))
           .cancel(gettextCatalog.getString('Cancel'))
         $mdDialog.show(confirm).then((foldername) => {
@@ -546,7 +529,7 @@
         confirm = $mdDialog.prompt()
           .title(gettextCatalog.getString('Login'))
           .theme(self.currentTheme)
-          .textContent(gettextCatalog.getString('Please enter this account passphrase to login.'))
+          .textContent(gettextCatalog.getString('Please enter the passphrase of this account to proceed.'))
           .placeholder(gettextCatalog.getString('passphrase'))
           .ariaLabel(gettextCatalog.getString('Passphrase'))
           .ok(gettextCatalog.getString('Login'))
@@ -554,9 +537,9 @@
         $mdDialog.show(confirm).then((passphrase) => {
           accountService.createVirtual(passphrase).then((virtual) => {
             account.virtual = virtual
-            toastService.success('Succesfully Logged In!', 3000)
+            toastService.success(gettext('Successfully logged in!'), 3000)
           }, (err) => {
-            toastService.success(gettextCatalog.getString('Error when trying to login: ') + err, 3000, true)
+            toastService.success(gettextCatalog.getString('Error when trying to login:') + ' ' + err, 3000, true)
           })
         })
       }
@@ -850,12 +833,12 @@
           accountService.fetchAccount(address).then((account) => {
             self.accounts.push(account)
             selectAccount(account)
-            toastService.success('Account added!', 3000)
+            toastService.success(gettext('Account added!'), 3000)
           })
           cancel()
         } else {
           toastService.error(
-            gettextCatalog.getString('Address') + ' ' + address + ' ' + gettextCatalog.getString('is not recognised'),
+            gettextCatalog.getString('Address \'{{ address }}\' is not recognized', {address: address}),
             3000,
             true
           )
@@ -1124,7 +1107,7 @@
 
           const readStream = fs.createReadStream(fileName)
           readStream.on('readable', () => {
-            toastService.success('Background Added Successfully!', 3000)
+            toastService.success(gettext('Background added successfully!'), 3000)
 
             const userImages = backgrounds['user']
             let url = fileName
@@ -1136,6 +1119,9 @@
           }).on('error', (error) => {
             toastService.error(`Error Adding Background (reading): ${error}`, 3000)
           })
+            .on('error', (error) => {
+              toastService.error(gettextCatalog.getString('Error adding background:') + ' ' + error, 3000)
+            })
         })
       }
 
@@ -1154,7 +1140,7 @@
           selectBackground(initialBackground)
         }
 
-        toastService.success('Background Removed Successfully!', 3000)
+        toastService.success(gettext('Background removed successfully!'), 3000)
       }
 
       function isImage (file) {
@@ -1272,7 +1258,7 @@
 
       function removeNetwork (network) {
         const confirm = $mdDialog.confirm()
-          .title(gettextCatalog.getString('Remove Network') + ' ' + network)
+          .title(gettextCatalog.getString('Remove network \'{{ network }}\'', {network: network}))
           .theme(self.currentTheme)
           .textContent(gettextCatalog.getString('Are you sure you want to remove this network and all data (accounts and settings) associated with it from your computer. Your accounts are still safe on the blockchain.'))
           .ok(gettextCatalog.getString('Remove from my computer all cached data from this network'))
@@ -1280,7 +1266,7 @@
         $mdDialog.show(confirm).then(() => {
           networkService.removeNetwork(network)
           self.listNetworks = networkService.getNetworks()
-          toastService.success('Network removed succesfully!', 3000)
+          toastService.success(gettext('Network removed succesfully!'), 3000)
         })
       }
 
@@ -1311,7 +1297,7 @@
         $mdDialog.hide()
         accountService.savePassphrases($scope.send.data.address, $scope.send.data.passphrase, $scope.send.data.secondpassphrase).then(
           (account) => {
-            toastService.success('Passphrases saved')
+            toastService.success(gettext('Passphrases saved'))
           },
           formatAndToastError
         )
@@ -1397,7 +1383,7 @@
             accountService.createAccount($scope.createAccountDialog.data.repassphrase).then((account) => {
               self.accounts.push(account)
               toastService.success(
-                gettextCatalog.getString('Account successfully created: ') + account.address,
+                gettextCatalog.getString('Account \'{{ address }}\' successfully created!', {address: account.address}),
                 null,
                 true
               )
@@ -1436,7 +1422,7 @@
 
         if (!$scope.send.data.customPassphrase && !isBIP39($scope.send.data.passphrase)) {
           toastService.error(
-            gettextCatalog.getString('Not valid BIP39 passphrase! Please check all words and spaces.')
+            gettextCatalog.getString('Not a valid BIP39 passphrase! Please check all words and spaces.')
             , null
             , true
           )
@@ -1450,7 +1436,8 @@
               for (let i = 0; i < self.accounts.length; i++) {
                 if (self.accounts[i].address === account.address) {
                   toastService.error(
-                    gettextCatalog.getString('Account was already imported: ') + account.address,
+                    gettextCatalog.getString('Account \'{{ address }}\' has already been imported!',
+                                             {address: account.address}),
                     null,
                     true
                   )
@@ -1460,7 +1447,8 @@
 
               self.accounts.push(account)
               toastService.success(
-                gettextCatalog.getString('Account successfully imported: ') + account.address,
+                gettextCatalog.getString('Account \'{{ address }}\' successfully imported!',
+                                         {address: account.address}),
                 null,
                 true
               )
@@ -1501,7 +1489,7 @@
 
       if (selectedAccount.secondSignature) {
         return formatAndToastError(
-          gettextCatalog.getString('This account already has a second passphrase: ' + selectedAccount.address)
+          gettextCatalog.getString('The account \'{{ address }}\' already has a second passphrase!', {address: selectedAccount.address})
         )
       }
 
@@ -1510,9 +1498,10 @@
           const secondPhraseArktoshiVal = fees['secondsignature']
           const secondPhraseArkVal = utilityService.arktoshiToArk(secondPhraseArktoshiVal, true)
           const confirm = $mdDialog.confirm({
-            title: gettextCatalog.getString('Second Passphrase') + ' ' + gettextCatalog.getString('Fee') + ' (' + networkService.getNetwork().symbol + ')',
+            title: gettextCatalog.getString('Second Passphrase fee ({{ currency }})', {currency: networkService.getNetwork().symbol}),
             secondPhraseArkVal: secondPhraseArkVal,
-            textContent: gettextCatalog.getString('WARNING! Second passphrase creation costs ' + secondPhraseArkVal + ' ' + networkService.getNetwork().token + '.'),
+            textContent: gettextCatalog.getString('WARNING! Second passphrase creation costs {{ cost }} {{ currency }}',
+                                                  {cost: secondPhraseArkVal, currency: networkService.getNetwork().token}),
             ok: gettextCatalog.getString('Continue'),
             cancel: gettextCatalog.getString('Cancel')
           })
@@ -1585,7 +1574,7 @@
               )
             } else {
               toastService.success(
-                gettextCatalog.getString('Transaction file successfully saved in') + ' ' + fileName,
+                gettextCatalog.getString('Transaction file successfully saved in \'{{ fileName }}\'.', {fileName: fileName}),
                 null,
                 true
               )
@@ -1604,7 +1593,7 @@
           (transaction) => {
             selectedAccount.transactions.unshift(transaction)
             toastService.success(
-              gettextCatalog.getString('Transaction') + ' ' + transaction.id + ' ' + gettextCatalog.getString('sent with success!'),
+              gettextCatalog.getString('Transaction \'{{ transactionId }}\' sent with success!', {transactionId: transaction.id}),
               null,
               true
             )

--- a/client/app/src/accounts/export-account.controller.js
+++ b/client/app/src/accounts/export-account.controller.js
@@ -11,13 +11,14 @@
       'toastService',
       'utilityService',
       'gettextCatalog',
+      'gettext',
       'account',
       'theme',
       'ARK_LAUNCH_DATE',
       ExportAccountController
     ])
 
-  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, utilityService, gettextCatalog, account, theme, ARK_LAUNCH_DATE) {
+  function ExportAccountController ($scope, $filter, $mdDialog, accountService, toastService, utilityService, gettextCatalog, gettext, account, theme, ARK_LAUNCH_DATE) {
     $scope.vm = {}
     $scope.vm.account = account
     $scope.vm.theme = theme
@@ -48,12 +49,12 @@
         prepareFile($scope.vm.account, transactions)
       }).catch(error => {
         if (error.transactions.length) {
-          toastService.error('An error occured when getting your transactions. However we still got ' + error.transactions.length + ' transactions! ' +
-                             'The exported file contains only these!',
+          toastService.error(gettextCatalog.getString('An error occured when getting your transactions. However we still got {{ count }} transactions! The exported file contains only these!',
+                                                      {count: error.transactions.length}),
           10000)
           prepareFile($scope.vm.account, error.transactions, true)
         } else {
-          toastService.error('An error occured when getting your transactions. Cannot export account!', 10000)
+          toastService.error(gettext('An error occured when getting your transactions. Cannot export account!'), 10000)
           $mdDialog.hide()
         }
       })

--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -40,7 +40,7 @@
       }
 
       if (ark.crypto.getAddress(transaction.senderPublicKey, networkService.getNetwork().version) !== config.fromAddress) {
-        deferred.reject(gettextCatalog.getString('Passphrase is not corresponding to account ') + config.fromAddress)
+        deferred.reject(gettextCatalog.getString('Passphrase is not corresponding to account \'{{ address }}\'', {address: config.fromAddress}))
         return
       }
 
@@ -59,12 +59,12 @@
     function createSendTransaction (config) {
       return prepareTransaction(config, (deferred, account, fees) => {
         if (!accountService.isValidAddress(config.toAddress)) {
-          deferred.reject(gettextCatalog.getString('The destination address ') + config.toAddress + gettextCatalog.getString(' is erroneous'))
+          deferred.reject(gettextCatalog.getString('The destination address \'{{ address }}\' is erroneous', {address: config.toAddress}))
           return
         }
 
         if (config.amount + fees.send > account.balance) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress)
+          deferred.reject(gettextCatalog.getString('Not enough {{ currency }} on your account \'{{ address }}\'!', {currency: networkService.getNetwork().token, address: config.fromAddress}))
           return
         }
 
@@ -94,12 +94,18 @@
           })
 
           if (invalidAddress) {
-            return reject(new Error(gettextCatalog.getString('The destination address ') + invalidAddress + gettextCatalog.getString(' is erroneous')))
+            return reject(new Error(gettextCatalog.getString('The destination address \'{{ address }}\' is erroneous', {address: invalidAddress})))
           }
 
           const total = transactions.reduce((total, t) => total + t.amount + fees.send, 0)
           if (total > account.balance) {
-            return reject(new Error(gettextCatalog.getString('Not enough ' + network.token + ' on your account ') + fromAddress))
+            return reject(new Error(gettextCatalog.getString(
+              'Not enough {{ currency }} on your account \'{{ address }}\' you need at least {{ amount }} to send your transactions!',
+            {
+              currency: network.token,
+              address: fromAddress,
+              amount: total
+            })))
           }
 
           const processed = Promise.all(
@@ -129,7 +135,7 @@
                   }, 2000 * i, true, transaction)
                 } else {
                   if (ark.crypto.getAddress(transaction.senderPublicKey, network.version) !== fromAddress) {
-                    return reject(new Error(gettextCatalog.getString('Passphrase is not corresponding to account ') + fromAddress))
+                    return reject(new Error(gettextCatalog.getString('Passphrase is not corresponding to account \'{{ address }}\'', {address: fromAddress})))
                   }
 
                   resolve(transaction)
@@ -148,8 +154,14 @@
     function createSecondPassphraseCreationTransaction (config) {
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.secondsignature) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                          ', ' + gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.secondsignature) + ' to create a second passphrase'))
+          deferred.reject(gettextCatalog.getString(
+              'Not enough {{ currency }} on your account \'{{ address }}\' you need at least {{ amount }} to create a second passphrase!',
+              {
+                currency: networkService.getNetwork().token,
+                address: config.fromAddress,
+                amount: arktoshiToArk(fees.secondsignature)
+              }
+          ))
           return
         }
 
@@ -163,8 +175,14 @@
     function createDelegateCreationTransaction (config) {
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.delegate) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress + ', ' +
-                          gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.delegate) + ' to register delegate'))
+          deferred.reject(gettextCatalog.getString(
+            'Not enough {{ currency }} on your account \'{{ address }}\' you need at least {{ amount }} to register delegate!',
+            {
+              currency: networkService.getNetwork().token,
+              address: config.fromAddress,
+              amount: arktoshiToArk(fees.delegate)
+            }
+          ))
           return
         }
 
@@ -178,8 +196,14 @@
     function createVoteTransaction (config) {
       return prepareTransaction(config, (deferred, account, fees) => {
         if (account.balance < fees.vote) {
-          deferred.reject(gettextCatalog.getString('Not enough ' + networkService.getNetwork().token + ' on your account ') + config.fromAddress +
-                           ', ' + gettextCatalog.getString('you need at least ' + arktoshiToArk(fees.vote) + ' to vote'))
+          deferred.reject(gettextCatalog.getString(
+            'Not enough {{ currency }} on your account \'{{ address }}\' you need at least {{ amount }} to vote!',
+            {
+              currency: networkService.getNetwork().token,
+              address: config.fromAddress,
+              amount: arktoshiToArk(fees.vote)
+            }
+          ))
           return
         }
 

--- a/client/app/src/accounts/view/createAccount.html
+++ b/client/app/src/accounts/view/createAccount.html
@@ -42,7 +42,7 @@
           <input ng-model="createAccountDialog.data.word9" type="text" ng-required="true" />
         </md-input-container>
         <div ng-if="createAccountDialog.data.showWrongRepassphrase">
-          <translate>The words does not match the original passphrase.</translate>
+          <translate>The words do not match the ones from the original passphrase.</translate>
         </div>
       </div>
     </md-dialog-content>

--- a/client/app/src/accounts/view/createDelegate.html
+++ b/client/app/src/accounts/view/createDelegate.html
@@ -24,8 +24,8 @@
           <label translate>Username</label>
           <input ng-model="createDelegate.data.username" type="text" ng-required="true" md-autofocus>
         </md-input-container>
-        <passphrase-field ng-if="!send.data.ledger" ng-model="createDelegate.data.passphrase" label="Passphrase"></passphrase-field>
-        <passphrase-field ng-if="createDelegate.data.secondSignature" ng-model="createDelegate.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!send.data.ledger" ng-model="createDelegate.data.passphrase" label="{{'Passphrase' | translate}}"></passphrase-field>
+        <passphrase-field ng-if="createDelegate.data.secondSignature" ng-model="createDelegate.data.secondpassphrase" label="{{'Second Passphrase' | translate}}"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/accounts/view/createSecondPassphrase.html
+++ b/client/app/src/accounts/view/createSecondPassphrase.html
@@ -15,9 +15,9 @@
           <md-card-title>
             <md-card-title-text>
               <span>
-                <translate>Please backup securely the second passphrase before continuing, this client does NOT store it and thus cannot recover your passphrase!</translate>
+                <translate>Please securely backup the second passphrase before continuing, this client does NOT store it and thus cannot recover your passphrase!</translate>
                 <br/>
-                <translate>After creating the second passphrase if you are having issues with forms (second passphrase field not showing up) please restart your client.</translate>
+                <translate>If you are having issues with forms (second passphrase field not showing up) after creating the second passphrase, please restart your client.</translate>
               </span>
             </md-card-title-text>
           </md-card-title>
@@ -25,8 +25,8 @@
         <div ng-if="createSecondPassphraseDialog.data.showRepassphrase" translate>
           Please paste the original and second passphrase to validate the creation.
         </div>
-        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.passphrase" label="Original Passphrase"></passphrase-field>
-        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.secondPassphrase" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.passphrase" label="{{'Original Passphrase' | translate}}"></passphrase-field>
+        <passphrase-field ng-if="createSecondPassphraseDialog.data.showRepassphrase" ng-model="createSecondPassphraseDialog.data.secondPassphrase" label="{{'Second Passphrase' | translate}}"></passphrase-field>
         <md-input-container class="md-block" ng-if="!createSecondPassphraseDialog.data.showRepassphrase">
             <label translate>Second Passphrase</label>
             <input ng-model="createSecondPassphraseDialog.data.secondPassphrase" type="text" readonly="readonly" md-autofocus />

--- a/client/app/src/accounts/view/exportAccount.html
+++ b/client/app/src/accounts/view/exportAccount.html
@@ -47,8 +47,7 @@
                 <md-card-title-text>
                   <span>
                     <translate>
-                      Select the timespan of the transactions which should be included when you export your account.
-                      Note that it can take quite a while if you choose a wide or old date range!
+                      Select the timespan of the transactions which should be included when you export your account. Note that it can take quite a while if you choose a wide or old date range!
                     </translate>
                   </span>
                 </md-card-title-text>

--- a/client/app/src/accounts/view/importAccount.html
+++ b/client/app/src/accounts/view/importAccount.html
@@ -19,7 +19,7 @@
           </md-card-title-text>
         </md-card-title>
       </md-card>
-      <passphrase-field ng-model="send.data.passphrase" label="Passphrase" auto-focus="true"></passphrase-field>
+      <passphrase-field ng-model="send.data.passphrase" label="{{'Passphrase' | translate}}" auto-focus="true"></passphrase-field>
       <div layout="row" flex style="margin-top: -20px;">
         <md-switch ng-model="send.data.customPassphrase" aria-label="Use a custom (non-BIP39) passphrase" class="md-primary" md-no-ink style="margin: 4px 0;">
           <translate>Use a custom (non-BIP39) passphrase</translate>

--- a/client/app/src/accounts/view/signMessage.html
+++ b/client/app/src/accounts/view/signMessage.html
@@ -15,7 +15,7 @@
           <label translate>Address</label>
           <input ng-model="sign.selectedAccount.address" ng-disabled="true" ng-required="true" type="text">
         </md-input-container>
-        <passphrase-field ng-if="!sign.selectedAccount.ledger" ng-model="sign.passphrase" label="Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!sign.selectedAccount.ledger" ng-model="sign.passphrase" label="{{'Passphrase' | translate}}"></passphrase-field>
         <md-input-container class="md-block">
           <label translate>Message</label>
           <input ng-model="sign.message" ng-required="true" type="text">

--- a/client/app/src/accounts/view/timestampDocument.html
+++ b/client/app/src/accounts/view/timestampDocument.html
@@ -36,8 +36,8 @@
         <md-input-container md-no-float class="md-block">
           <span><b translate>SHA256 Signature</b> {{send.data.smartbridge}}</span>
         </md-input-container>
-        <passphrase-field ng-if="!send.data.ledger" ng-model="send.data.passphrase" label="Passphrase"></passphrase-field>
-        <passphrase-field ng-if="!send.data.ledger && send.data.secondSignature" ng-model="send.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!send.data.ledger" ng-model="send.data.passphrase" label="{{'Passphrase' | translate}}"></passphrase-field>
+        <passphrase-field ng-if="!send.data.ledger && send.data.secondSignature" ng-model="send.data.secondpassphrase" label="{{'Second Passphrase' | translate}}"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row" style="padding-left: 20px">

--- a/client/app/src/accounts/view/vote.html
+++ b/client/app/src/accounts/view/vote.html
@@ -15,8 +15,8 @@
         <md-chips ng-model="voteDialog.data.votes" readonly="true">
           <md-chip-template>{{$chip.vote}}{{$chip.username}}</md-chip-template>
         </md-chips>
-        <passphrase-field ng-if="!voteDialog.data.ledger" ng-model="voteDialog.data.passphrase" label="Passphrase"></passphrase-field>
-        <passphrase-field ng-if="voteDialog.data.secondSignature" ng-model="voteDialog.data.secondpassphrase" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!voteDialog.data.ledger" ng-model="voteDialog.data.passphrase" label="{{'Passphrase' | translate}}"></passphrase-field>
+        <passphrase-field ng-if="voteDialog.data.secondSignature" ng-model="voteDialog.data.secondpassphrase" label="{{'Second Passphrase' | translate}}"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/components/account/account-card.controller.js
+++ b/client/app/src/components/account/account-card.controller.js
@@ -14,10 +14,10 @@
         accountCtrl: '=',
         addressBookCtrl: '='
       },
-      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'accountService', 'toastService', 'transactionSenderService', 'utilityService', '$timeout', AccountCardController]
+      controller: ['$scope', '$mdDialog', '$mdBottomSheet', 'gettextCatalog', 'gettext', 'accountService', 'toastService', 'transactionSenderService', 'utilityService', '$timeout', AccountCardController]
     })
 
-  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, accountService, toastService, transactionSender, utilityService, $timeout) {
+  function AccountCardController ($scope, $mdDialog, $mdBottomSheet, gettextCatalog, gettext, accountService, toastService, transactionSender, utilityService, $timeout) {
     let getCurrentAccount = () => null
 
     $scope.$on('app:onURI', (event, scheme) => {
@@ -36,23 +36,23 @@
       const items = []
       const add = (text, icon) => items.push({ name: gettextCatalog.getString(text), icon })
 
-      add('Open in explorer', 'open_in_new')
+      add(gettext('Open in explorer'), 'open_in_new')
 
       if (!account.ledger) {
-        add('Remove', 'clear')
+        add(gettext('Remove'), 'clear')
       }
       if (!account.delegate) {
-        add('Label', 'local_offer')
+        add(gettext('Label'), 'local_offer')
 
         if (!account.ledger) {
-          add('Register Delegate', 'perm_identity')
+          add(gettext('Register Delegate'), 'perm_identity')
         }
       }
 
-      add('Timestamp Document', 'verified_user')
+      add(gettext('Timestamp Document'), 'verified_user')
 
       if (!account.secondSignature && !account.ledger) {
-        add('Second Passphrase', 'lock')
+        add(gettext('Second Passphrase'), 'lock')
       }
 
       return items
@@ -60,7 +60,7 @@
 
     this.confirmRemoval = account => {
       const confirm = $mdDialog.confirm({
-        title: gettextCatalog.getString('Remove Account') + ' ' + account.address,
+        title: gettextCatalog.getString('Remove Account \'{{ address }}\'', {address: account.address}),
         ariaLabel: gettextCatalog.getString('Remove Account'),
         theme: this.accountCtrl.currentTheme,
         textContent: gettextCatalog.getString('Remove this account from your wallet. ' +
@@ -79,7 +79,7 @@
             this.accountCtrl.selected = null
           }
 
-          toastService.success('Account removed!', 3000)
+          toastService.success(gettext('Account removed!'), 3000)
         })
       })
     }
@@ -102,7 +102,7 @@
       return $mdDialog.show(prompt).then(label => {
         accountService.setUsername(account.address, label)
         this.accountCtrl.accounts = accountService.loadAllAccounts()
-        toastService.success('Label set', 3000)
+        toastService.success(gettext('Label set'), 3000)
       })
     }
 

--- a/client/app/src/components/account/templates/exchange-tab.html
+++ b/client/app/src/components/account/templates/exchange-tab.html
@@ -3,6 +3,6 @@
     <translate>Exchange</translate>
   </md-tab-label>
   <md-tab-body>
-    <empty-state header="Coming soon"></empty-state>
+    <empty-state header="{{'Coming soon' | translate}}"></empty-state>
   </md-tab-body>
 </md-tab>

--- a/client/app/src/components/account/templates/offchain-tab.html
+++ b/client/app/src/components/account/templates/offchain-tab.html
@@ -15,7 +15,7 @@
             </md-card-title-media>
             <md-card-title-text>
               <translate>
-                If you own this account, you can enable virtual folders. Virtual Folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br> Moreover, this account will move under
+                If you own this account, you can enable virtual folders. Virtual folders are simple subaccounts to better organise your money, without needing to send a real transaction and pay a fee. <br> Moreover, this account will move under
                 the "My Accounts" list.
               </translate>
               <md-button ng-click="$ctrl.ul.manageFolder($ctrl.ul.selected)">
@@ -72,7 +72,9 @@
     </md-list>
 
     <md-content ng-if="$ctrl.ul.selected.virtual && !$ctrl.ul.selected.virtual.getFolders().length">
-        <empty-state header="This address does not have any virtual folders" content="Virtual folders for this account will appear here."></empty-state>
+        <empty-state header="{{'This address does not have any virtual folders' | translate}}"
+                     content="{{'Virtual folders for this account will appear here.' | translate}}'">
+        </empty-state>
     </md-content>
   </md-tab-body>
 </md-tab>

--- a/client/app/src/components/account/templates/send-transaction-dialog.html
+++ b/client/app/src/components/account/templates/send-transaction-dialog.html
@@ -1,6 +1,6 @@
 <md-dialog aria-label="{{'Send'|translate}} {{network.token}}" ng-cloak md-theme="ac.currentTheme">
-  <md-toolbar>
-    <div class="md-toolbar-tools">
+    <md-toolbar>
+      <div class="md-toolbar-tools">
       <h2 ng-if="data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromLabel}} ({{data.fromAddress}})</h2>
       <h2 ng-if="! data.fromLabel"><span>{{'Send'|translate}} {{network.token}} {{'from'|translate}}</span>&nbsp;{{data.fromAddress}}</h2>
 
@@ -46,8 +46,8 @@
                                md-autofocus="true"
                                ng-attr-md-floating-label="{{'Type an address or a name'|translate}}"
                                ng-blur="onAddressFieldBlur()">
-                <md-item-template>
-                  <span class="item-title">
+            <md-item-template>
+              <span class="item-title">
                       <md-icon md-font-library="material-icons">
                         {{contact.icon}}
                         <md-tooltip>
@@ -56,39 +56,39 @@
                       </md-icon>
                       <span ng-if="contact.name"> {{contact.name}} -</span>
                       <span>{{contact.address}}</span>
-                  </span>
-                </md-item-template>
-              </md-autocomplete>
-            </div>
+              </span>
+            </md-item-template>
+          </md-autocomplete>
+        </div>
 
-            <div layout="row" flex layout-align="start center" ng-if="receiverValidation.failType">
-              <md-icon flex="5" md-font-library="material-icons">{{receiverValidation.failType}}</md-icon>
-              <div flex="95">{{receiverValidation.message}}</div>
-            </div>
+        <div layout="row" flex layout-align="start center" ng-if="receiverValidation.failType">
+          <md-icon flex="5" md-font-library="material-icons">{{receiverValidation.failType}}</md-icon>
+          <div flex="95">{{receiverValidation.message}}</div>
+        </div>
 
-            <div layout="row" layout-align="space-between start">
-              <md-input-container class="md-block" style="width: 100%">
+        <div layout="row" layout-align="space-between start">
+          <md-input-container class="md-block" style="width: 100%">
                 <label>{{'Amount'|translate}} ({{network.token}})</label>
                 <input style="width: 100%" ng-model="data.amount" type="number" step="0.00000001" min="0.00000001" max="100000000000000" valid-amount autocomplete="off" ng-required="true" tabIndex="2">
-                <div class="hint">
+            <div class="hint">
                   {{ac.currency.symbol}} {{data.amount | amountToCurrency:this}}
-                </div>
-              </md-input-container>
-
-              <md-input-container class="md-block">
-                <md-button ng-click="fillSendableBalance()" class="md-primary">
-                  <translate>Send All</translate>
-                </md-button>
-              </md-input-container>
             </div>
+          </md-input-container>
 
-            <md-input-container md-no-float class="md-block">
+          <md-input-container class="md-block">
+                <md-button ng-click="fillSendableBalance()" class="md-primary">
+              <translate>Send All</translate>
+            </md-button>
+          </md-input-container>
+        </div>
+
+        <md-input-container md-no-float class="md-block">
               <label>{{'Smartbridge or message'|translate}} ({{'Optional'|translate}})</label>
               <input ng-model="data.smartbridge" type="text" ng-required="false" maxlength="64" tabIndex="3">
-            </md-input-container>
+        </md-input-container>
 
-            <passphrase-field ng-if="!data.ledger" ng-model="data.passphrase" label="Passphrase" tab-index="4"></passphrase-field>
-            <passphrase-field ng-if="data.secondSignature"ng-model="data.secondPassphrase" label="Second Passphrase" tab-index="5"></passphrase-field>
+            <passphrase-field ng-if="!data.ledger" ng-model="data.passphrase" label="{{'Passphrase' | translate}}" tab-index="4"></passphrase-field>
+            <passphrase-field ng-if="data.secondSignature"ng-model="data.secondPassphrase" label="{{'Second Passphrase' | translate}}" tab-index="5"></passphrase-field>
 
           </form>
         </md-tab-body>
@@ -118,25 +118,25 @@
               <input ng-model="data.file" ng-click="selectFile()" type="text" ng-required="true" maxlength="64" tabIndex="1">
             </md-input-container>
 
-            <passphrase-field ng-if="!data.ledger" ng-model="data.passphrase" label="Passphrase" tab-index="2"></passphrase-field>
-            <passphrase-field ng-if="data.secondSignature"ng-model="data.secondPassphrase" label="Second Passphrase" tab-index="3"></passphrase-field>
+            <passphrase-field ng-if="!data.ledger" ng-model="data.passphrase" label="{{'Passphrase' | translate}}" tab-index="2"></passphrase-field>
+            <passphrase-field ng-if="data.secondSignature"ng-model="data.secondPassphrase" label="{{'Second Passphrase' | translate}}" tab-index="3"></passphrase-field>
 
           </form>
         </md-tab-body>
       </md-tab>
     </md-tabs>
 
-  </md-dialog-content>
+    </md-dialog-content>
 
-  <md-dialog-actions layout="row" style="padding-left: 20px">
+    <md-dialog-actions layout="row" style="padding-left: 20px">
 
-    <div class="remaining-balance">
-      <div class="md-caption">
-        <translate>Remaining balance</translate>
-      </div>
+      <div class="remaining-balance">
+        <div class="md-caption">
+          <translate>Remaining balance</translate>
+        </div>
       <div class="balance">{{network.symbol}} {{ remainingBalance }}</div>
-    </div>
-    <span flex></span>
+      </div>
+      <span flex></span>
 
     <md-button type="submit"
                ng-click="submit(tab)"
@@ -144,11 +144,11 @@
                tabIndex="6">
       <translate ng-if="!data.ledger">Next</translate>
       <translate ng-if="data.ledger">Sign with Ledger</translate>
-    </md-button>
+      </md-button>
 
     <md-button ng-click="cancel()" style="margin-right:20px;" tabIndex="7">
-      <translate>Cancel</translate>
-    </md-button>
+        <translate>Cancel</translate>
+      </md-button>
 
-  </md-dialog-actions>
+    </md-dialog-actions>
 </md-dialog>

--- a/client/app/src/components/account/templates/signing-tab.html
+++ b/client/app/src/components/account/templates/signing-tab.html
@@ -74,8 +74,10 @@
       </md-table-container>
     </md-content>
 
-    <md-content ng-if="!$ctrl.ul.selected.publicKey" class="tab-text-only-content" translate>
-      <empty-state header="This address has not received any ARK" content="Until it has, it is not on the ARK blockchain and can not be used for signing messages."></empty-state>
+    <md-content ng-if="!$ctrl.ul.selected.publicKey" class="tab-text-only-content">
+      <empty-state header="{{'This address has not received any ARK' | translate}}"
+                   content="{{'Until it has, it is not on the ARK blockchain and can not be used for signing messages.' | translate}}">
+      </empty-state>
     </md-content>
 
   </md-tab-body>

--- a/client/app/src/components/account/templates/transaction-tab.html
+++ b/client/app/src/components/account/templates/transaction-tab.html
@@ -22,7 +22,9 @@
       <tbody md-body style="white-space:nowrap;" infinite-scroll="$ctrl.transactionsCtrl.loadNext()" infinite-scroll-disabled='$ctrl.transactionsCtrl.isBusy' infinite-scroll-container='".tx-list-container"'>
         <tr md-row disabled ng-if="!$ctrl.transactionsCtrl.transactions.length">
           <td md-cell colspan="7">
-            <empty-state header="This account does not have any transactions" content="All transactions associated to this account will appear here."></empty-state>
+            <empty-state header="{{'This account does not have any transactions' | translate}}"
+                         content="{{'All transactions associated to this account will appear here.' | translate}}">
+            </empty-state>
           </td>
         </tr>
         <tr md-row md-select="transaction" md-select-id="id" md-auto-select ng-repeat="it in $ctrl.transactionsCtrl.transactions | orderBy: query.order | limitTo: $ctrl.transactionsCtrl.pageSize track by it.id">

--- a/client/app/src/components/account/votes-tab/templates/vote.dialog.html
+++ b/client/app/src/components/account/votes-tab/templates/vote.dialog.html
@@ -25,8 +25,8 @@
           <input ng-disabled="$dialog.delegateToUnvote" ng-model="$dialog.delegate.name" type="text">
         </md-input-container>
 
-        <passphrase-field ng-if="!$dialog.account.ledger" ng-model="$dialog.passphrases.first" label="Passphrase"></passphrase-field>
-        <passphrase-field ng-if="$dialog.passphrases.second || $dialog.hasSecondPassphrase" ng-model="$dialog.passphrases.second" label="Second Passphrase"></passphrase-field>
+        <passphrase-field ng-if="!$dialog.account.ledger" ng-model="$dialog.passphrases.first" label="{{'Passphrase' | translate}}"></passphrase-field>
+        <passphrase-field ng-if="$dialog.passphrases.second || $dialog.hasSecondPassphrase" ng-model="$dialog.passphrases.second" label="{{'Second Passphrase' | translate}}"></passphrase-field>
       </div>
     </md-dialog-content>
     <md-dialog-actions layout="row">

--- a/client/app/src/components/account/votes-tab/templates/votes-tab.html
+++ b/client/app/src/components/account/votes-tab/templates/votes-tab.html
@@ -105,16 +105,21 @@
           </tr>
           <tr md-row disabled ng-if="!$ctrl.getDelegateList($ctrl.account).length">
               <td md-cell colspan="7">
-                <empty-state header="This account does not have any selected delegates" content="Once a delegate is selected for this account, it will appear here."></empty-state>
+                <empty-state header="{{'This account does not have any selected delegates' | translate}}"
+                             content="{{'Once a delegate is selected for this account, it will appear here.' | translate}}">
+                </empty-state>
               </td>
             </tr>
         </tbody>
       </table>
     </md-table-container>
 
-    <md-content id="vote-help" translate>
-      Voting is an optional, but important mechanism that keeps the Ark network secure. The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks. This page can be used to cast your vote for
-      a delegate that you support. Learn more about voting for a delegate on the <a href="#" ng-click="$ctrl.openBlog('/how-to-vote-or-un-vote-an-ark-delegate-and-how-does-it-all-work-819c5439da68')">ARK blog</a>.
+    <md-content id="vote-help">
+      <translate>
+        Voting is an optional, but important mechanism that keeps the Ark network secure. The 51 delegates with the most votes from the network are responsible for verifying and forging transactions into new blocks. This page can be used to cast your vote for
+        a delegate that you support. Learn more about voting for a delegate by clicking on the following link.
+      </translate>
+      <a href="#" ng-click="$ctrl.openBlog('/how-to-vote-or-un-vote-an-ark-delegate-and-how-does-it-all-work-819c5439da68')" translate>ARK blog</a>.
     </md-content>
 
   </md-tab-body>

--- a/client/app/src/components/account/votes-tab/vote.dialog.controller.js
+++ b/client/app/src/components/account/votes-tab/vote.dialog.controller.js
@@ -2,7 +2,7 @@
   'use strict'
 
   const MAXIMUM_VOTE_CNT = 101
-  let VoteDialogController = function VoteDialogController ($mdDialog, accountService, toastService, accountObj, delegateToUnvote, passphrasesArr, activeDelegates, currentTheme) {
+  let VoteDialogController = function VoteDialogController ($mdDialog, accountService, toastService, gettext, accountObj, delegateToUnvote, passphrasesArr, activeDelegates, currentTheme) {
     this.account = accountObj
     this.delegateToUnvote = delegateToUnvote
     this.activeDelegates = activeDelegates
@@ -34,7 +34,7 @@
         if (this.delegateToUnvote || (this.account.selectedVotes.length < MAXIMUM_VOTE_CNT && !this.delegateExists(this.account.selectedVotes, delegateObj))) {
           $mdDialog.hide({ new_delegate: delegateObj, passphrases: this.passphrases })
         } else {
-          toastService.error('List full or delegate already voted.')
+          toastService.error(gettext('Either you have already used all your votes or you have already voted for this delegate.'))
         }
       }).catch(err => {
         // TODO refactor formatErrorMessage into service

--- a/client/app/src/components/account/votes-tab/votes-tab.controller.js
+++ b/client/app/src/components/account/votes-tab/votes-tab.controller.js
@@ -1,7 +1,7 @@
 ;(function () {
   'use strict'
 
-  let VotesTabController = function VotesTabController ($scope, $mdDialog, accountService, transactionBuilderService, networkService, toastService, TRANSACTION_TYPES) {
+  let VotesTabController = function VotesTabController ($scope, $mdDialog, accountService, transactionBuilderService, networkService, toastService, gettext, TRANSACTION_TYPES) {
     this.accountAddress = ''
     this.delegates = []
     this.network = networkService.getNetwork()
@@ -39,7 +39,7 @@
               .getActiveDelegates()
               .then(delegates => delegates)
               .catch(() => {
-                toastService.error('Could not fetch active delegates - please check your internet connection')
+                toastService.error(gettext('Could not fetch active delegates - please check your internet connection'))
               })
           },
           currentTheme: () => this.theme

--- a/client/app/src/components/addressbook/addressbook.controller.js
+++ b/client/app/src/components/addressbook/addressbook.controller.js
@@ -3,9 +3,9 @@
 
   angular
     .module('arkclient.components')
-    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'accountService', 'utilityService', AddressbookController])
+    .controller('AddressbookController', ['$scope', '$mdDialog', 'toastService', 'storageService', 'gettextCatalog', 'gettext', 'accountService', 'utilityService', AddressbookController])
 
-  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, accountService, utilityService) {
+  function AddressbookController ($scope, $mdDialog, toastService, storageService, gettextCatalog, gettext, accountService, utilityService) {
     const self = this
     // var contacts
     self.trim = function (str) {
@@ -45,16 +45,16 @@
       return existsIn(self.contacts.map(c => c.name), name)
     }
 
-    self.showToast = function (message, variable, error) {
+    self.showToast = function (message, variable, error, stringParams) {
       if (error) {
         toastService.error(
-          gettextCatalog.getString(message) + (variable ? ' - ' + variable : ''),
+          gettextCatalog.getString(message, stringParams) + (variable ? ' - ' + variable : ''),
           null,
           true
         )
       } else {
         toastService.success(
-          gettextCatalog.getString(message) + (variable ? ' - ' + variable : ''),
+          gettextCatalog.getString(message, stringParams) + (variable ? ' - ' + variable : ''),
           null,
           true
         )
@@ -74,21 +74,21 @@
       function add (name, address) {
         self.getContacts()
         if (self.trim(name) === '') {
-          self.showToast('This Contact Name is not valid', name, true)
+          self.showToast(gettext('This contact name is not valid'), name, true)
           return
         }
         if (self.trim(address) === '' || !self.isAddress(address)) {
-          self.showToast('This Contact Address is not valid', address, true)
+          self.showToast(gettext('The address of this contact is not valid'), address, true)
           return
         }
 
         const newContact = { name: name, address: address }
         if (self.addressExists(address)) {
-          self.showToast('A Contact with this Address already exists', address, true)
+          self.showToast(gettext('A contact with this address already exists'), address, true)
           return
         }
         if (self.contactExists(name)) {
-          self.showToast('A Contact with this Name already exists', name, true)
+          self.showToast(gettext('A contact with this name already exists'), name, true)
           return
         }
 
@@ -100,17 +100,17 @@
         }, [])
 
         if (existsIn(knownAccounts.map(a => a.address), address)) {
-          self.showToast('This Address is already taken, please add a different one', address, true)
+          self.showToast(gettext('This address is already used by another contact or account'), address, true)
           return
         }
         if (existsIn(knownAccounts.map(a => a.username), name)) {
-          self.showToast('This Name is already taken, please use a different one', name, true)
+          self.showToast(gettext('This name is already used by another contact or account'), name, true)
           return
         }
 
         self.contacts.push(newContact)
         self.save()
-        self.showToast(`Contact '${name}' with address '${address}' added successfully`)
+        self.showToast(gettext('Contact \'{{ name }}\' with address \'{{ address }}\' added successfully'), null, false, {name: name, address: address})
         if (successCallback) {
           successCallback()
         }
@@ -130,7 +130,7 @@
     self.editAddressbookContact = function (address) {
       const contact = self.getContactFromAddress(address)
       if (!contact) {
-        self.showToast('This address is not a contact', address, true)
+        self.showToast(gettext('This address is not a contact'), address, true)
         return
       }
       const name = contact.name
@@ -149,20 +149,20 @@
 
       function save (name, address) {
         if (self.trim(name) === '') {
-          self.showToast('this Contact Name is not valid', name, true)
+          self.showToast(gettext('This contact name is not valid'), name, true)
           return
         }
         if (self.trim(address) === '') {
-          self.showToast('this Contact Address is not valid', address, true)
+          self.showToast(gettext('The address of this contact is not valid'), address, true)
           return
         }
         self.getContacts()
         if (!self.contactExists(name)) {
-          self.showToast('this Contact Name doesnt exist', name, true)
+          self.showToast(gettext('A contact with this name doesn\'t exist'), name, true)
           return
         }
         if (!self.isAddress(address)) {
-          self.showToast('this seems to be not a valid Address', address, true)
+          self.showToast(gettext('The address of this contact is not valid'), address, true)
           return
         }
         for (let i = 0; i < self.contacts.length; i++) {
@@ -171,14 +171,14 @@
           }
         }
         self.save()
-        self.showToast(`Contact '${name}' with address '${address}' saved successfully`)
+        self.showToast(gettext('Contact \'{{ name }}\' with address \'{{ address }}\' saved successfully'), null, false, {name: name, address: address})
         cancel()
       }
 
       function remove (name) {
         self.getContacts()
         if (!self.contactExists(name)) {
-          self.showToast('this Contact-Name doesnt exist: ', name, true)
+          self.showToast(gettext('A contact with this name doesn\'t exist'), name, true)
           return
         }
         for (let i = 0; i < self.contacts.length; i++) {
@@ -188,7 +188,7 @@
           }
         }
         self.save()
-        self.showToast('Contact successfully removed', name, false)
+        self.showToast(gettext('Contact successfully removed'), name, false)
         cancel()
       }
 

--- a/client/app/src/components/dashboard/account-box.controller.js
+++ b/client/app/src/components/dashboard/account-box.controller.js
@@ -13,29 +13,29 @@
         accountCtrl: '=',
         addressbookCtrl: '='
       },
-      controller: ['$scope', 'networkService', 'accountService', 'utilityService', 'gettextCatalog', 'toastService', '$timeout', AccountBoxController]
+      controller: ['$scope', 'networkService', 'accountService', 'utilityService', 'gettextCatalog', 'gettext', 'toastService', '$timeout', AccountBoxController]
     })
 
-  function AccountBoxController ($scope, networkService, accountService, utilityService, gettextCatalog, toastService, $timeout) {
+  function AccountBoxController ($scope, networkService, accountService, utilityService, gettextCatalog, gettext, toastService, $timeout) {
     this.$onInit = () => {
       // Alias that is used on the template
       this.ac = this.accountCtrl
 
-      this.myAccountsType = this.createAccountType('My Accounts',
+      this.myAccountsType = this.createAccountType(gettext('My Accounts'),
                                                    this.ac.myAccounts,
                                                    this.ac.getAllAccounts,
-                                                   utilityService.createRefreshState('Accounts refreshed', 'Could not refresh accounts'),
+                                                   utilityService.createRefreshState(gettext('Accounts refreshed'), gettext('Could not refresh accounts')),
                                                    this.ac.createAccount,
-                                                   'Create Account',
+                                                   gettext('Create Account'),
                                                    this.ac.importAccount,
-                                                   'Import Account')
+                                                   gettext('Import Account'))
 
-      this.contactsType = this.createAccountType('Contacts',
+      this.contactsType = this.createAccountType(gettext('Contacts'),
                                                  this.addressbookCtrl.getContacts,
                                                  this.addressbookCtrl.getContacts,
-                                                 utilityService.createRefreshState('Contacts refreshed', 'Could not refresh contacts'),
+                                                 utilityService.createRefreshState(gettext('Contacts refreshed'), gettext('Could not refresh contacts')),
                                                  () => this.addressbookCtrl.addAddressbookContact(() => this.refreshAccounts()),
-                                                 'Add Contact')
+                                                 gettext('Add Contact'))
 
       if (this.myAccountsType.getAccountsToRefresh().length || !this.contactsType.getAccountsToRefresh().length) {
         this.selectedAccountType = this.myAccountsType

--- a/client/app/src/components/dashboard/dashboard.controller.js
+++ b/client/app/src/components/dashboard/dashboard.controller.js
@@ -10,11 +10,11 @@
         addressbookCtrl: '='
       },
       controller: [
-        '$scope', '$mdToast', 'toastService', 'feedService', 'storageService', DashboardController
+        '$scope', '$mdToast', 'toastService', 'gettext', 'feedService', 'storageService', DashboardController
       ]
     })
 
-  function DashboardController ($scope, $mdToast, toastService, feedService, storageService) {
+  function DashboardController ($scope, $mdToast, toastService, gettext, feedService, storageService) {
     this.$onInit = () => {
       setTimeout(() => this.showAnnouncements(), 1000)
     }
@@ -45,7 +45,7 @@
             })
           }
         })
-        .catch(_ => toastService.error('Error loading the announcements.', 3000))
+        .catch(_ => toastService.error(gettext('Error loading the announcements.'), 3000))
     }
   }
 })()

--- a/client/app/src/components/emptystate/empty-state.controller.js
+++ b/client/app/src/components/emptystate/empty-state.controller.js
@@ -10,14 +10,14 @@
         header: '@?',
         content: '@?'
       },
-      controller: EmptyStateController,
+      controller: ['gettextCatalog', EmptyStateController],
       controllerAs: '$es'
     })
 
-  function EmptyStateController ($scope) {
+  function EmptyStateController ($scope, gettextCatalog) {
     this.$onInit = () => {
       this.imgSrc = this.imgSrc || 'assets/images/logo/white.png'
-      this.header = this.header || 'No data found'
+      this.header = this.header || gettextCatalog.getString('No data found')
     }
   }
 })()

--- a/client/app/src/components/passphrase-field/passphrase-field.html
+++ b/client/app/src/components/passphrase-field/passphrase-field.html
@@ -3,7 +3,7 @@
     <qr-scanner input-callback-func="$pwc.onQrCodeScanned(qr)"></qr-scanner>
   </md-input-container>
   <md-input-container class="md-block" flex="95">
-    <label ng-if="$pwc.label" translate ng-class="{'md-required': !$pwc.isOptional}">
+    <label ng-if="$pwc.label" ng-class="{'md-required': !$pwc.isOptional}">
       {{$pwc.label}}
     </label>
     <input type="password"

--- a/client/app/src/components/qr-scanner/qr-scanner.directive.js
+++ b/client/app/src/components/qr-scanner/qr-scanner.directive.js
@@ -1,9 +1,9 @@
 ;(function () {
   'use strict'
 
-  angular.module('arkclient.components').directive('qrScanner', ['$rootScope', '$timeout', '$mdDialog', 'toastService', qrScanner])
+  angular.module('arkclient.components').directive('qrScanner', ['$rootScope', '$timeout', '$mdDialog', 'toastService', 'gettextCatalog', qrScanner])
 
-  function qrScanner ($rootScope, $timeout, $mdDialog, toastService) {
+  function qrScanner ($rootScope, $timeout, $mdDialog, toastService, gettextCatalog) {
     function controller ($scope) {
       $scope.hasWebcam = function () {
         navigator.mediaDevices.enumerateDevices()
@@ -18,7 +18,8 @@
 
       $scope.onSuccess = function (result) {
         if (typeof (result.type) !== 'undefined') {
-          toastService.success(`The ${result.type} ${result.qr} has been successfully scanned.`)
+          toastService.success(gettextCatalog.getString('The {{ qrCodeType }} {{ qrCode }} has been successfully scanned.',
+                                                        {qrCodeType: result.type, qrCode: result.qr}))
         }
 
         if ($scope.inputCallback) {

--- a/client/app/src/directives/copy-to-clipboard.directive.js
+++ b/client/app/src/directives/copy-to-clipboard.directive.js
@@ -2,7 +2,7 @@
   'use strict'
 
   angular.module('arkclient.directives')
-    .directive('copyToClipboard', ['toastService', '$window', function (toastService, $window) {
+    .directive('copyToClipboard', ['toastService', 'gettext', '$window', function (toastService, gettext, $window) {
       const body = angular.element($window.document.body)
       const textarea = angular.element('<textarea/>')
       textarea.css({
@@ -19,10 +19,10 @@
           const successful = document.execCommand('copy')
           if (!successful) throw successful
           else {
-            toastService.success('Copied to clipboard', 3000)
+            toastService.success(gettext('Copied to clipboard'), 3000)
           }
         } catch (err) {
-          toastService.error('Failed to copy', 3000)
+          toastService.error(gettext('Failed to copy'), 3000)
         }
         textarea.remove()
       }

--- a/client/app/src/services/transaction-sender.service.js
+++ b/client/app/src/services/transaction-sender.service.js
@@ -2,7 +2,7 @@
   'use strict'
 
   angular.module('arkclient.services')
-    .service('transactionSenderService', ['$timeout', 'gettextCatalog', 'dialogService', 'utilityService', 'accountService', 'storageService', 'toastService', 'neoApiService', 'transactionBuilderService', 'transactionValidatorService', TransactionSenderService])
+    .service('transactionSenderService', ['$timeout', 'gettextCatalog', 'gettext', 'dialogService', 'utilityService', 'accountService', 'storageService', 'toastService', 'neoApiService', 'transactionBuilderService', 'transactionValidatorService', TransactionSenderService])
 
   /**
    * TransactionSenderService
@@ -13,7 +13,7 @@
    *
    * TODO check the passphrase before moving to the next step
    */
-  function TransactionSenderService ($timeout, gettextCatalog, dialogService, utilityService, accountService, storageService, toastService, neoApiService, transactionBuilderService, transactionValidator) {
+  function TransactionSenderService ($timeout, gettextCatalog, gettext, dialogService, utilityService, accountService, storageService, toastService, neoApiService, transactionBuilderService, transactionValidator) {
     /**
      * Show the send transaction dialog. Reuses the controller and its $scope
      * TODO because currently it depends on the original implementation of AccountController too
@@ -32,12 +32,12 @@
         const fs = require('fs')
         fs.readFile(filePath, 'utf8', (err, data) => {
           if (err) {
-            toastService.error(`Unable to load file: ${err}`)
+            toastService.error(gettextCatalog.getString('Unable to load file') + ': ' + err)
           } else {
             const parse = require('csv-parse')
             parse(data, { quote: null, to: $scope.maxTransactionsPerFile }, (err, transactionsData) => {
               if (err) {
-                return toastService.error('Error while parsing the file')
+                return toastService.error(gettext('Error while parsing the file'))
               }
 
               callback(transactionsData)

--- a/client/app/src/services/transaction-validator.service.js
+++ b/client/app/src/services/transaction-validator.service.js
@@ -33,7 +33,7 @@
               )
             } else {
               toastService.success(
-                gettextCatalog.getString('Transactions file successfully saved in') + ' ' + fileName,
+                gettextCatalog.getString('Transactions file successfully saved in \'{{ fileName }}\'.', {fileName: fileName}),
                 null,
                 true
               )

--- a/test/services/transaction-builder.service.js
+++ b/test/services/transaction-builder.service.js
@@ -3,7 +3,7 @@
 describe('transactionBuilderService', () => {
   const tokenName = 'test-ark'
   let transactionBuilderService, accountService
-  let configServiceMock, gettextCatalogMock, networkServiceMock, ledgerServiceMock, getAccountStub
+  let configServiceMock, gettextCatalogMock, gettextMock, networkServiceMock, ledgerServiceMock, getAccountStub
   let intervalRef
 
   const fees = {
@@ -57,7 +57,9 @@ describe('transactionBuilderService', () => {
   beforeEach(() => {
     module('arkclient.accounts', $provide => {
       configServiceMock = { notice: sinon.stub(), getByGroupAndKey: sinon.stub() }
-      gettextCatalogMock = {getString: sinon.stub().returnsArg(0)}
+      // return options / params, we don't care about the string
+      gettextCatalogMock = {getString: sinon.stub().returnsArg(1)}
+      gettextMock = sinon.stub().returnsArg(0)
       networkServiceMock = {
         listenNetworkHeight: sinon.stub(),
         getPeer: sinon.stub().returns('127.0.0.1'),
@@ -68,6 +70,7 @@ describe('transactionBuilderService', () => {
       // inject the mock services
       $provide.value('configService', configServiceMock)
       $provide.value('gettextCatalog', gettextCatalogMock)
+      $provide.value('gettext', gettextMock)
       $provide.value('networkService', networkServiceMock)
       $provide.value('ledgerService', ledgerServiceMock)
     })
@@ -194,7 +197,7 @@ describe('transactionBuilderService', () => {
       sendPromise.then(transaction => {
         done("error: shouldn't be here!")
       }, err => {
-        expect(err).to.have.string(tokenName)
+        expect(err['currency']).to.have.string(tokenName)
         done()
       }).catch(err => done(err))
     })
@@ -230,7 +233,7 @@ describe('transactionBuilderService', () => {
       sendPromise.then(transaction => {
         done("error: shouldn't be here!")
       }, err => {
-        expect(err).to.have.string(tokenName)
+        expect(err['currency']).to.have.string(tokenName)
         done()
       }).catch(err => done(err))
     })
@@ -266,7 +269,7 @@ describe('transactionBuilderService', () => {
       sendPromise.then(transaction => {
         done("error: shouldn't be here!")
       }, err => {
-        expect(err).to.have.string(tokenName)
+        expect(err['currency']).to.have.string(tokenName)
         done()
       }).catch(err => done(err))
     })


### PR DESCRIPTION
I've gone through all places where we use translations (or at least I tried to, probably forgot some places) and did the following:

- always explicitly annotate translatable text (if we don't want it to translate directly, we have to use the `gettext` annotate method)
- correctly pass parameters to `getString` method (use interpolation!, e.g `getString('Abc {{ myParam}}', {myParam: 'value'})`)
- improve bad translations (English)
- remove spaces on the end of translations

Fixes: #544