### PR TITLE
Fix that toAdress was sometimes an object

### DIFF
--- a/client/app/src/services/transaction-sender.service.js
+++ b/client/app/src/services/transaction-sender.service.js
@@ -233,7 +233,7 @@
       }
 
       $scope.searchTextChange = text => {
-        $scope.data.toAddress = { address: text }
+        $scope.data.toAddress = text
         validateReceiverAddress(text)
       }
 
@@ -245,17 +245,13 @@
       }
 
       $scope.onAddressFieldBlur = () => {
-        const address = $scope.data.toAddress && $scope.data.toAddress.hasOwnProperty('address')
-          ? $scope.data.toAddress.address
-          : $scope.data.toAddress
-
-        if (!address) {
+        if (!$scope.data.toAddress) {
           return
         }
 
         // we check if the input is a valid address or a non-ambiguous contact name
         // if it's a contact name, we resolve it to an address
-        const contact = validateReceiverAddress(address, true)
+        const contact = validateReceiverAddress($scope.data.toAddress, true)
         if (contact && contact.address) {
           // setting the selectedAddress will trigger 'selectedContactChange'
           // which will then do a new validation again


### PR DESCRIPTION
If you paste an address directly in the address field it was an object `{address: <address>}`.
If you then clicked send this resulted in an exception:

```
dependencies.min.js:1 TypeError: $scope.data.toAddress.trim is not a function
    at Scope.$scope.submit.tab [as submit] (transaction-sender.service.js:100)
    at fn (eval at compile (dependencies.min.js:1), <anonymous>:4:202)
    at callback (dependencies.min.js:1)
    at Scope.$eval (dependencies.min.js:1)
    at Scope.$apply (dependencies.min.js:1)
    at HTMLButtonElement.<anonymous> (dependencies.min.js:1)
    at defaultHandlerWrapper (dependencies.min.js:1)
    at HTMLButtonElement.eventHandler (dependencies.min.js:1)
```

Should probably be reviewed by @j-a-m-l . Since he "introduced" this, maybe it has a meaning or got forgotten while refactoring?