### PR TITLE
Fee override from the network

### DIFF
--- a/client/app/src/accounts/transaction-builder.service.js
+++ b/client/app/src/accounts/transaction-builder.service.js
@@ -75,7 +75,9 @@
                                                                   config.amount,
                                                                   config.smartbridge,
                                                                   config.masterpassphrase,
-                                                                  config.secondpassphrase))
+                                                                  config.secondpassphrase,
+                                                                  undefined,
+                                                                  fees.send))
       })
     }
 
@@ -111,7 +113,7 @@
           const processed = Promise.all(
             transactions.map(({ address, amount, smartbridge }, i) => {
               return new Promise((resolve, reject) => {
-                const transaction = ark.transaction.createTransaction(address, amount, smartbridge, masterpassphrase, secondpassphrase)
+                const transaction = ark.transaction.createTransaction(address, amount, smartbridge, masterpassphrase, secondpassphrase, undefined, fees.send)
 
                 transaction.fee = fees.send
                 transaction.senderId = fromAddress
@@ -168,7 +170,7 @@
         createTransaction(deferred,
                           config,
                           fees.secondsignature,
-                          () => ark.signature.createSignature(config.masterpassphrase, config.secondpassphrase))
+                          () => ark.signature.createSignature(config.masterpassphrase, config.secondpassphrase, fees.secondsignature))
       })
     }
 
@@ -189,7 +191,7 @@
         createTransaction(deferred,
                           config,
                           fees.delegate,
-                          () => ark.delegate.createDelegate(config.masterpassphrase, config.username, config.secondpassphrase))
+                          () => ark.delegate.createDelegate(config.masterpassphrase, config.username, config.secondpassphrase, fees.delegate))
       })
     }
 
@@ -210,7 +212,7 @@
         createTransaction(deferred,
                           config,
                           fees.vote,
-                          () => ark.vote.createVote(config.masterpassphrase, config.publicKeys.split(','), config.secondpassphrase),
+                          () => ark.vote.createVote(config.masterpassphrase, config.publicKeys.split(','), config.secondpassphrase, fees.vote),
                           (transaction) => { transaction.recipientId = config.fromAddress })
       })
     }


### PR DESCRIPTION
This is in conjunction with https://github.com/ArkEcosystem/ark-js/pull/53 whereby the fees can be customised on bridgechains. With the desktop wallet, we already fetch the fee from the network, but we're now passing those fees into the create transaction methods to correctly build a transaction object.

@luciorubeens @j-a-m-l if you could take a look and have a quick test, that would be great! Thanks