### PR TITLE
fix: adjust `SendTransfer` form state

### DIFF
--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -68,6 +68,7 @@ export const SendTransfer = () => {
 		register("network", sendTransfer.network());
 		register("recipients");
 		register("senderAddress", sendTransfer.senderAddress());
+		register("fees");
 		register("fee", common.fee(remainingBalance, wallet?.network?.()));
 		register("smartbridge", sendTransfer.smartbridge());
 

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -49,7 +49,6 @@ export const SendTransfer = () => {
 			remainingBalance: wallet?.balance?.(),
 			recipients: [],
 		},
-		shouldUnregister: false,
 	});
 
 	const { clearErrors, formState, getValues, register, setError, setValue, handleSubmit, watch } = form;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
-   [x] Unregister unused form fields in `SendTransfer`
-   [x] Fixes issue where continue button is disabled when going back from authentication step.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
