### PR TITLE
Fix broken reload command on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,7 +184,7 @@ function createWindow () {
           label: 'Learn More',
           click () { require('electron').shell.openExternal('https://ark.io') }
         },
-        { label: 'Reload App', accelerator: 'Command+R', click: function () { mainWindow.reload() } },
+        { label: 'Reload App', accelerator: 'CmdOrCtrl+R', click: function () { mainWindow.reload() } },
         { label: 'Open Dev Tools', accelerator: 'CmdOrCtrl+D', click: function () { mainWindow.webContents.openDevTools() } }
       ]
     }


### PR DESCRIPTION
With #558 happened some changes in the menu.

On windows (can't speak for other systems) there is now a bug that the `Reload` command doesn't work anymore via keyboard - this PR fixes this.

However I also saw that some commands which were previously there are now missing, I don't know if they were omitted or changed on purpose, so I didn't change anything yet:

- `About ArkClient` became `About Electron` 
  - pretty sure this is wrong and should be changed back right?
- `Maximize` is missing
- `Full Screen` is missing
- `Quit` was removed from `Application` and is now instead called `Close` beneath `Window`
  - I personally liked `Quit` more below application (or both)

@gabrielbull  @alexbarnsley 