### PR TITLE
Remove global flag on regex validation of delegate name.

### DIFF
--- a/client/app/src/accounts/account.service.js
+++ b/client/app/src/accounts/account.service.js
@@ -666,7 +666,7 @@
       return virtual
     }
 
-    const allowedDelegateNameChars = /^[a-z0-9!@$&_.]+$/g
+    const allowedDelegateNameChars = /^[a-z0-9!@$&_.]+$/
 
     function sanitizeDelegateName (delegateName) {
       if (!delegateName) {


### PR DESCRIPTION
alexbarnsley requested that I send this PR.

When attempting to register a delegate, there were cases where the regex name validation would flag a valid name as invalid.  This appeared to be tied to multiple calls to the regext.test(....) function with the "g" option enabled on the regex.  Removing the "g" option appears to fix the issue.  Javscript is not my first language but it appears that this type of behavior is not uncommon when using the "g" option due to some sort of state preservation between calls.

Repo Steps:

1. Open the register delegate dialog
2. Click in the username edit box and type in a valid username
3. Press the tab key twice to move focus to the pass phrase edit box. (Note:  The tabs may not be strictly necessary but I observed consistent results with this)
4. Enter the correct pass phrase
5. Click the next button

You will either get the error toast saying the delegate username contains an invalid character (which is the false positive) or the checks will pass and the next dialog will appear.  If the bug does not appear, abort to delegate registration and try again until it does.  In my testing I saw about a 50% reproduce rate.

I observed this bug in the 1.5.1 production release as well as latest master branch.

