### PR TITLE
Add loading indicator when switching network

### DIFF
--- a/client/app/src/accounts/account.controller.js
+++ b/client/app/src/accounts/account.controller.js
@@ -212,7 +212,14 @@
     self.manageNetworks = manageNetworks
     self.createDelegate = createDelegate
     self.currency = storageService.get('currency') || self.currencies[0]
-    self.switchNetwork = networkService.switchNetwork
+    self.switchNetwork = (newNetwork, reload) => {
+      if (reload) {
+        dialogService.openLoadingDialog(self.currentTheme,
+                                        gettext('Switching network'),
+                                        gettext('Please wait while the the switching is in progress'))
+      }
+      networkService.switchNetwork(newNetwork, reload)
+    }
     self.marketinfo = {}
     self.network = networkService.getNetwork()
     self.listNetworks = networkService.getNetworks()

--- a/client/app/src/components/loading-dialog/loadingDialog.html
+++ b/client/app/src/components/loading-dialog/loadingDialog.html
@@ -1,0 +1,19 @@
+<md-dialog aria-label="{{title | translate}}" ng-cloak md-theme="{{theme}}">
+  <md-toolbar>
+    <div class="md-toolbar-tools">
+      <h2 md-truncate flex>
+        {{title | translate}}...
+      </h2>
+    </div>
+  </md-toolbar>
+  <md-dialog-content>
+    <div class="md-dialog-content">
+      <div style="text-align:center;">
+        <md-progress-circular style="margin:0 auto; padding-bottom: 50px;"></md-progress-circular>
+        <span ng-if="text">
+          {{text | translate}}...
+        </span>
+      </div>
+    </div>
+  </md-dialog-content>
+</md-dialog>

--- a/client/app/src/services/dialog.service.js
+++ b/client/app/src/services/dialog.service.js
@@ -22,9 +22,30 @@
     }
     const hide = () => $mdDialog.hide()
 
+    const openLoadingDialog = (theme, title, text) => {
+      $mdDialog.show({
+        parent: angular.element(document.getElementById('app')),
+        templateUrl: './src/components/loading-dialog/loadingDialog.html',
+        clickOutsideToClose: false,
+        escapeToClose: false,
+        fullscreen: true,
+        locals: {
+          title: title,
+          text: text,
+          theme: theme
+        },
+        controller: ['$scope', 'title', 'text', 'theme', ($scope, title, text, theme) => {
+          $scope.title = title
+          $scope.text = text
+          $scope.theme = theme
+        }]
+      })
+    }
+
     return {
       open,
-      hide
+      hide,
+      openLoadingDialog
     }
   }
 })()


### PR DESCRIPTION
- implement it so that it can also be used in other places

To test:
- go to the `network.service.js` file.
- replace `return window.location.reload()` with `setTimeout(() => return window.location.reload(), 10000)` in the method `switchNetwork`.

fixes: #560