### PR TITLE
refactor: get rid of act warnings in sign message tests

### DIFF
--- a/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
+++ b/src/domains/wallet/components/SignMessage/SignMessage.test.tsx
@@ -366,9 +366,9 @@ describe("SignMessage", () => {
 			fireEvent.click(getByTestId("SignMessage__submit-button"));
 		});
 
-		// await waitFor(() =>
-		//  expect(toastSpy).toHaveBeenCalledWith(walletTranslations.MODAL_LEDGER_WALLET.NO_DEVICE_FOUND),
-		// );
+		await waitFor(() => {
+			expect(toastSpy).toHaveBeenCalledWith(walletTranslations.MODAL_LEDGER_WALLET.NO_DEVICE_FOUND);
+		});
 
 		toastSpy.mockRestore();
 		transportSpy.mockRestore();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/fjyzdm

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
