### PR TITLE
Save network not directly after create was pressed

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1188,28 +1188,30 @@
       function save () {
         // these are not needed as the createNetwork now rerender automatically
         $mdDialog.hide()
-        for (const network in $scope.send.networks) {
-          networkService.setNetwork(network, $scope.send.networks[network])
+        for (const networkName in $scope.send.networks) {
+          const network = $scope.send.networks[networkName]
+          delete network.isUnsaved
+          networkService.setNetwork(networkName, network)
           self.listNetworks = networkService.getNetworks()
         }
       // window.location.reload()
       }
 
-      function refreshTabs () {
+      function refreshTabs (newNetwork) {
         // reload networks
-        networks = networkService.getNetworks()
-        self.listNetworks = networks
+        const refreshedNetworks = networkService.getNetworks()
+        if (newNetwork) {
+          refreshedNetworks[newNetwork.name] = newNetwork.network
+        }
         // add it back to the scope
-        $scope.send.networkKeys = Object.keys(networks)
-        $scope.send.networks = networks
-        // tell angular that the list changed
-        $scope.$apply()
+        $scope.send.networkKeys = Object.keys(refreshedNetworks)
+        $scope.send.networks = refreshedNetworks
       }
 
       function createNetwork () {
         networkService.createNetwork($scope.send.createnetwork).then(
-          (network) => {
-            refreshTabs()
+          (newNetwork) => {
+            refreshTabs(newNetwork)
           },
           formatAndToastError
         )

--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -1185,16 +1185,13 @@
     function manageNetworks () {
       let networks = networkService.getNetworks()
 
-      function save () {
-        // these are not needed as the createNetwork now rerender automatically
+      function save (networkName) {
         $mdDialog.hide()
-        for (const networkName in $scope.send.networks) {
-          const network = $scope.send.networks[networkName]
-          delete network.isUnsaved
-          networkService.setNetwork(networkName, network)
-          self.listNetworks = networkService.getNetworks()
-        }
-      // window.location.reload()
+
+        const network = $scope.send.networks[networkName]
+        delete network.isUnsaved
+        networkService.setNetwork(networkName, network)
+        self.listNetworks = networkService.getNetworks()
       }
 
       function refreshTabs (newNetwork) {

--- a/client/app/src/accounts/view/manageNetwork.html
+++ b/client/app/src/accounts/view/manageNetwork.html
@@ -10,50 +10,50 @@
   </md-toolbar>
   <md-content class="md-padding">
     <md-tabs md-dynamic-height md-selected="0" md-stretch-tabs>
-      <md-tab ng-repeat="network in send.networkKeys" label="{{network}}">
+      <md-tab ng-repeat="networkName in send.networkKeys" label="{{networkName}}">
         <div>
           <md-input-container md-no-float class="md-block">
             <label translate>Token name</label>
-            <input ng-model="send.networks[network].token" type="text" ng-required="false">
+            <input ng-model="send.networks[networkName].token" type="text" ng-required="false">
           </md-input-container>
           <md-input-container md-no-float class="md-block">
             <label translate>Symbol</label>
-            <input ng-model="send.networks[network].symbol" type="text" ng-required="false">
+            <input ng-model="send.networks[networkName].symbol" type="text" ng-required="false">
           </md-input-container>
           <md-input-container md-no-float class="md-block">
             <label translate>Address version</label>
-            <input ng-model="send.networks[network].version" type="text" ng-required="false">
+            <input ng-model="send.networks[networkName].version" type="text" ng-required="false">
           </md-input-container>
           <md-input-container md-no-float class="md-block">
             <label translate>Nethash</label>
-            <input ng-model="send.networks[network].nethash" type="text" ng-required="true">
+            <input ng-model="send.networks[networkName].nethash" type="text" ng-required="true">
           </md-input-container>
           <md-input-container md-no-float class="md-block">
             <label translate>SLIP 44</label>
-            <input ng-model="send.networks[network].slip44" type="text" ng-required="true">
+            <input ng-model="send.networks[networkName].slip44" type="text" ng-required="true">
           </md-input-container>
           <div layout-gt-sm="row">
             <md-input-container class="md-block" flex-gt-sm="80">
               <label translate>Seed Server</label>
-              <input ng-model="send.networks[network].peerseed" type="text" ng-required="true">
+              <input ng-model="send.networks[networkName].peerseed" type="text" ng-required="true">
             </md-input-container>
             <md-input-container class="md-block" flex-gt-sm="20">
-              <md-switch class="md-secondary" ng-model="send.networks[network].forcepeer" aria-label="Force">
+              <md-switch class="md-secondary" ng-model="send.networks[networkName].forcepeer" aria-label="Force">
                 <translate>Force?</translate>
               </md-switch>
             </md-input-container>
           </div>
           <md-input-container class="md-block">
             <label translate>Explorer</label>
-            <input ng-model="send.networks[network].explorer" type="text" ng-required="false">
+            <input ng-model="send.networks[networkName].explorer" type="text" ng-required="false">
           </md-input-container>
-          <md-input-container class="md-block" ng-hide="network === 'mainnet'">
+          <md-input-container class="md-block" ng-hide="networkName === 'mainnet'">
             <label translate>Coin Market Cap Ticker</label>
-            <input ng-model="send.networks[network].cmcTicker" type="text" ng-required="false">
+            <input ng-model="send.networks[networkName].cmcTicker" type="text" ng-required="false">
           </md-input-container>
         </div>
         <md-dialog-actions layout="row" style="padding-left: 10px">
-          <md-button ng-click="send.removeNetwork(network)" class="md-raised md-warn" ng-disabled="network == 'mainnet'">
+          <md-button ng-if="!send.networks[networkName].isUnsaved" ng-click="send.removeNetwork(networkName)" class="md-raised md-warn" ng-disabled="networkName == 'mainnet'">
             <translate>Remove</translate>
           </md-button>
           <span flex></span>
@@ -89,7 +89,7 @@
         </md-input-container>
         <md-dialog-actions layout="row">
           <md-button ng-click="send.createNetwork()" class="md-primary md-raised">
-            <translate>Create</translate>
+            <translate>Next</translate>
           </md-button>
           <md-button ng-click="send.cancel()" style="margin-right:20px;">
             <translate>Cancel</translate>

--- a/client/app/src/accounts/view/manageNetwork.html
+++ b/client/app/src/accounts/view/manageNetwork.html
@@ -57,7 +57,7 @@
             <translate>Remove</translate>
           </md-button>
           <span flex></span>
-          <md-button class="md-primary md-raised" ng-click="send.save()">
+          <md-button class="md-primary md-raised" ng-click="send.save(networkName)">
             <translate>Save</translate>
           </md-button>
           <md-button ng-click="send.cancel()" style="margin-right:20px;">

--- a/client/app/src/components/layout/main-navbar.html
+++ b/client/app/src/components/layout/main-navbar.html
@@ -39,7 +39,7 @@
 				</md-button>
 				<md-menu-content flex width="6" ng-style="$ctrl.ul.showExchangeRate() && {'min-height': '540px'} || {'min-height': '480px'}"; style="overflow:hidden;">
 					<md-list class="left-list">
-						<md-list-item ng-show="$ctrl.ul.showExchangeRate()">
+						<md-list-item ng-if="$ctrl.ul.showExchangeRate()">
 							<md-icon>attach_money</md-icon>
 							<p translate>Currency</p>
 							<md-select aria-label="Currency" class="currency md-secondary md-no-underline" ng-model="$ctrl.ul.currency" ng-init="$ctrl.ul.currency" id="price-list" ng-change="$ctrl.ul.changeCurrency()">

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -51,10 +51,9 @@
     }
 
     function createNetwork (data) {
-      const n = storageService.getGlobal('networks')
-      let newnetwork = data
+      const networks = storageService.getGlobal('networks')
       const deferred = $q.defer()
-      if (n[data.name]) {
+      if (networks[data.name]) {
         deferred.reject("Network name '" + data.name + "' already taken, please choose another one")
       } else {
         $http({
@@ -63,14 +62,13 @@
           timeout: 5000
         }).then(
           (resp) => {
-            newnetwork = resp.data.network
-            newnetwork.forcepeer = data.forcepeer
-            newnetwork.peerseed = data.peerseed
-            newnetwork.slip44 = 1 // default to testnet slip44
-            newnetwork.cmcTicker = data.cmcTicker
-            n[data.name] = newnetwork
-            storageService.setGlobal('networks', n)
-            deferred.resolve(n[data.name])
+            let newNetwork = resp.data.network
+            newNetwork.isUnsaved = true
+            newNetwork.forcepeer = data.forcepeer
+            newNetwork.peerseed = data.peerseed
+            newNetwork.slip44 = 1 // default to testnet slip44
+            newNetwork.cmcTicker = data.cmcTicker
+            deferred.resolve({name: data.name, network: newNetwork})
           },
           (resp) => {
             deferred.reject('Cannot connect to peer to autoconfigure the network')

--- a/client/app/src/services/network.service.js
+++ b/client/app/src/services/network.service.js
@@ -62,7 +62,7 @@
           timeout: 5000
         }).then(
           (resp) => {
-            let newNetwork = resp.data.network
+            const newNetwork = resp.data.network
             newNetwork.isUnsaved = true
             newNetwork.forcepeer = data.forcepeer
             newNetwork.peerseed = data.peerseed


### PR DESCRIPTION
This PR solves various things:

- don't add network directly after create was pressed
- an angularjs error which was displayed because `$scope.apply()` was called
- only the "active network" is saved, when save was pressed (before all networks were saved). Imho both approaches are not optimal but I find it more user friendly this way
- fix that position of settings menu changed, when there was no `currency` menu item:
 ![best bug](https://files.gitter.im/Nasicus/9WBg/resolve.gif)

Fixes: #549 