### PR TITLE
fix: circular dependency in plugins test

### DIFF
--- a/src/app/__snapshots__/App.test.tsx.snap
+++ b/src/app/__snapshots__/App.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`App should render application error if the app fails to boot 1`] = `
               </p>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ mt-8"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc mt-8"
               data-testid="ApplicationError__button--reload"
               type="button"
             >

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -1,64 +1,7 @@
-import { Icon } from "app/components//Icon";
-import { Spinner } from "app/components/Spinner";
 import { pluginManager } from "app/PluginProviders";
 import { withThemeDecorator } from "plugins";
-import React from "react";
-import { styled } from "twin.macro";
-import { ButtonVariant, Size } from "types";
 
-import { getStyles } from "./Button.styles";
-
-type ButtonProps = {
-	variant?: ButtonVariant;
-	size?: Size;
-	isLoading?: boolean;
-	icon?: string;
-	iconWidth?: number | string;
-	iconHeight?: number | string;
-} & React.ButtonHTMLAttributes<any>;
-
-const StyledButton = styled.button<ButtonProps>(getStyles);
-
-export const OriginalButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
-	({ children, icon, isLoading, iconWidth = 14, iconHeight = 14, ...props }: ButtonProps, ref) => {
-		const renderContent = () => {
-			if (isLoading) {
-				return (
-					<div className="flex relative items-center">
-						<span className="flex invisible items-center space-x-2">
-							{icon && <Icon name={icon} width={iconWidth} height={iconHeight} />}
-							{children}
-						</span>
-
-						<div className="absolute top-0 right-0 bottom-0 left-0">
-							<Spinner size="sm" className="m-auto" />
-						</div>
-					</div>
-				);
-			}
-
-			return (
-				<>
-					{icon && <Icon name={icon} width={iconWidth} height={iconHeight} />}
-					{children}
-				</>
-			);
-		};
-
-		return (
-			<StyledButton {...props} ref={ref}>
-				<div className="flex relative items-center space-x-2">{renderContent()}</div>
-			</StyledButton>
-		);
-	},
-);
-
-OriginalButton.defaultProps = {
-	type: "button",
-	variant: "primary",
-};
-
-OriginalButton.displayName = "Button";
+import { OriginalButton } from "./OriginalButton";
 
 // Expose button to be overriden by plugins
 export const Button = withThemeDecorator("button", OriginalButton, pluginManager);

--- a/src/app/components/Button/OriginalButton.tsx
+++ b/src/app/components/Button/OriginalButton.tsx
@@ -1,0 +1,59 @@
+import { Icon } from "app/components//Icon";
+import { Spinner } from "app/components/Spinner";
+import React from "react";
+import { styled } from "twin.macro";
+import { ButtonVariant, Size } from "types";
+
+import { getStyles } from "./Button.styles";
+
+type ButtonProps = {
+	variant?: ButtonVariant;
+	size?: Size;
+	isLoading?: boolean;
+	icon?: string;
+	iconWidth?: number | string;
+	iconHeight?: number | string;
+} & React.ButtonHTMLAttributes<any>;
+
+const StyledButton = styled.button<ButtonProps>(getStyles);
+
+export const OriginalButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+	({ children, icon, isLoading, iconWidth = 14, iconHeight = 14, ...props }: ButtonProps, ref) => {
+		const renderContent = () => {
+			if (isLoading) {
+				return (
+					<div className="flex relative items-center">
+						<span className="flex invisible items-center space-x-2">
+							{icon && <Icon name={icon} width={iconWidth} height={iconHeight} />}
+							{children}
+						</span>
+
+						<div className="absolute top-0 right-0 bottom-0 left-0">
+							<Spinner size="sm" className="m-auto" />
+						</div>
+					</div>
+				);
+			}
+
+			return (
+				<>
+					{icon && <Icon name={icon} width={iconWidth} height={iconHeight} />}
+					{children}
+				</>
+			);
+		};
+
+		return (
+			<StyledButton {...props} ref={ref}>
+				<div className="flex relative items-center space-x-2">{renderContent()}</div>
+			</StyledButton>
+		);
+	},
+);
+
+OriginalButton.defaultProps = {
+	type: "button",
+	variant: "primary",
+};
+
+OriginalButton.displayName = "Button";

--- a/src/app/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/app/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button should render 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
     type="button"
   >
     <div
@@ -16,7 +16,7 @@ exports[`Button should render 1`] = `
 exports[`Button should render a large one 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 dznQvQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc"
     type="button"
   >
     <div
@@ -29,7 +29,7 @@ exports[`Button should render a large one 1`] = `
 exports[`Button should render a small one 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 bJTcuL"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 kUBBRj"
     type="button"
   >
     <div
@@ -42,7 +42,7 @@ exports[`Button should render a small one 1`] = `
 exports[`Button should render an icon 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 cgAqkb"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 dpEMaj"
     type="button"
   >
     <div
@@ -55,7 +55,7 @@ exports[`Button should render an icon 1`] = `
 exports[`Button should render as danger button 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
     type="button"
   >
     <div
@@ -68,7 +68,7 @@ exports[`Button should render as danger button 1`] = `
 exports[`Button should render as primary button 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
     type="button"
   >
     <div
@@ -81,7 +81,7 @@ exports[`Button should render as primary button 1`] = `
 exports[`Button should render as secondary button 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
     type="button"
   >
     <div
@@ -94,7 +94,7 @@ exports[`Button should render as secondary button 1`] = `
 exports[`Button should render as transparent button 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 lnzPxq"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 icTvPi"
     type="button"
   >
     <div
@@ -107,7 +107,7 @@ exports[`Button should render as transparent button 1`] = `
 exports[`Button should render if disabled 1`] = `
 <DocumentFragment>
   <button
-    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
     data-testid="Button"
     disabled=""
     type="button"
@@ -124,7 +124,7 @@ exports[`Button should render if disabled 1`] = `
 exports[`Button should render loading with icon 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 cgAqkb"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 dpEMaj"
     type="button"
   >
     <div
@@ -159,7 +159,7 @@ exports[`Button should render loading with icon 1`] = `
 exports[`Button should render with icon 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
     type="button"
   >
     <div
@@ -183,7 +183,7 @@ exports[`Button should render with icon 1`] = `
 exports[`Button should render with icon and custom icon width and height 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
     type="button"
   >
     <div
@@ -207,7 +207,7 @@ exports[`Button should render with icon and custom icon width and height 1`] = `
 exports[`Button should render with loading state enabled 1`] = `
 <div>
   <button
-    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
     type="button"
   >
     <div

--- a/src/app/components/Button/index.ts
+++ b/src/app/components/Button/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./OriginalButton";

--- a/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
+++ b/src/app/components/DeleteResource/__snapshots__/DeleteResource.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DeleteResource should render with children 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -65,7 +65,7 @@ exports[`DeleteResource should render with children 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DeleteResource__cancel-button"
               type="button"
             >
@@ -76,7 +76,7 @@ exports[`DeleteResource should render with children 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="DeleteResource__submit-button"
               type="submit"
             >

--- a/src/app/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/src/app/components/Header/__snapshots__/Header.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`Header should render an header with extra 1`] = `
         class="flex justify-end space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
           data-testid="header__extra"
           type="button"
         >
@@ -81,7 +81,7 @@ exports[`Header should render an header with extra 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
           data-testid="header__extra"
           type="button"
         >

--- a/src/app/components/Layout/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/src/app/components/Layout/components/Page/__snapshots__/Page.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Page should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -93,7 +93,7 @@ exports[`Page should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -259,7 +259,7 @@ exports[`Page should render without sidebar 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -290,7 +290,7 @@ exports[`Page should render without sidebar 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"

--- a/src/app/components/Modal/Modal.tsx
+++ b/src/app/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { Button } from "app/components/Button";
+import { OriginalButton } from "app/components/Button/OriginalButton";
 import { Icon } from "app/components/Icon";
 import React, { useEffect, useRef, useState } from "react";
 import tw, { styled } from "twin.macro";
@@ -77,7 +77,7 @@ const ModalContent = (props: ModalContentProps) => {
 			data-testid="modal__inner"
 		>
 			<div className="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400">
-				<Button
+				<OriginalButton
 					data-testid="modal__close-btn"
 					variant="transparent"
 					size="icon"
@@ -85,7 +85,7 @@ const ModalContent = (props: ModalContentProps) => {
 					className="w-11 h-11"
 				>
 					<Icon name="CrossSlim" width={14} height={14} />
-				</Button>
+				</OriginalButton>
 			</div>
 
 			<div className="relative">

--- a/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/app/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Modal should closed by the Esc key 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -72,7 +72,7 @@ exports[`Modal should render a 3x large one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -125,7 +125,7 @@ exports[`Modal should render a 4x large one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -178,7 +178,7 @@ exports[`Modal should render a 5x large one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -231,7 +231,7 @@ exports[`Modal should render a 5x large one 2`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -284,7 +284,7 @@ exports[`Modal should render a large one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -337,7 +337,7 @@ exports[`Modal should render a medium one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -390,7 +390,7 @@ exports[`Modal should render a modal with banner 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -453,7 +453,7 @@ exports[`Modal should render a modal with content 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -508,7 +508,7 @@ exports[`Modal should render a modal with description 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -567,7 +567,7 @@ exports[`Modal should render a modal with overlay 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -622,7 +622,7 @@ exports[`Modal should render a small one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -675,7 +675,7 @@ exports[`Modal should render a xlarge one 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/app/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
+++ b/src/app/components/NavigationBar/__snapshots__/NavigationBar.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`NavigationBar should not render if no active profile 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--notifications"
                     type="button"
                   >
@@ -117,7 +117,7 @@ exports[`NavigationBar should not render if no active profile 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--send"
                 type="button"
               >
@@ -147,7 +147,7 @@ exports[`NavigationBar should not render if no active profile 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--receive"
                 type="button"
               >
@@ -346,7 +346,7 @@ exports[`NavigationBar should render 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--notifications"
                     type="button"
                   >
@@ -385,7 +385,7 @@ exports[`NavigationBar should render 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--send"
                 type="button"
               >
@@ -415,7 +415,7 @@ exports[`NavigationBar should render 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--receive"
                 type="button"
               >
@@ -654,7 +654,7 @@ exports[`NavigationBar should render with custom menu 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--notifications"
                     type="button"
                   >
@@ -693,7 +693,7 @@ exports[`NavigationBar should render with custom menu 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--send"
                 type="button"
               >
@@ -723,7 +723,7 @@ exports[`NavigationBar should render with custom menu 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--receive"
                 type="button"
               >
@@ -876,7 +876,7 @@ exports[`NavigationBar should render with shadow if there is a scroll 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                 data-testid="navbar__buttons--send"
                 disabled=""
                 type="button"
@@ -907,7 +907,7 @@ exports[`NavigationBar should render with shadow if there is a scroll 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                 data-testid="navbar__buttons--receive"
                 disabled=""
                 type="button"
@@ -1097,7 +1097,7 @@ exports[`NavigationBar should render with title 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--notifications"
                     type="button"
                   >
@@ -1136,7 +1136,7 @@ exports[`NavigationBar should render with title 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--send"
                 type="button"
               >
@@ -1166,7 +1166,7 @@ exports[`NavigationBar should render with title 1`] = `
               class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                 data-testid="navbar__buttons--receive"
                 type="button"
               >

--- a/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
+++ b/src/app/components/Notifications/__snapshots__/NotificationsDropdown.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -325,7 +325,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
           class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
             data-testid="modal__close-btn"
             type="button"
           >
@@ -382,7 +382,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
                 class="flex flex-col justify-center space-x-0 sm:flex-row sm:space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV mt-2 sm:mt-0"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-2 sm:mt-0"
                   data-testid="WalletUpdate__cancel-button"
                   type="button"
                 >
@@ -393,7 +393,7 @@ exports[`Notifications should open and cancel wallet update notification modal 1
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="WalletUpdate__update-button"
                   type="button"
                 >
@@ -426,7 +426,7 @@ exports[`Notifications should open and cancel wallet update notification modal 2
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -740,7 +740,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -1052,7 +1052,7 @@ exports[`Notifications should open and close transaction details modal 1`] = `
           class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
             data-testid="modal__close-btn"
             type="button"
           >
@@ -1461,7 +1461,7 @@ exports[`Notifications should open and close transaction details modal 2`] = `
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -1775,7 +1775,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -2087,7 +2087,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
           class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
             data-testid="modal__close-btn"
             type="button"
           >
@@ -2144,7 +2144,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
                 class="flex flex-col justify-center space-x-0 sm:flex-row sm:space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV mt-2 sm:mt-0"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-2 sm:mt-0"
                   data-testid="WalletUpdate__cancel-button"
                   type="button"
                 >
@@ -2155,7 +2155,7 @@ exports[`Notifications should open and close wallet update notification modal 1`
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="WalletUpdate__update-button"
                   type="button"
                 >
@@ -2188,7 +2188,7 @@ exports[`Notifications should open and close wallet update notification modal 2`
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >
@@ -2502,7 +2502,7 @@ exports[`Notifications should render with transactions and plugins 1`] = `
           class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
         >
           <button
-            class="Button__StyledButton-mdtvtf-0 fHYGyx"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
             data-testid="navbar__buttons--notifications"
             type="button"
           >

--- a/src/app/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/app/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Pagination should handle first page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -26,7 +26,7 @@ exports[`Pagination should handle first page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -103,7 +103,7 @@ exports[`Pagination should handle first page click properly 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -123,7 +123,7 @@ exports[`Pagination should handle first page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -205,7 +205,7 @@ exports[`Pagination should handle last page click properly 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -225,7 +225,7 @@ exports[`Pagination should handle last page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -254,7 +254,7 @@ exports[`Pagination should handle next page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -293,7 +293,7 @@ exports[`Pagination should handle next page click properly 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -342,7 +342,7 @@ exports[`Pagination should handle page selection properly 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -372,7 +372,7 @@ exports[`Pagination should handle previous page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -391,7 +391,7 @@ exports[`Pagination should handle previous page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -464,7 +464,7 @@ exports[`Pagination should handle previous page click properly 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -547,7 +547,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -567,7 +567,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -596,7 +596,7 @@ exports[`Pagination should not render first button if pagination buttons include
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -669,7 +669,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -689,7 +689,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -718,7 +718,7 @@ exports[`Pagination should not render first button if pagination buttons include
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -791,7 +791,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -811,7 +811,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -840,7 +840,7 @@ exports[`Pagination should not render first button if pagination buttons include
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -859,7 +859,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -942,7 +942,7 @@ exports[`Pagination should not render first button if pagination buttons include
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -961,7 +961,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -1034,7 +1034,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -1064,7 +1064,7 @@ exports[`Pagination should not render first button if pagination buttons include
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -1083,7 +1083,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -1156,7 +1156,7 @@ exports[`Pagination should not render first button if pagination buttons include
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -1186,7 +1186,7 @@ exports[`Pagination should not render next button on last page 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__first"
       type="button"
     >
@@ -1205,7 +1205,7 @@ exports[`Pagination should not render next button on last page 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__previous"
       type="button"
     >
@@ -1341,7 +1341,7 @@ exports[`Pagination should not render previous buttons on first page 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -1361,7 +1361,7 @@ exports[`Pagination should not render previous buttons on first page 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__last"
       type="button"
     >
@@ -1409,7 +1409,7 @@ exports[`Pagination should render 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
       data-testid="Pagination__next"
       type="button"
     >
@@ -1444,7 +1444,7 @@ exports[`Pagination should render condensed 1`] = `
       Page 1 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -1463,7 +1463,7 @@ exports[`Pagination should render condensed 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >

--- a/src/app/components/Pagination/components/CompactPagination/__snapshots__/CompactPagination.test.tsx.snap
+++ b/src/app/components/Pagination/components/CompactPagination/__snapshots__/CompactPagination.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`CompactPagination should handle first page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__first"
       type="button"
     >
@@ -26,7 +26,7 @@ exports[`CompactPagination should handle first page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__previous"
       type="button"
     >
@@ -65,7 +65,7 @@ exports[`CompactPagination should handle last page click properly 1`] = `
       Page 1 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -84,7 +84,7 @@ exports[`CompactPagination should handle last page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >
@@ -113,7 +113,7 @@ exports[`CompactPagination should handle next page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__previous"
       type="button"
     >
@@ -137,7 +137,7 @@ exports[`CompactPagination should handle next page click properly 1`] = `
       Page 2 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -156,7 +156,7 @@ exports[`CompactPagination should handle next page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >
@@ -185,7 +185,7 @@ exports[`CompactPagination should handle previous page click properly 1`] = `
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__previous"
       type="button"
     >
@@ -209,7 +209,7 @@ exports[`CompactPagination should handle previous page click properly 1`] = `
       Page 2 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -228,7 +228,7 @@ exports[`CompactPagination should handle previous page click properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >
@@ -262,7 +262,7 @@ exports[`CompactPagination should not render first and previous buttons on first
       Page 1 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -281,7 +281,7 @@ exports[`CompactPagination should not render first and previous buttons on first
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >
@@ -310,7 +310,7 @@ exports[`CompactPagination should not render next and last buttons on last page 
     data-testid="Pagination"
   >
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__first"
       type="button"
     >
@@ -329,7 +329,7 @@ exports[`CompactPagination should not render next and last buttons on last page 
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__previous"
       type="button"
     >
@@ -368,7 +368,7 @@ exports[`CompactPagination should render properly 1`] = `
       Page 1 of 3
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__next"
       type="button"
     >
@@ -387,7 +387,7 @@ exports[`CompactPagination should render properly 1`] = `
       </div>
     </button>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV w-8"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-8"
       data-testid="CompactPagination__last"
       type="button"
     >

--- a/src/app/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/app/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`SearchBar should render 1`] = `
         </div>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ my-1"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-1"
         data-testid="SearchBar__button"
         type="button"
       >

--- a/src/app/components/SelectProfileImage/__snapshots__/SelectProfileImage.test.tsx.snap
+++ b/src/app/components/SelectProfileImage/__snapshots__/SelectProfileImage.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`SelectProfileImage should handle upload file 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
           data-testid="SelectProfileImage__remove-button"
           type="button"
         >
@@ -92,7 +92,7 @@ exports[`SelectProfileImage should render 1`] = `
             class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="SelectProfileImage__upload-button"
               type="button"
             >
@@ -216,7 +216,7 @@ exports[`SelectProfileImage should render without value svg 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
           data-testid="SelectProfileImage__remove-button"
           type="button"
         >
@@ -285,7 +285,7 @@ exports[`SelectProfileImage shouldn't handle upload file 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
           data-testid="SelectProfileImage__remove-button"
           type="button"
         >

--- a/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
+++ b/src/domains/contact/components/ContactForm/__snapshots__/ContactForm.test.tsx.snap
@@ -308,7 +308,7 @@ exports[`ContactForm should select 1`] = `
         class="mt-4"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
           data-testid="contact-form__add-address-btn"
           disabled=""
           type="button"
@@ -328,7 +328,7 @@ exports[`ContactForm should select 1`] = `
         class="space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="contact-form__cancel-btn"
           type="button"
         >
@@ -339,7 +339,7 @@ exports[`ContactForm should select 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="contact-form__save-btn"
           disabled=""
           type="submit"
@@ -683,7 +683,7 @@ exports[`ContactForm should select with errors 1`] = `
         class="mt-4"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
           data-testid="contact-form__add-address-btn"
           disabled=""
           type="button"
@@ -703,7 +703,7 @@ exports[`ContactForm should select with errors 1`] = `
         class="space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="contact-form__cancel-btn"
           type="button"
         >
@@ -714,7 +714,7 @@ exports[`ContactForm should select with errors 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="contact-form__save-btn"
           disabled=""
           type="submit"
@@ -870,7 +870,7 @@ exports[`ContactForm when creating a new contact should render the form 1`] = `
         class="mt-4"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
           data-testid="contact-form__add-address-btn"
           disabled=""
           type="button"
@@ -890,7 +890,7 @@ exports[`ContactForm when creating a new contact should render the form 1`] = `
         class="space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="contact-form__cancel-btn"
           type="button"
         >
@@ -901,7 +901,7 @@ exports[`ContactForm when creating a new contact should render the form 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="contact-form__save-btn"
           disabled=""
           type="submit"
@@ -1057,7 +1057,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
         class="mt-4"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
           data-testid="contact-form__add-address-btn"
           disabled=""
           type="button"
@@ -1138,7 +1138,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
             </div>
           </span>
           <button
-            class="Button__StyledButton-mdtvtf-0 cPeHIJ flex items-center ml-auto"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex items-center ml-auto"
             data-testid="contact-form__remove-address-btn"
             type="button"
           >
@@ -1163,7 +1163,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
       class="flex w-full justify-between"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 hrpPWq"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
         data-testid="contact-form__delete-btn"
         type="button"
       >
@@ -1188,7 +1188,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
         class="space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="contact-form__cancel-btn"
           type="button"
         >
@@ -1199,7 +1199,7 @@ exports[`ContactForm when editing an existing contact should render the form 1`]
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="contact-form__save-btn"
           disabled=""
           type="submit"

--- a/src/domains/contact/components/ContactListItem/__snapshots__/ContactListItem.test.tsx.snap
+++ b/src/domains/contact/components/ContactListItem/__snapshots__/ContactListItem.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`ContactListItem should render 1`] = `
                 data-testid="dropdown__toggle"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 OTOjy"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                   type="button"
                 >
                   <div
@@ -325,7 +325,7 @@ exports[`ContactListItem should render as delegate 1`] = `
                 data-testid="dropdown__toggle"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 OTOjy"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                   type="button"
                 >
                   <div
@@ -480,7 +480,7 @@ exports[`ContactListItem should render using variant 1`] = `
                 data-testid="dropdown__toggle"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 OTOjy"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                   type="button"
                 >
                   <div
@@ -656,7 +656,7 @@ exports[`ContactListItem should render with multiple addresses 1`] = `
                 data-testid="dropdown__toggle"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 OTOjy"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                   type="button"
                 >
                   <div
@@ -1054,7 +1054,7 @@ exports[`ContactListItem should render with multiple options 1`] = `
                 data-testid="dropdown__toggle"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 OTOjy"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                   type="button"
                 >
                   <div
@@ -1446,7 +1446,7 @@ exports[`ContactListItem should render with one option 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="ContactListItem__one-option-button-0"
               type="button"
             >

--- a/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
+++ b/src/domains/contact/components/CreateContact/__snapshots__/CreateContact.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CreateContact should render create contact modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -363,7 +363,7 @@ exports[`CreateContact should render create contact modal 1`] = `
                   class="mt-4"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
                     data-testid="contact-form__add-address-btn"
                     disabled=""
                     type="button"
@@ -383,7 +383,7 @@ exports[`CreateContact should render create contact modal 1`] = `
                   class="space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="contact-form__cancel-btn"
                     type="button"
                   >
@@ -394,7 +394,7 @@ exports[`CreateContact should render create contact modal 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="contact-form__save-btn"
                     disabled=""
                     type="submit"

--- a/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
+++ b/src/domains/contact/components/DeleteContact/__snapshots__/DeleteContact.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DeleteContact should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -63,7 +63,7 @@ exports[`DeleteContact should render a modal 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DeleteResource__cancel-button"
               type="button"
             >
@@ -74,7 +74,7 @@ exports[`DeleteContact should render a modal 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="DeleteResource__submit-button"
               type="submit"
             >

--- a/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
+++ b/src/domains/contact/components/UpdateContact/__snapshots__/UpdateContact.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`UpdateContact should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -189,7 +189,7 @@ exports[`UpdateContact should render a modal 1`] = `
                   class="mt-4"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
                     data-testid="contact-form__add-address-btn"
                     disabled=""
                     type="button"
@@ -270,7 +270,7 @@ exports[`UpdateContact should render a modal 1`] = `
                       </div>
                     </span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 cPeHIJ flex items-center ml-auto"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex items-center ml-auto"
                       data-testid="contact-form__remove-address-btn"
                       type="button"
                     >
@@ -295,7 +295,7 @@ exports[`UpdateContact should render a modal 1`] = `
                 class="flex w-full justify-between"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                   data-testid="contact-form__delete-btn"
                   type="button"
                 >
@@ -320,7 +320,7 @@ exports[`UpdateContact should render a modal 1`] = `
                   class="space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="contact-form__cancel-btn"
                     type="button"
                   >
@@ -331,7 +331,7 @@ exports[`UpdateContact should render a modal 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="contact-form__save-btn"
                     type="submit"
                   >

--- a/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
+++ b/src/domains/contact/pages/Contacts/__snapshots__/Contacts.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`Contacts should render with contacts 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`Contacts should render with contacts 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -172,7 +172,7 @@ exports[`Contacts should render with contacts 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -341,7 +341,7 @@ exports[`Contacts should render with contacts 1`] = `
                   />
                 </div>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                   data-testid="contacts__add-contact-btn"
                   type="button"
                 >
@@ -629,7 +629,7 @@ exports[`Contacts should render with contacts 1`] = `
                             data-testid="dropdown__toggle"
                           >
                             <button
-                              class="Button__StyledButton-mdtvtf-0 OTOjy"
+                              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                               type="button"
                             >
                               <div
@@ -782,7 +782,7 @@ exports[`Contacts should render with contacts 1`] = `
                             data-testid="dropdown__toggle"
                           >
                             <button
-                              class="Button__StyledButton-mdtvtf-0 OTOjy"
+                              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                               type="button"
                             >
                               <div
@@ -1126,7 +1126,7 @@ exports[`Contacts should render without contacts 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1165,7 +1165,7 @@ exports[`Contacts should render without contacts 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1195,7 +1195,7 @@ exports[`Contacts should render without contacts 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1324,7 +1324,7 @@ exports[`Contacts should render without contacts 1`] = `
                 class="flex justify-end items-top"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                   data-testid="contacts__add-contact-btn"
                   type="button"
                 >

--- a/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/dashboard/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -1518,7 +1518,7 @@ exports[`Transactions should fetch more transactions 1`] = `
         </div>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
         data-testid="transactions__fetch-more-button"
         type="button"
       >
@@ -2415,7 +2415,7 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
         </div>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
         data-testid="transactions__fetch-more-button"
         type="button"
       >
@@ -3312,7 +3312,7 @@ exports[`Transactions should render 1`] = `
         </div>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
         data-testid="transactions__fetch-more-button"
         type="button"
       >

--- a/src/domains/dashboard/components/Wallets/__snapshots__/Wallets.test.tsx.snap
+++ b/src/domains/dashboard/components/Wallets/__snapshots__/Wallets.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Wallets should load more wallets 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -136,7 +136,7 @@ exports[`Wallets should load more wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -162,7 +162,7 @@ exports[`Wallets should load more wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -718,7 +718,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -744,7 +744,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -770,7 +770,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -1226,7 +1226,7 @@ exports[`Wallets should open and close ledger import modal 1`] = `
             class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
               data-testid="modal__close-btn"
               type="button"
             >
@@ -1416,7 +1416,7 @@ exports[`Wallets should render empty profile wallets 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -1442,7 +1442,7 @@ exports[`Wallets should render empty profile wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -1468,7 +1468,7 @@ exports[`Wallets should render empty profile wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -1748,7 +1748,7 @@ exports[`Wallets should render grid 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -1774,7 +1774,7 @@ exports[`Wallets should render grid 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -1800,7 +1800,7 @@ exports[`Wallets should render grid 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -2189,7 +2189,7 @@ exports[`Wallets should render grid in loading state 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -2215,7 +2215,7 @@ exports[`Wallets should render grid in loading state 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -2241,7 +2241,7 @@ exports[`Wallets should render grid in loading state 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -2630,7 +2630,7 @@ exports[`Wallets should render list 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -2656,7 +2656,7 @@ exports[`Wallets should render list 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -2682,7 +2682,7 @@ exports[`Wallets should render list 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -3238,7 +3238,7 @@ exports[`Wallets should render without testnet wallets 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -3264,7 +3264,7 @@ exports[`Wallets should render without testnet wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -3290,7 +3290,7 @@ exports[`Wallets should render without testnet wallets 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >
@@ -3611,7 +3611,7 @@ exports[`Wallets should toggle between grid and list view 1`] = `
               class="flex space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__create-wallet"
                 type="button"
               >
@@ -3637,7 +3637,7 @@ exports[`Wallets should toggle between grid and list view 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-wallet"
                 type="button"
               >
@@ -3663,7 +3663,7 @@ exports[`Wallets should toggle between grid and list view 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="WalletControls__import-ledger"
                 type="button"
               >

--- a/src/domains/dashboard/components/Wallets/__snapshots__/WalletsList.test.tsx.snap
+++ b/src/domains/dashboard/components/Wallets/__snapshots__/WalletsList.test.tsx.snap
@@ -1217,7 +1217,7 @@ exports[`WalletsList should render with view more button 1`] = `
       data-testid="WalletTable"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
         data-testid="WalletsList__ViewMore"
         type="button"
       >

--- a/src/domains/dashboard/components/WalletsControls/__snapshots__/WalletsControls.test.tsx.snap
+++ b/src/domains/dashboard/components/WalletsControls/__snapshots__/WalletsControls.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`WalletsControls should render 1`] = `
       class="flex space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__create-wallet"
         type="button"
       >
@@ -121,7 +121,7 @@ exports[`WalletsControls should render 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__import-wallet"
         type="button"
       >
@@ -147,7 +147,7 @@ exports[`WalletsControls should render 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__import-ledger"
         type="button"
       >
@@ -272,7 +272,7 @@ exports[`WalletsControls should render with networks selection 1`] = `
       class="flex space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__create-wallet"
         type="button"
       >
@@ -298,7 +298,7 @@ exports[`WalletsControls should render with networks selection 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__import-wallet"
         type="button"
       >
@@ -324,7 +324,7 @@ exports[`WalletsControls should render with networks selection 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="WalletControls__import-ledger"
         type="button"
       >

--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Dashboard should render 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -150,7 +150,7 @@ exports[`Dashboard should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -180,7 +180,7 @@ exports[`Dashboard should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -389,7 +389,7 @@ exports[`Dashboard should render 1`] = `
                   class="flex space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="WalletControls__create-wallet"
                     type="button"
                   >
@@ -415,7 +415,7 @@ exports[`Dashboard should render 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="WalletControls__import-wallet"
                     type="button"
                   >
@@ -441,7 +441,7 @@ exports[`Dashboard should render 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="WalletControls__import-ledger"
                     type="button"
                   >
@@ -1597,7 +1597,7 @@ exports[`Dashboard should render 1`] = `
             </div>
           </div>
           <button
-            class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
             data-testid="transactions__fetch-more-button"
             type="button"
           >

--- a/src/domains/error/pages/ApplicationError/__snapshots__/ApplicationError.test.tsx.snap
+++ b/src/domains/error/pages/ApplicationError/__snapshots__/ApplicationError.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`ApplicationError should render 1`] = `
               </p>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ mt-8"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc mt-8"
               data-testid="ApplicationError__button--reload"
               type="button"
             >

--- a/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
+++ b/src/domains/exchange/components/AddExchange/__snapshots__/AddExchange.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`AddExchange should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -205,7 +205,7 @@ exports[`AddExchange should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           type="button"
                         >
                           <div
@@ -264,7 +264,7 @@ exports[`AddExchange should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           type="button"
                         >
                           <div
@@ -323,7 +323,7 @@ exports[`AddExchange should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           type="button"
                         >
                           <div
@@ -382,7 +382,7 @@ exports[`AddExchange should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           type="button"
                         >
                           <div

--- a/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
+++ b/src/domains/exchange/pages/Exchange/__snapshots__/Exchange.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -145,7 +145,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -175,7 +175,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -304,7 +304,7 @@ exports[`Exchange should not render filler exchange cards 1`] = `
                   class="flex justify-end items-top"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                     data-testid="Exchange__add-exchange-button"
                     type="button"
                   >
@@ -660,7 +660,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -699,7 +699,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -729,7 +729,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -858,7 +858,7 @@ exports[`Exchange should open & close add exchange modal 1`] = `
                   class="flex justify-end items-top"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                     data-testid="Exchange__add-exchange-button"
                     type="button"
                   >
@@ -1085,7 +1085,7 @@ exports[`Exchange should render 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -1124,7 +1124,7 @@ exports[`Exchange should render 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -1154,7 +1154,7 @@ exports[`Exchange should render 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -1283,7 +1283,7 @@ exports[`Exchange should render 1`] = `
                   class="flex justify-end items-top"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                     data-testid="Exchange__add-exchange-button"
                     type="button"
                   >
@@ -1510,7 +1510,7 @@ exports[`Exchange should render filler exchange cards 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -1549,7 +1549,7 @@ exports[`Exchange should render filler exchange cards 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -1579,7 +1579,7 @@ exports[`Exchange should render filler exchange cards 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -1708,7 +1708,7 @@ exports[`Exchange should render filler exchange cards 1`] = `
                   class="flex justify-end items-top"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                     data-testid="Exchange__add-exchange-button"
                     type="button"
                   >
@@ -1935,7 +1935,7 @@ exports[`Exchange should render with exchanges 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -1974,7 +1974,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -2004,7 +2004,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -2133,7 +2133,7 @@ exports[`Exchange should render with exchanges 1`] = `
                   class="flex justify-end items-top"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ whitespace-nowrap"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc whitespace-nowrap"
                     data-testid="Exchange__add-exchange-button"
                     type="button"
                   >

--- a/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
+++ b/src/domains/news/components/AddAssets/__snapshots__/AddAssets.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`AddAssets should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -760,7 +760,7 @@ exports[`AddAssets should render a modal 1`] = `
               class="flex justify-end mt-4 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 type="button"
               >
                 <div
@@ -770,7 +770,7 @@ exports[`AddAssets should render a modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 type="submit"
               >
                 <div

--- a/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
+++ b/src/domains/news/components/NewsOptions/__snapshots__/NewsOptions.test.tsx.snap
@@ -255,7 +255,7 @@ exports[`NewsOptions should render 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
           data-testid="NewsOptions__submit"
           disabled=""
           type="button"

--- a/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
+++ b/src/domains/news/pages/News/__snapshots__/News.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -144,7 +144,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -174,7 +174,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -798,7 +798,7 @@ exports[`News should filter results based on category query and asset 1`] = `
                       </div>
                     </div>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV w-full"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-full"
                       data-testid="NewsOptions__submit"
                       type="button"
                     >
@@ -925,7 +925,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -964,7 +964,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -994,7 +994,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1420,7 +1420,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                     </div>
                   </div>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="Pagination__next"
                     type="button"
                   >
@@ -1440,7 +1440,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="Pagination__last"
                     type="button"
                   >
@@ -1724,7 +1724,7 @@ exports[`News should filter results based on category query and asset 2`] = `
                       </div>
                     </div>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV w-full"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-full"
                       data-testid="NewsOptions__submit"
                       type="button"
                     >

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -747,7 +747,7 @@ exports[`PluginGrid should render pagination 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__next"
           type="button"
         >
@@ -1518,7 +1518,7 @@ exports[`PluginGrid should split by page 1`] = `
         data-testid="Pagination"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__previous"
           type="button"
         >
@@ -1557,7 +1557,7 @@ exports[`PluginGrid should split by page 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__next"
           type="button"
         >

--- a/src/domains/plugin/components/PluginHeader/__snapshots__/PluginHeader.test.tsx.snap
+++ b/src/domains/plugin/components/PluginHeader/__snapshots__/PluginHeader.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`PluginHeader should render properly 1`] = `
             class="flex"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="PluginHeader__button--install"
               type="button"
             >
@@ -50,7 +50,7 @@ exports[`PluginHeader should render properly 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV ml-3"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax ml-3"
               data-testid="PluginHeader__button--report"
               type="button"
             >
@@ -305,7 +305,7 @@ exports[`PluginHeader should render updating plugin 1`] = `
             class="flex"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="PluginHeader__button--install"
               type="button"
             >
@@ -316,7 +316,7 @@ exports[`PluginHeader should render updating plugin 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV ml-3"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax ml-3"
               data-testid="PluginHeader__button--report"
               type="button"
             >

--- a/src/domains/plugin/components/PluginList/__snapshots__/PluginList.test.tsx.snap
+++ b/src/domains/plugin/components/PluginList/__snapshots__/PluginList.test.tsx.snap
@@ -274,7 +274,7 @@ exports[`PluginList should render pagination 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -389,7 +389,7 @@ exports[`PluginList should render pagination 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                   data-testid="PluginListItem__install"
                   type="button"
                 >
@@ -505,7 +505,7 @@ exports[`PluginList should render pagination 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -632,7 +632,7 @@ exports[`PluginList should render pagination 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -681,7 +681,7 @@ exports[`PluginList should render pagination 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__next"
           type="button"
         >
@@ -980,7 +980,7 @@ exports[`PluginList should render without pagination 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -1095,7 +1095,7 @@ exports[`PluginList should render without pagination 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                   data-testid="PluginListItem__install"
                   type="button"
                 >
@@ -1389,7 +1389,7 @@ exports[`PluginList should split by page 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -1424,7 +1424,7 @@ exports[`PluginList should split by page 1`] = `
         data-testid="Pagination"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__previous"
           type="button"
         >
@@ -1737,7 +1737,7 @@ exports[`PluginList should trigger delete 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -1852,7 +1852,7 @@ exports[`PluginList should trigger delete 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                   data-testid="PluginListItem__install"
                   type="button"
                 >
@@ -2149,7 +2149,7 @@ exports[`PluginList should trigger install 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -2264,7 +2264,7 @@ exports[`PluginList should trigger install 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                   data-testid="PluginListItem__install"
                   type="button"
                 >
@@ -2561,7 +2561,7 @@ exports[`PluginList shouldn't render pagination 1`] = `
                         class="relative"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                           type="button"
                         >
                           <div
@@ -2676,7 +2676,7 @@ exports[`PluginList shouldn't render pagination 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                   data-testid="PluginListItem__install"
                   type="button"
                 >

--- a/src/domains/plugin/components/PluginListItem/__snapshots__/PluginListItem.test.tsx.snap
+++ b/src/domains/plugin/components/PluginListItem/__snapshots__/PluginListItem.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`PluginListItem should render 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
               data-testid="PluginListItem__install"
               type="button"
             >
@@ -199,7 +199,7 @@ exports[`PluginListItem should render grant icon 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
               data-testid="PluginListItem__install"
               type="button"
             >
@@ -312,7 +312,7 @@ exports[`PluginListItem should render official icon 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
               data-testid="PluginListItem__install"
               type="button"
             >
@@ -416,7 +416,7 @@ exports[`PluginListItem should trigger install 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
               data-testid="PluginListItem__install"
               type="button"
             >

--- a/src/domains/plugin/components/PluginManualInstallModal/__snapshots__/PluginManualInstallModal.test.tsx.snap
+++ b/src/domains/plugin/components/PluginManualInstallModal/__snapshots__/PluginManualInstallModal.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`PluginManualInstallModal should render properly 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -123,7 +123,7 @@ exports[`PluginManualInstallModal should render properly 1`] = `
               class="flex space-x-3 justify-end mt-8"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="PluginManualInstallModal__cancel-button"
                 type="button"
               >
@@ -134,7 +134,7 @@ exports[`PluginManualInstallModal should render properly 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 data-testid="PluginManualInstallModal__submit-button"
                 type="submit"
               >

--- a/src/domains/plugin/components/PluginPermissionsModal/__snapshots__/PluginPermissionsModal.test.tsx.snap
+++ b/src/domains/plugin/components/PluginPermissionsModal/__snapshots__/PluginPermissionsModal.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Plugin Permissions should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/plugin/components/PluginUninstallConfirmation/__snapshots__/PluginUninstallConfirmation.test.tsx.snap
+++ b/src/domains/plugin/components/PluginUninstallConfirmation/__snapshots__/PluginUninstallConfirmation.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Plugin Uninstall Confirmation should remove the plugin 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -64,7 +64,7 @@ exports[`Plugin Uninstall Confirmation should remove the plugin 1`] = `
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="PluginUninstall__cancel-button"
                 type="button"
               >
@@ -75,7 +75,7 @@ exports[`Plugin Uninstall Confirmation should remove the plugin 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="PluginUninstall__submit-button"
                 type="submit"
               >

--- a/src/domains/plugin/components/PluginUpdatesConfirmation/__snapshots__/PluginUpdatesConfirmation.test.tsx.snap
+++ b/src/domains/plugin/components/PluginUpdatesConfirmation/__snapshots__/PluginUpdatesConfirmation.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Plugin Updates Confirmation should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -250,7 +250,7 @@ exports[`Plugin Updates Confirmation should render 1`] = `
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="PluginUpdates__cancel-button"
                 type="button"
               >
@@ -261,7 +261,7 @@ exports[`Plugin Updates Confirmation should render 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 data-testid="PluginUpdates__continue-button"
                 type="button"
               >

--- a/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`PluginDetails should render properly 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -146,7 +146,7 @@ exports[`PluginDetails should render properly 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -176,7 +176,7 @@ exports[`PluginDetails should render properly 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -321,7 +321,7 @@ exports[`PluginDetails should render properly 1`] = `
                       class="flex items-center space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="PluginHeader__button--report"
                         type="button"
                       >
@@ -346,7 +346,7 @@ exports[`PluginDetails should render properly 1`] = `
                           data-testid="dropdown__toggle"
                         >
                           <button
-                            class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                             data-testid="PluginHeader__dropdown-toggle"
                             type="button"
                           >
@@ -648,7 +648,7 @@ exports[`PluginDetails should render properly for remote package 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -687,7 +687,7 @@ exports[`PluginDetails should render properly for remote package 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -717,7 +717,7 @@ exports[`PluginDetails should render properly for remote package 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -859,7 +859,7 @@ exports[`PluginDetails should render properly for remote package 1`] = `
                     class="flex"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="PluginHeader__button--install"
                       type="button"
                     >
@@ -870,7 +870,7 @@ exports[`PluginDetails should render properly for remote package 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV ml-3"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax ml-3"
                       data-testid="PluginHeader__button--report"
                       type="button"
                     >
@@ -1169,7 +1169,7 @@ exports[`PluginDetails should report plugin 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1208,7 +1208,7 @@ exports[`PluginDetails should report plugin 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1238,7 +1238,7 @@ exports[`PluginDetails should report plugin 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1383,7 +1383,7 @@ exports[`PluginDetails should report plugin 1`] = `
                       class="flex items-center space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="PluginHeader__button--report"
                         type="button"
                       >
@@ -1408,7 +1408,7 @@ exports[`PluginDetails should report plugin 1`] = `
                           data-testid="dropdown__toggle"
                         >
                           <button
-                            class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                             data-testid="PluginHeader__dropdown-toggle"
                             type="button"
                           >
@@ -1710,7 +1710,7 @@ exports[`PluginDetails should show configuration for plugins from npm 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1749,7 +1749,7 @@ exports[`PluginDetails should show configuration for plugins from npm 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1779,7 +1779,7 @@ exports[`PluginDetails should show configuration for plugins from npm 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1923,7 +1923,7 @@ exports[`PluginDetails should show configuration for plugins from npm 1`] = `
                     class="flex"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="PluginHeader__button--install"
                       type="button"
                     >
@@ -1934,7 +1934,7 @@ exports[`PluginDetails should show configuration for plugins from npm 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV ml-3"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax ml-3"
                       data-testid="PluginHeader__button--report"
                       type="button"
                     >
@@ -2267,7 +2267,7 @@ exports[`PluginDetails should update package 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2306,7 +2306,7 @@ exports[`PluginDetails should update package 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2336,7 +2336,7 @@ exports[`PluginDetails should update package 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2481,7 +2481,7 @@ exports[`PluginDetails should update package 1`] = `
                       class="flex items-center space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="PluginHeader__button--report"
                         type="button"
                       >
@@ -2506,7 +2506,7 @@ exports[`PluginDetails should update package 1`] = `
                           data-testid="dropdown__toggle"
                         >
                           <button
-                            class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                             data-testid="PluginHeader__dropdown-toggle"
                             type="button"
                           >

--- a/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginManager/__snapshots__/PluginManager.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -145,7 +145,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -175,7 +175,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -871,7 +871,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                           >
                             <button
-                              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                               data-testid="PluginListItem__install"
                               type="button"
                             >
@@ -968,7 +968,7 @@ exports[`PluginManager should cancel install plugin 1`] = `
                             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                           >
                             <button
-                              class="Button__StyledButton-mdtvtf-0 iUSBMV flex-1"
+                              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex-1"
                               data-testid="PluginListItem__install"
                               type="button"
                             >
@@ -1199,7 +1199,7 @@ exports[`PluginManager should disable plugin on my-plugins 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -1238,7 +1238,7 @@ exports[`PluginManager should disable plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -1268,7 +1268,7 @@ exports[`PluginManager should disable plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -1952,7 +1952,7 @@ exports[`PluginManager should disable plugin on my-plugins 1`] = `
                                     class="relative"
                                   >
                                     <button
-                                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                                       type="button"
                                     >
                                       <div
@@ -2098,7 +2098,7 @@ exports[`PluginManager should enable plugin on my-plugins 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -2137,7 +2137,7 @@ exports[`PluginManager should enable plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -2167,7 +2167,7 @@ exports[`PluginManager should enable plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -2851,7 +2851,7 @@ exports[`PluginManager should enable plugin on my-plugins 1`] = `
                                     class="relative"
                                   >
                                     <button
-                                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                                       type="button"
                                     >
                                       <div
@@ -2997,7 +2997,7 @@ exports[`PluginManager should render 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -3036,7 +3036,7 @@ exports[`PluginManager should render 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -3066,7 +3066,7 @@ exports[`PluginManager should render 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -4385,7 +4385,7 @@ exports[`PluginManager should search for plugin 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -4424,7 +4424,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -4454,7 +4454,7 @@ exports[`PluginManager should search for plugin 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -5782,7 +5782,7 @@ exports[`PluginManager should search for plugin 2`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -5821,7 +5821,7 @@ exports[`PluginManager should search for plugin 2`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -5851,7 +5851,7 @@ exports[`PluginManager should search for plugin 2`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -7134,7 +7134,7 @@ exports[`PluginManager should switch to exchange category by clicking on view mo
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -7173,7 +7173,7 @@ exports[`PluginManager should switch to exchange category by clicking on view mo
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -7203,7 +7203,7 @@ exports[`PluginManager should switch to exchange category by clicking on view mo
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -7702,7 +7702,7 @@ exports[`PluginManager should switch to gaming category by clicking on view more
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -7741,7 +7741,7 @@ exports[`PluginManager should switch to gaming category by clicking on view more
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -7771,7 +7771,7 @@ exports[`PluginManager should switch to gaming category by clicking on view more
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -8270,7 +8270,7 @@ exports[`PluginManager should switch to other category by clicking on view more 
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -8309,7 +8309,7 @@ exports[`PluginManager should switch to other category by clicking on view more 
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -8339,7 +8339,7 @@ exports[`PluginManager should switch to other category by clicking on view more 
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -8838,7 +8838,7 @@ exports[`PluginManager should switch to utility category by clicking on view mor
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -8877,7 +8877,7 @@ exports[`PluginManager should switch to utility category by clicking on view mor
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -8907,7 +8907,7 @@ exports[`PluginManager should switch to utility category by clicking on view mor
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -9593,7 +9593,7 @@ exports[`PluginManager should toggle between list and grid on all 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -9632,7 +9632,7 @@ exports[`PluginManager should toggle between list and grid on all 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -9662,7 +9662,7 @@ exports[`PluginManager should toggle between list and grid on all 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -10348,7 +10348,7 @@ exports[`PluginManager should toggle between list and grid on latest 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -10387,7 +10387,7 @@ exports[`PluginManager should toggle between list and grid on latest 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -10417,7 +10417,7 @@ exports[`PluginManager should toggle between list and grid on latest 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -11736,7 +11736,7 @@ exports[`PluginManager should toggle between list and grid on utility tab 1`] = 
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -11775,7 +11775,7 @@ exports[`PluginManager should toggle between list and grid on utility tab 1`] = 
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -11805,7 +11805,7 @@ exports[`PluginManager should toggle between list and grid on utility tab 1`] = 
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -12491,7 +12491,7 @@ exports[`PluginManager should update plugin on my-plugins 1`] = `
                       class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                         data-testid="navbar__buttons--notifications"
                         type="button"
                       >
@@ -12530,7 +12530,7 @@ exports[`PluginManager should update plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--send"
                     type="button"
                   >
@@ -12560,7 +12560,7 @@ exports[`PluginManager should update plugin on my-plugins 1`] = `
                   class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                     data-testid="navbar__buttons--receive"
                     type="button"
                   >
@@ -12957,7 +12957,7 @@ exports[`PluginManager should update plugin on my-plugins 1`] = `
                     There is 1 update available for your plugins. Would you like to update it?
                   </span>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ -mr-1"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc -mr-1"
                     data-testid="PluginManager__update-all"
                     type="button"
                   >
@@ -13281,7 +13281,7 @@ exports[`PluginManager should update plugin on my-plugins 1`] = `
                                       <span />
                                     </span>
                                     <button
-                                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                                       type="button"
                                     >
                                       <div

--- a/src/domains/plugin/pages/PluginView/__snapshots__/PluginView.test.tsx.snap
+++ b/src/domains/plugin/pages/PluginView/__snapshots__/PluginView.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Plugin View should render plugin content 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -143,7 +143,7 @@ exports[`Plugin View should render plugin content 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -173,7 +173,7 @@ exports[`Plugin View should render plugin content 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >

--- a/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
+++ b/src/domains/profile/components/DeleteProfile/__snapshots__/DeleteProfile.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`DeleteProfile should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -61,7 +61,7 @@ exports[`DeleteProfile should render 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DeleteResource__cancel-button"
               type="button"
             >
@@ -72,7 +72,7 @@ exports[`DeleteProfile should render 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="DeleteResource__submit-button"
               type="submit"
             >

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`PasswordModal should render with title and description 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -114,7 +114,7 @@ exports[`PasswordModal should render with title and description 1`] = `
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="PasswordModal__submit-button"
                 disabled=""
                 type="submit"

--- a/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
+++ b/src/domains/profile/components/ProfileCreated/__snapshots__/ProfileCreated.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`ProfileCreated should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -75,7 +75,7 @@ exports[`ProfileCreated should render a modal 1`] = `
               class="flex flex-col justify-center space-x-0 sm:flex-row sm:space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 type="button"
               >
                 <div
@@ -85,7 +85,7 @@ exports[`ProfileCreated should render a modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV mt-2 sm:mt-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-2 sm:mt-0"
                 type="button"
               >
                 <div

--- a/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
+++ b/src/domains/profile/components/ResetProfile/__snapshots__/ResetProfile.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ResetProfile should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -61,7 +61,7 @@ exports[`ResetProfile should render 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="ResetProfile__cancel-button"
               type="button"
             >
@@ -72,7 +72,7 @@ exports[`ResetProfile should render 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="ResetProfile__submit-button"
               type="submit"
             >

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SignIn should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -158,7 +158,7 @@ exports[`SignIn should render a modal 1`] = `
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="SignIn__cancel-button"
                 type="button"
               >
@@ -169,7 +169,7 @@ exports[`SignIn should render a modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="SignIn__submit-button"
                 disabled=""
                 type="submit"

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -697,7 +697,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -707,7 +707,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -879,7 +879,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -1416,7 +1416,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -1426,7 +1426,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -1598,7 +1598,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -2135,7 +2135,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -2145,7 +2145,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -2339,7 +2339,7 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                             </div>
                           </div>
                           <button
-                            class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                             data-testid="SelectProfileImage__remove-button"
                             type="button"
                           >
@@ -2632,7 +2632,7 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -2642,7 +2642,7 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -2795,7 +2795,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -3332,7 +3332,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -3342,7 +3342,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="CreateProfile__submit-button"
                   type="submit"
                 >
@@ -3494,7 +3494,7 @@ exports[`CreateProfile should render 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -3789,7 +3789,7 @@ exports[`CreateProfile should render 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -3799,7 +3799,7 @@ exports[`CreateProfile should render 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -3974,7 +3974,7 @@ exports[`CreateProfile should store profile 1`] = `
                             </div>
                           </div>
                           <button
-                            class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                             data-testid="SelectProfileImage__remove-button"
                             type="button"
                           >
@@ -4509,7 +4509,7 @@ exports[`CreateProfile should store profile 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -4519,7 +4519,7 @@ exports[`CreateProfile should store profile 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="CreateProfile__submit-button"
                   type="submit"
                 >
@@ -4671,7 +4671,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -5206,7 +5206,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -5216,7 +5216,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="CreateProfile__submit-button"
                   type="submit"
                 >
@@ -5669,7 +5669,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -5679,7 +5679,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -5851,7 +5851,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -6146,7 +6146,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -6156,7 +6156,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="CreateProfile__submit-button"
                   disabled=""
                   type="submit"
@@ -6309,7 +6309,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -6846,7 +6846,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                 class="flex justify-end pt-4 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   type="button"
                 >
                   <div
@@ -6856,7 +6856,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="CreateProfile__submit-button"
                   type="submit"
                 >

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ErrorStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ErrorStep.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Import Profile - Error Step should render 1`] = `
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="ImportError__back"
         type="button"
       >
@@ -89,7 +89,7 @@ exports[`Import Profile - Error Step should render 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
         data-testid="ImportError__retry"
         type="button"
       >

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ImportProfile.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ImportProfile.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`ImportProfile should render first step 1`] = `
                     class="flex justify-end mt-8 space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="SelectFileStep__back"
                       type="button"
                     >

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
@@ -668,7 +668,7 @@ exports[`Import Profile - Profile Form Step should fail password confirmation 1`
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -679,7 +679,7 @@ exports[`Import Profile - Profile Form Step should fail password confirmation 1`
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="CreateProfile__submit-button"
               disabled=""
               type="submit"
@@ -1102,7 +1102,7 @@ exports[`Import Profile - Profile Form Step should render profile form 1`] = `
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -1113,7 +1113,7 @@ exports[`Import Profile - Profile Form Step should render profile form 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="CreateProfile__submit-button"
               disabled=""
               type="submit"
@@ -1536,7 +1536,7 @@ exports[`Import Profile - Profile Form Step should render profile form with empt
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -1547,7 +1547,7 @@ exports[`Import Profile - Profile Form Step should render profile form with empt
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="CreateProfile__submit-button"
               disabled=""
               type="submit"
@@ -1970,7 +1970,7 @@ exports[`Import Profile - Profile Form Step should render profile form with hidd
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -1981,7 +1981,7 @@ exports[`Import Profile - Profile Form Step should render profile form with hidd
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="CreateProfile__submit-button"
               disabled=""
               type="submit"
@@ -2117,7 +2117,7 @@ exports[`Import Profile - Profile Form Step should store new profile with passwo
                         </div>
                       </div>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                         data-testid="SelectProfileImage__remove-button"
                         type="button"
                       >
@@ -2650,7 +2650,7 @@ exports[`Import Profile - Profile Form Step should store new profile with passwo
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -2661,7 +2661,7 @@ exports[`Import Profile - Profile Form Step should store new profile with passwo
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="CreateProfile__submit-button"
               type="submit"
             >
@@ -2796,7 +2796,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
                         </div>
                       </div>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                         data-testid="SelectProfileImage__remove-button"
                         type="button"
                       >
@@ -3331,7 +3331,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -3342,7 +3342,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="CreateProfile__submit-button"
               type="submit"
             >
@@ -3599,7 +3599,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -3610,7 +3610,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="CreateProfile__submit-button"
               type="submit"
             >
@@ -3745,7 +3745,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
                         </div>
                       </div>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                         data-testid="SelectProfileImage__remove-button"
                         type="button"
                       >
@@ -3881,7 +3881,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
             class="flex justify-end pt-4 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="CreateProfile__back-button"
               type="button"
             >
@@ -3892,7 +3892,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="CreateProfile__submit-button"
               type="submit"
             >

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/SelectFileStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/SelectFileStep.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`Import Profile Select File Step should change back from json to dwe 1`]
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="SelectFileStep__back"
         type="button"
       >
@@ -190,7 +190,7 @@ exports[`Import Profile Select File Step should handle back event 1`] = `
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="SelectFileStep__back"
         type="button"
       >
@@ -285,7 +285,7 @@ exports[`Import Profile Select File Step should render file selection for dwe an
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="SelectFileStep__back"
         type="button"
       >
@@ -380,7 +380,7 @@ exports[`Import Profile Select File Step should render with dwe fileFormat selec
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="SelectFileStep__back"
         type="button"
       >
@@ -490,7 +490,7 @@ exports[`Import Profile Select File Step should render with json fileFormat sele
       class="flex justify-end mt-8 space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="SelectFileStep__back"
         type="button"
       >

--- a/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
+++ b/src/domains/setting/components/AdvancedMode/__snapshots__/AdvancedMode.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`AdvancedMode should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -87,7 +87,7 @@ By clicking "I Accept" you acknowledge that enabling Advanced Mode may result in
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AdvancedMode__decline-button"
               type="button"
             >
@@ -98,7 +98,7 @@ By clicking "I Accept" you acknowledge that enabling Advanced Mode may result in
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="AdvancedMode__accept-button"
               type="button"
             >

--- a/src/domains/setting/components/CreatePeer/__snapshots__/CreatePeer.test.tsx.snap
+++ b/src/domains/setting/components/CreatePeer/__snapshots__/CreatePeer.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`CreatePeer should render create peer modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -385,7 +385,7 @@ exports[`CreatePeer should render create peer modal 1`] = `
               class="flex justify-end mt-4"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="PeerForm__submit-button"
                 disabled=""
                 type="submit"

--- a/src/domains/setting/components/DeletePeer/__snapshots__/DeletePeer.test.tsx.snap
+++ b/src/domains/setting/components/DeletePeer/__snapshots__/DeletePeer.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DeletePeer should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -63,7 +63,7 @@ exports[`DeletePeer should render a modal 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DeleteResource__cancel-button"
               type="button"
             >
@@ -74,7 +74,7 @@ exports[`DeletePeer should render a modal 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="DeleteResource__submit-button"
               type="submit"
             >

--- a/src/domains/setting/components/DevelopmentNetwork/__snapshots__/DevelopmentNetwork.test.tsx.snap
+++ b/src/domains/setting/components/DevelopmentNetwork/__snapshots__/DevelopmentNetwork.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DevelopmentNetwork should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -58,7 +58,7 @@ exports[`DevelopmentNetwork should render a modal 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DevelopmentNetwork__cancel-button"
               type="button"
             >
@@ -69,7 +69,7 @@ exports[`DevelopmentNetwork should render a modal 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DevelopmentNetwork__continue-button"
               type="button"
             >

--- a/src/domains/setting/components/PeerForm/__snapshots__/PeerForm.test.tsx.snap
+++ b/src/domains/setting/components/PeerForm/__snapshots__/PeerForm.test.tsx.snap
@@ -338,7 +338,7 @@ exports[`PeerForm should render 1`] = `
       class="flex justify-end mt-4"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
         data-testid="PeerForm__submit-button"
         disabled=""
         type="submit"
@@ -710,7 +710,7 @@ exports[`PeerForm should render the peer on the form 1`] = `
       class="flex justify-end mt-4"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
         data-testid="PeerForm__submit-button"
         type="submit"
       >

--- a/src/domains/setting/components/PeerListItem/__snapshots__/PeerListItem.test.tsx.snap
+++ b/src/domains/setting/components/PeerListItem/__snapshots__/PeerListItem.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`PeerListItem should render 1`] = `
                   class="float-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 OTOjy"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu"
                     type="button"
                   >
                     <div

--- a/src/domains/setting/components/UpdatePeer/__snapshots__/UpdatePeer.test.tsx.snap
+++ b/src/domains/setting/components/UpdatePeer/__snapshots__/UpdatePeer.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`UpdatePeer should render update peer modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -403,7 +403,7 @@ exports[`UpdatePeer should render update peer modal 1`] = `
               class="flex justify-end mt-4"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 data-testid="PeerForm__submit-button"
                 type="submit"
               >

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`Settings should change a password 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`Settings should change a password 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -173,7 +173,7 @@ exports[`Settings should change a password 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -624,7 +624,7 @@ exports[`Settings should change a password 1`] = `
                       class="flex justify-end mt-8 w-full"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                         data-testid="Password-settings__submit-button"
                         disabled=""
                         type="submit"
@@ -751,7 +751,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -790,7 +790,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -820,7 +820,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1157,7 +1157,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                             </div>
                           </div>
                           <button
-                            class="Button__StyledButton-mdtvtf-0 cPeHIJ flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 dscUFp flex absolute -top-3 -right-3 justify-center items-center p-1 w-6 h-6"
                             data-testid="SelectProfileImage__remove-button"
                             type="button"
                           >
@@ -2187,7 +2187,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                     class="flex justify-between pt-2 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                       type="button"
                     >
                       <div
@@ -2211,7 +2211,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                       class="space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         type="button"
                       >
                         <div
@@ -2221,7 +2221,7 @@ exports[`Settings should not update the uploaded avatar when removing focus from
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                         data-testid="General-settings__submit-button"
                         type="submit"
                       >
@@ -2347,7 +2347,7 @@ exports[`Settings should render 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2386,7 +2386,7 @@ exports[`Settings should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2416,7 +2416,7 @@ exports[`Settings should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3769,7 +3769,7 @@ exports[`Settings should render 1`] = `
                     class="flex justify-between pt-2 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                       type="button"
                     >
                       <div
@@ -3793,7 +3793,7 @@ exports[`Settings should render 1`] = `
                       class="space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         type="button"
                       >
                         <div
@@ -3803,7 +3803,7 @@ exports[`Settings should render 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                         data-testid="General-settings__submit-button"
                         type="submit"
                       >
@@ -3929,7 +3929,7 @@ exports[`Settings should render export settings 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3968,7 +3968,7 @@ exports[`Settings should render export settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -3999,7 +3999,7 @@ exports[`Settings should render export settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -4399,7 +4399,7 @@ exports[`Settings should render export settings 1`] = `
                     class="flex justify-end w-full space-x-3 mt-8"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="Export-settings__submit-button"
                       type="submit"
                     >
@@ -4524,7 +4524,7 @@ exports[`Settings should render password settings 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -4563,7 +4563,7 @@ exports[`Settings should render password settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -4594,7 +4594,7 @@ exports[`Settings should render password settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -4993,7 +4993,7 @@ exports[`Settings should render password settings 1`] = `
                       class="flex justify-end mt-8 w-full"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                         data-testid="Password-settings__submit-button"
                         disabled=""
                         type="submit"
@@ -5120,7 +5120,7 @@ exports[`Settings should render peer settings 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5159,7 +5159,7 @@ exports[`Settings should render peer settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -5190,7 +5190,7 @@ exports[`Settings should render peer settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -5597,7 +5597,7 @@ exports[`Settings should render peer settings 1`] = `
                     class="flex justify-end w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="Peer-settings__submit-button"
                       type="submit"
                     >
@@ -5722,7 +5722,7 @@ exports[`Settings should render plugin settings 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5761,7 +5761,7 @@ exports[`Settings should render plugin settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -5792,7 +5792,7 @@ exports[`Settings should render plugin settings 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -6241,7 +6241,7 @@ exports[`Settings should render plugin settings 1`] = `
                     class="flex justify-end mt-8 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="Plugins-settings__submit-button"
                       type="submit"
                     >
@@ -6366,7 +6366,7 @@ exports[`Settings should set a password 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -6405,7 +6405,7 @@ exports[`Settings should set a password 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -6436,7 +6436,7 @@ exports[`Settings should set a password 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -6887,7 +6887,7 @@ exports[`Settings should set a password 1`] = `
                       class="flex justify-end mt-8 w-full"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                         data-testid="Password-settings__submit-button"
                         disabled=""
                         type="submit"
@@ -7014,7 +7014,7 @@ exports[`Settings should show an error toast if the current password does not ma
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -7053,7 +7053,7 @@ exports[`Settings should show an error toast if the current password does not ma
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -7084,7 +7084,7 @@ exports[`Settings should show an error toast if the current password does not ma
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -7535,7 +7535,7 @@ exports[`Settings should show an error toast if the current password does not ma
                       class="flex justify-end mt-8 w-full"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                         data-testid="Password-settings__submit-button"
                         type="submit"
                       >
@@ -7661,7 +7661,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -7700,7 +7700,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -7731,7 +7731,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -8197,7 +8197,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                       class="flex justify-end mt-8 w-full"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                         data-testid="Password-settings__submit-button"
                         disabled=""
                         type="submit"
@@ -8324,7 +8324,7 @@ exports[`Settings should update profile 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -8363,7 +8363,7 @@ exports[`Settings should update profile 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -8393,7 +8393,7 @@ exports[`Settings should update profile 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -8708,7 +8708,7 @@ exports[`Settings should update profile 1`] = `
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -9741,7 +9741,7 @@ exports[`Settings should update profile 1`] = `
                     class="flex justify-between pt-2 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                       type="button"
                     >
                       <div
@@ -9765,7 +9765,7 @@ exports[`Settings should update profile 1`] = `
                       class="space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         type="button"
                       >
                         <div
@@ -9775,7 +9775,7 @@ exports[`Settings should update profile 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                         data-testid="General-settings__submit-button"
                         type="submit"
                       >
@@ -9901,7 +9901,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -9940,7 +9940,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -9970,7 +9970,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -11323,7 +11323,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                     class="flex justify-between pt-2 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                       type="button"
                     >
                       <div
@@ -11347,7 +11347,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                       class="space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         type="button"
                       >
                         <div
@@ -11357,7 +11357,7 @@ exports[`Settings should update the avatar when removing focus from name input 1
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                         data-testid="General-settings__submit-button"
                         type="submit"
                       >
@@ -11483,7 +11483,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -11522,7 +11522,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -11552,7 +11552,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -11867,7 +11867,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                               class="SelectProfileImage__UploadButtonWrapper-t6smk3-0 fPlqSP"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                                 data-testid="SelectProfileImage__upload-button"
                                 type="button"
                               >
@@ -12918,7 +12918,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                     class="flex justify-between pt-2 w-full"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                       type="button"
                     >
                       <div
@@ -12942,7 +12942,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                       class="space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         type="button"
                       >
                         <div
@@ -12952,7 +12952,7 @@ exports[`Settings should update the avatar when removing focus from name input 2
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                         data-testid="General-settings__submit-button"
                         disabled=""
                         type="submit"

--- a/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/AddRecipient/__snapshots__/AddRecipient.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`AddRecipient should render 1`] = `
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -47,7 +47,7 @@ exports[`AddRecipient should render 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >
@@ -284,7 +284,7 @@ exports[`AddRecipient should render with multiple recipients tab 1`] = `
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -295,7 +295,7 @@ exports[`AddRecipient should render with multiple recipients tab 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >
@@ -532,7 +532,7 @@ exports[`AddRecipient should render with single recipient data 1`] = `
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -543,7 +543,7 @@ exports[`AddRecipient should render with single recipient data 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >
@@ -791,7 +791,7 @@ exports[`AddRecipient should render without recipients 1`] = `
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -802,7 +802,7 @@ exports[`AddRecipient should render without recipients 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >
@@ -1233,7 +1233,7 @@ exports[`AddRecipient should set available amount 1`] = `
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -1244,7 +1244,7 @@ exports[`AddRecipient should set available amount 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >
@@ -1481,7 +1481,7 @@ exports[`AddRecipient should show zero amount if wallet has zero or insufficient
         class="flex items-stretch select-buttons"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
           data-testid="AddRecipient__single"
           type="button"
         >
@@ -1492,7 +1492,7 @@ exports[`AddRecipient should show zero amount if wallet has zero or insufficient
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
           data-testid="AddRecipient__multi"
           type="button"
         >

--- a/src/domains/transaction/components/ConfirmSendTransaction/__snapshots__/ConfirmSendTransaction.test.tsx.snap
+++ b/src/domains/transaction/components/ConfirmSendTransaction/__snapshots__/ConfirmSendTransaction.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`ConfirmSendTransaction should render modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -157,7 +157,7 @@ exports[`ConfirmSendTransaction should render modal 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="ConfirmSendTransaction__cancel"
               type="button"
             >
@@ -168,7 +168,7 @@ exports[`ConfirmSendTransaction should render modal 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="ConfirmSendTransaction__confirm"
               type="submit"
             >

--- a/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateRegistrationDetail/__snapshots__/DelegateRegistrationDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DelegateRegistrationDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -372,7 +372,7 @@ exports[`DelegateRegistrationDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/DelegateResignationDetail/__snapshots__/DelegateResignationDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DelegateResignationDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -372,7 +372,7 @@ exports[`DelegateResignationDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
+++ b/src/domains/transaction/components/EntityDetail/__snapshots__/EntityDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`EntityDetail should render a business entity resignation modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -353,7 +353,7 @@ exports[`EntityDetail should render a business entity update modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -687,7 +687,7 @@ exports[`EntityDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1021,7 +1021,7 @@ exports[`EntityDetail should render a modal without a wallet alias 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1344,7 +1344,7 @@ exports[`EntityDetail should render a module entity registration modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1678,7 +1678,7 @@ exports[`EntityDetail should render a module entity resignation modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2012,7 +2012,7 @@ exports[`EntityDetail should render a module entity update modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2346,7 +2346,7 @@ exports[`EntityDetail should render a plugin entity registration modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2680,7 +2680,7 @@ exports[`EntityDetail should render a plugin entity resignation modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3014,7 +3014,7 @@ exports[`EntityDetail should render a plugin entity update modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3348,7 +3348,7 @@ exports[`EntityDetail should render a product entity registration modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3682,7 +3682,7 @@ exports[`EntityDetail should render a product entity resignation modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -4016,7 +4016,7 @@ exports[`EntityDetail should render a product entity update modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -4350,7 +4350,7 @@ exports[`EntityDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/ErrorStep/__snapshots__/ErrorStep.test.tsx.snap
+++ b/src/domains/transaction/components/ErrorStep/__snapshots__/ErrorStep.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ErrorStep should emit onBack 1`] = `
       class="flex justify-end space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="ErrorStep__wallet-button"
         type="button"
       >
@@ -45,7 +45,7 @@ exports[`ErrorStep should emit onBack 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
         data-testid="ErrorStep__repeat-button"
         type="button"
       >
@@ -94,7 +94,7 @@ exports[`ErrorStep should emit onRepeat 1`] = `
       class="flex justify-end space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="ErrorStep__wallet-button"
         type="button"
       >
@@ -105,7 +105,7 @@ exports[`ErrorStep should emit onRepeat 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
         data-testid="ErrorStep__repeat-button"
         type="button"
       >
@@ -154,7 +154,7 @@ exports[`ErrorStep should render with custom title and description 1`] = `
       class="flex justify-end space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="ErrorStep__wallet-button"
         type="button"
       >
@@ -165,7 +165,7 @@ exports[`ErrorStep should render with custom title and description 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
         data-testid="ErrorStep__repeat-button"
         type="button"
       >
@@ -214,7 +214,7 @@ exports[`ErrorStep should render with default texts 1`] = `
       class="flex justify-end space-x-3"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
         data-testid="ErrorStep__wallet-button"
         type="button"
       >
@@ -225,7 +225,7 @@ exports[`ErrorStep should render with default texts 1`] = `
         </div>
       </button>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
         data-testid="ErrorStep__repeat-button"
         type="button"
       >

--- a/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
+++ b/src/domains/transaction/components/FeeWarning/__snapshots__/FeeWarning.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`FeeWarning should render a warning for a fee that is too HIGH 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -83,7 +83,7 @@ exports[`FeeWarning should render a warning for a fee that is too HIGH 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="FeeWarning__cancel-button"
               type="button"
             >
@@ -94,7 +94,7 @@ exports[`FeeWarning should render a warning for a fee that is too HIGH 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="FeeWarning__continue-button"
               type="button"
             >
@@ -129,7 +129,7 @@ exports[`FeeWarning should render a warning for a fee that is too LOW 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -193,7 +193,7 @@ exports[`FeeWarning should render a warning for a fee that is too LOW 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="FeeWarning__cancel-button"
               type="button"
             >
@@ -204,7 +204,7 @@ exports[`FeeWarning should render a warning for a fee that is too LOW 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="FeeWarning__continue-button"
               type="button"
             >

--- a/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
+++ b/src/domains/transaction/components/IpfsDetail/__snapshots__/IpfsDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`IpfsDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -385,7 +385,7 @@ exports[`IpfsDetail should render a modal without a wallet alias 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -740,7 +740,7 @@ exports[`IpfsDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
+++ b/src/domains/transaction/components/LegacyMagistrateDetail/__snapshots__/LegacyMagistrateDetail.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -351,7 +351,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -685,7 +685,7 @@ exports[`LegacyMagistrateDetail Legacy Bridgechain Transactions should render a 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1019,7 +1019,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1353,7 +1353,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1687,7 +1687,7 @@ exports[`LegacyMagistrateDetail Legacy Business Transactions should render a leg
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiPaymentDetail/__snapshots__/MultiPaymentDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`MultiPaymentDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -436,7 +436,7 @@ exports[`MultiPaymentDetail should render with recipients 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureDetail.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`MultiSignatureDetail should fail to broadcast transaction 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -411,7 +411,7 @@ exports[`MultiSignatureDetail should fail to broadcast transaction 1`] = `
                 class="flex justify-center mt-8 space-x-2"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="MultiSignatureDetail__broadcast"
                   type="submit"
                 >
@@ -448,7 +448,7 @@ exports[`MultiSignatureDetail should not show send button when waiting for confi
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -864,7 +864,7 @@ exports[`MultiSignatureDetail should render summary step for ipfs 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1227,7 +1227,7 @@ exports[`MultiSignatureDetail should render summary step for multi payment 1`] =
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1800,7 +1800,7 @@ exports[`MultiSignatureDetail should render summary step for multi signature 1`]
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2133,7 +2133,7 @@ exports[`MultiSignatureDetail should render summary step for transfer 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2549,7 +2549,7 @@ exports[`MultiSignatureDetail should render summary step for unvote 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2979,7 +2979,7 @@ exports[`MultiSignatureDetail should render summary step for vote 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3409,7 +3409,7 @@ exports[`MultiSignatureDetail should show paginator when able to sign 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3803,7 +3803,7 @@ exports[`MultiSignatureDetail should show paginator when able to sign 1`] = `
                 class="flex justify-end mt-8 space-x-2"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="Paginator__cancel"
                   type="button"
                 >
@@ -3814,7 +3814,7 @@ exports[`MultiSignatureDetail should show paginator when able to sign 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="Paginator__sign"
                   type="button"
                 >
@@ -3851,7 +3851,7 @@ exports[`MultiSignatureDetail should show send button when able to broadcast 1`]
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -4245,7 +4245,7 @@ exports[`MultiSignatureDetail should show send button when able to broadcast 1`]
                 class="flex justify-center mt-8 space-x-2"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                   data-testid="MultiSignatureDetail__broadcast"
                   type="submit"
                 >
@@ -4282,7 +4282,7 @@ exports[`MultiSignatureDetail should sign transaction after authentication page 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureDetail/__snapshots__/MultiSignatureRegistrationDetail.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`MultiSignatureRegistrationDetail should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/__snapshots__/MultiSignatureRegistrationForm.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`MultiSignature Registration Form should render form step 1`] = `
                 </div>
               </fieldset>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn my-4 w-full"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr my-4 w-full"
                 disabled=""
                 type="button"
               >
@@ -275,7 +275,7 @@ exports[`MultiSignature Registration Form should render form step 1`] = `
                           class="py-6 w-20 text-right"
                         >
                           <button
-                            class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                            class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                             data-testid="recipient-list__remove-recipient"
                             type="button"
                           >

--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/__snapshots__/AddParticipant.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`Add Participant should fail if cannot find the address remotely 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax my-4 w-full"
         type="button"
       >
         <div
@@ -286,7 +286,7 @@ exports[`Add Participant should fail if cannot find the address remotely 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -478,7 +478,7 @@ exports[`Add Participant should fail to find 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax my-4 w-full"
         type="button"
       >
         <div
@@ -605,7 +605,7 @@ exports[`Add Participant should fail to find 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -797,7 +797,7 @@ exports[`Add Participant should fail with cold wallet 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax my-4 w-full"
         type="button"
       >
         <div
@@ -924,7 +924,7 @@ exports[`Add Participant should fail with cold wallet 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -1072,7 +1072,7 @@ exports[`Add Participant should render custom participants 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 kwcZQn my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr my-4 w-full"
         disabled=""
         type="button"
       >
@@ -1200,7 +1200,7 @@ exports[`Add Participant should render custom participants 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -1444,7 +1444,7 @@ exports[`Add Participant should work with a remote wallet 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax my-4 w-full"
         type="button"
       >
         <div
@@ -1571,7 +1571,7 @@ exports[`Add Participant should work with a remote wallet 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -1646,7 +1646,7 @@ exports[`Add Participant should work with a remote wallet 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -1890,7 +1890,7 @@ exports[`Add Participant should work with an imported wallet 1`] = `
         </div>
       </fieldset>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV my-4 w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax my-4 w-full"
         type="button"
       >
         <div
@@ -2017,7 +2017,7 @@ exports[`Add Participant should work with an imported wallet 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >
@@ -2092,7 +2092,7 @@ exports[`Add Participant should work with an imported wallet 1`] = `
                   class="py-6 w-20 text-right"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                     data-testid="recipient-list__remove-recipient"
                     type="button"
                   >

--- a/src/domains/transaction/components/RecipientList/__snapshots__/RecipientList.test.tsx.snap
+++ b/src/domains/transaction/components/RecipientList/__snapshots__/RecipientList.test.tsx.snap
@@ -500,7 +500,7 @@ exports[`RecipientList should render editable 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -606,7 +606,7 @@ exports[`RecipientList should render editable 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -712,7 +712,7 @@ exports[`RecipientList should render editable 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -807,7 +807,7 @@ exports[`RecipientList should render editable 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -1342,7 +1342,7 @@ exports[`RecipientList should render without amount column 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -1428,7 +1428,7 @@ exports[`RecipientList should render without amount column 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -1514,7 +1514,7 @@ exports[`RecipientList should render without amount column 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >
@@ -1589,7 +1589,7 @@ exports[`RecipientList should render without amount column 1`] = `
               class="py-6 w-20 text-right"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                 data-testid="recipient-list__remove-recipient"
                 type="button"
               >

--- a/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
+++ b/src/domains/transaction/components/SearchRecipient/__snapshots__/SearchRecipient.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SearchRecipient should not render recipient if not in same network 1`] 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -238,7 +238,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -491,7 +491,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -565,7 +565,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -639,7 +639,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -713,7 +713,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -787,7 +787,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -861,7 +861,7 @@ exports[`SearchRecipient should not render recipient if not in same network 2`] 
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -902,7 +902,7 @@ exports[`SearchRecipient should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1155,7 +1155,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1229,7 +1229,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1303,7 +1303,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1377,7 +1377,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1451,7 +1451,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1525,7 +1525,7 @@ exports[`SearchRecipient should render a modal 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1566,7 +1566,7 @@ exports[`SearchRecipient should render a modal with custom title and description
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1819,7 +1819,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1893,7 +1893,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -1967,7 +1967,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -2041,7 +2041,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -2115,7 +2115,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >
@@ -2189,7 +2189,7 @@ exports[`SearchRecipient should render a modal with custom title and description
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="RecipientListItem__select-button"
                           type="button"
                         >

--- a/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureDetail/__snapshots__/SecondSignatureDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SecondSignatureDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -353,7 +353,7 @@ exports[`SecondSignatureDetail should render a modal without a wallet alias 1`] 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -676,7 +676,7 @@ exports[`SecondSignatureDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
+++ b/src/domains/transaction/components/SecondSignatureRegistrationForm/__snapshots__/SecondSignatureRegistrationForm.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`SecondSignatureRegistrationForm backup step should render 1`] = `
               data-testid="clipboard__wrapper"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="SecondSignature__copy"
                 type="button"
               >
@@ -154,7 +154,7 @@ exports[`SecondSignatureRegistrationForm backup step should render 1`] = `
             class="flex justify-end w-full"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV flex items-center space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex items-center space-x-2"
               data-testid="SecondSignature__download"
               type="button"
             >

--- a/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionDetailModal/__snapshots__/TransactionDetailModal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TransactionDetailModal should render a delegate registration modal 1`] 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -373,7 +373,7 @@ exports[`TransactionDetailModal should render a delegate resignation modal 1`] =
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -727,7 +727,7 @@ exports[`TransactionDetailModal should render a entity modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1062,7 +1062,7 @@ exports[`TransactionDetailModal should render a ipfs modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1429,7 +1429,7 @@ exports[`TransactionDetailModal should render a legacy magistrate modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1764,7 +1764,7 @@ exports[`TransactionDetailModal should render a multi payment modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2182,7 +2182,7 @@ exports[`TransactionDetailModal should render a multi signature modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2584,7 +2584,7 @@ exports[`TransactionDetailModal should render a second signature modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -2919,7 +2919,7 @@ exports[`TransactionDetailModal should render a transfer modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3379,7 +3379,7 @@ exports[`TransactionDetailModal should render a unvote modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -3876,7 +3876,7 @@ exports[`TransactionDetailModal should render a vote modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/TransactionTable/SignedTransactionTable/__snapshots__/SignedTransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/SignedTransactionTable/__snapshots__/SignedTransactionTable.test.tsx.snap
@@ -2606,7 +2606,7 @@ exports[`Signed Transaction Table should show the sign button 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="TransactionRow__sign"
                   type="button"
                 >

--- a/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/__snapshots__/TransactionTable.test.tsx.snap
@@ -4431,7 +4431,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="TransactionRow__sign"
                   type="button"
                 >
@@ -4630,7 +4630,7 @@ exports[`TransactionTable should render with sign 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="TransactionRow__sign"
                   type="button"
                 >

--- a/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
+++ b/src/domains/transaction/components/TransferDetail/__snapshots__/TransferDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TransferDetail should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -478,7 +478,7 @@ exports[`TransferDetail should render as confirmed 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -939,7 +939,7 @@ exports[`TransferDetail should render as not is sent 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1398,7 +1398,7 @@ exports[`TransferDetail should render with wallet alias 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
+++ b/src/domains/transaction/components/VoteDetail/__snapshots__/VoteDetail.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`VoteDetail should render a modal with unvotes 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -450,7 +450,7 @@ exports[`VoteDetail should render a modal with votes 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -881,7 +881,7 @@ exports[`VoteDetail should render a modal with votes and unvotes 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -172,7 +172,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -517,7 +517,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__back-button"
                     type="button"
                   >
@@ -528,7 +528,7 @@ exports[`SendDelegateResignation Delegate Resignation should change fee 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="SendDelegateResignation__continue-button"
                     type="button"
                   >
@@ -652,7 +652,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -691,7 +691,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -721,7 +721,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1066,7 +1066,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__back-button"
                     type="button"
                   >
@@ -1077,7 +1077,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 1st step 1`]
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="SendDelegateResignation__continue-button"
                     type="button"
                   >
@@ -1201,7 +1201,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1240,7 +1240,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1270,7 +1270,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1620,7 +1620,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__back-button"
                     type="button"
                   >
@@ -1631,7 +1631,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 2nd step 1`]
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="SendDelegateResignation__continue-button"
                     type="button"
                   >
@@ -1755,7 +1755,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1794,7 +1794,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1824,7 +1824,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2092,7 +2092,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__back-button"
                     type="button"
                   >
@@ -2103,7 +2103,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn space-x-2"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr space-x-2"
                     data-testid="SendDelegateResignation__send-button"
                     disabled=""
                     type="submit"
@@ -2239,7 +2239,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2278,7 +2278,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2308,7 +2308,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2472,7 +2472,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step 1`]
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -2483,7 +2483,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step 1`]
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >
@@ -2612,7 +2612,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2651,7 +2651,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2681,7 +2681,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2845,7 +2845,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -2856,7 +2856,7 @@ exports[`SendDelegateResignation Delegate Resignation should show error step and
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >
@@ -2985,7 +2985,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3024,7 +3024,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3054,7 +3054,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3337,7 +3337,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__back-button"
                     type="button"
                   >
@@ -3348,7 +3348,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn space-x-2"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr space-x-2"
                     data-testid="SendDelegateResignation__send-button"
                     disabled=""
                     type="submit"
@@ -3484,7 +3484,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3523,7 +3523,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3553,7 +3553,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3959,7 +3959,7 @@ exports[`SendDelegateResignation Delegate Resignation should successfully sign a
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendDelegateResignation__wallet-button"
                     type="button"
                   >

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -172,7 +172,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -401,7 +401,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                   class="flex justify-end mt-10 space-x-2"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendIpfs__button--back"
                     type="button"
                   >
@@ -412,7 +412,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendIpfs__button--submit"
                     disabled=""
                     type="submit"
@@ -1110,7 +1110,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1149,7 +1149,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1179,7 +1179,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1551,7 +1551,7 @@ exports[`SendIpfs should send an IPFS transaction and go back to wallet page 1`]
                   class="flex justify-end mt-10 space-x-2"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV block"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax block"
                     data-testid="SendIpfs__button--back-to-wallet"
                     type="button"
                   >
@@ -1677,7 +1677,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1716,7 +1716,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1746,7 +1746,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2249,7 +2249,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                   class="flex justify-end mt-10 space-x-2"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendIpfs__button--back"
                     type="button"
                   >
@@ -2260,7 +2260,7 @@ exports[`SendIpfs should show an error if an invalid IPFS hash is entered 1`] = 
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendIpfs__button--continue"
                     disabled=""
                     type="button"
@@ -2385,7 +2385,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2424,7 +2424,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2454,7 +2454,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2618,7 +2618,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -2629,7 +2629,7 @@ exports[`SendIpfs should show error step and go back 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >

--- a/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
+++ b/src/domains/transaction/pages/SendRegistration/__snapshots__/SendRegistration.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`Registration should show error step and go back 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -144,7 +144,7 @@ exports[`Registration should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -174,7 +174,7 @@ exports[`Registration should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -338,7 +338,7 @@ exports[`Registration should show error step and go back 1`] = `
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -349,7 +349,7 @@ exports[`Registration should show error step and go back 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -172,7 +172,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -561,7 +561,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                               class="flex items-stretch select-buttons"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                                 data-testid="AddRecipient__single"
                                 type="button"
                               >
@@ -572,7 +572,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                                 </div>
                               </button>
                               <button
-                                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                                 data-testid="AddRecipient__multi"
                                 type="button"
                               >
@@ -916,7 +916,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -927,7 +927,7 @@ exports[`SendTransfer should display disabled address selection input if selecte
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--continue"
                     disabled=""
                     type="button"
@@ -1052,7 +1052,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1091,7 +1091,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1121,7 +1121,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1350,7 +1350,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -1361,7 +1361,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--submit"
                     disabled=""
                     type="button"
@@ -1614,7 +1614,7 @@ exports[`SendTransfer should render 1st step with custom deeplink values and use
               class="flex items-stretch select-buttons"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1"
                 data-testid="AddRecipient__single"
                 type="button"
               >
@@ -1625,7 +1625,7 @@ exports[`SendTransfer should render 1st step with custom deeplink values and use
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1 border-l-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1 border-l-0"
                 data-testid="AddRecipient__multi"
                 type="button"
               >
@@ -1800,7 +1800,7 @@ exports[`SendTransfer should render 1st step with custom deeplink values and use
               </fieldset>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn mt-4 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr mt-4 w-full"
               data-testid="AddRecipient__add-button"
               disabled=""
               type="button"
@@ -1963,7 +1963,7 @@ exports[`SendTransfer should render 1st step with custom deeplink values and use
                         class="py-6 w-20 text-right"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                           data-testid="recipient-list__remove-recipient"
                           type="button"
                         >
@@ -2188,7 +2188,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2227,7 +2227,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2257,7 +2257,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2661,7 +2661,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                               class="flex items-stretch select-buttons"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                                 data-testid="AddRecipient__single"
                                 type="button"
                               >
@@ -2672,7 +2672,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                                 </div>
                               </button>
                               <button
-                                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                                 data-testid="AddRecipient__multi"
                                 type="button"
                               >
@@ -3024,7 +3024,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -3035,7 +3035,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--continue"
                     disabled=""
                     type="button"
@@ -3160,7 +3160,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3199,7 +3199,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3229,7 +3229,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3633,7 +3633,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                               class="flex items-stretch select-buttons"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                                 data-testid="AddRecipient__single"
                                 type="button"
                               >
@@ -3644,7 +3644,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                                 </div>
                               </button>
                               <button
-                                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                                 data-testid="AddRecipient__multi"
                                 type="button"
                               >
@@ -3996,7 +3996,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -4007,7 +4007,7 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--continue"
                     disabled=""
                     type="button"
@@ -4233,7 +4233,7 @@ exports[`SendTransfer should render form step 1`] = `
               class="flex items-stretch select-buttons"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                 data-testid="AddRecipient__single"
                 type="button"
               >
@@ -4244,7 +4244,7 @@ exports[`SendTransfer should render form step 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                 data-testid="AddRecipient__multi"
                 type="button"
               >
@@ -4728,7 +4728,7 @@ exports[`SendTransfer should render form step with deeplink values and use them 
               class="flex items-stretch select-buttons"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1"
                 data-testid="AddRecipient__single"
                 type="button"
               >
@@ -4739,7 +4739,7 @@ exports[`SendTransfer should render form step with deeplink values and use them 
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1 border-l-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1 border-l-0"
                 data-testid="AddRecipient__multi"
                 type="button"
               >
@@ -4914,7 +4914,7 @@ exports[`SendTransfer should render form step with deeplink values and use them 
               </fieldset>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn mt-4 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr mt-4 w-full"
               data-testid="AddRecipient__add-button"
               disabled=""
               type="button"
@@ -5077,7 +5077,7 @@ exports[`SendTransfer should render form step with deeplink values and use them 
                         class="py-6 w-20 text-right"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 hrpPWq"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
                           data-testid="recipient-list__remove-recipient"
                           type="button"
                         >
@@ -5403,7 +5403,7 @@ exports[`SendTransfer should render form step without test networks 1`] = `
               class="flex items-stretch select-buttons"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                 data-testid="AddRecipient__single"
                 type="button"
               >
@@ -5414,7 +5414,7 @@ exports[`SendTransfer should render form step without test networks 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                 data-testid="AddRecipient__multi"
                 type="button"
               >
@@ -5797,7 +5797,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5836,7 +5836,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -5866,7 +5866,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -6130,7 +6130,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -6141,7 +6141,7 @@ exports[`SendTransfer should render network selection without selected wallet 1`
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--continue"
                     disabled=""
                     type="button"
@@ -6984,7 +6984,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -7023,7 +7023,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -7053,7 +7053,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -7460,7 +7460,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                               class="flex items-stretch select-buttons"
                             >
                               <button
-                                class="Button__StyledButton-mdtvtf-0 dznQvQ flex-1"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 eXZVBc flex-1"
                                 data-testid="AddRecipient__single"
                                 type="button"
                               >
@@ -7471,7 +7471,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                                 </div>
                               </button>
                               <button
-                                class="Button__StyledButton-mdtvtf-0 eJuaWR flex-1 border-l-0"
+                                class="OriginalButton__StyledButton-sc-1y2wptt-0 ehNoEt flex-1 border-l-0"
                                 data-testid="AddRecipient__multi"
                                 type="button"
                               >
@@ -7827,7 +7827,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -7838,7 +7838,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendTransfer__button--continue"
                     disabled=""
                     type="button"
@@ -7963,7 +7963,7 @@ exports[`SendTransfer should select cryptoasset first and see select address inp
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -8002,7 +8002,7 @@ exports[`SendTransfer should select cryptoasset first and see select address inp
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -8032,7 +8032,7 @@ exports[`SendTransfer should select cryptoasset first and see select address inp
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -8314,7 +8314,7 @@ exports[`SendTransfer should select cryptoasset first and see select address inp
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendTransfer__button--back"
                     type="button"
                   >
@@ -8325,7 +8325,7 @@ exports[`SendTransfer should select cryptoasset first and see select address inp
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="SendTransfer__button--continue"
                     type="button"
                   >
@@ -8449,7 +8449,7 @@ exports[`SendTransfer should send a single transfer 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -8488,7 +8488,7 @@ exports[`SendTransfer should send a single transfer 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -8518,7 +8518,7 @@ exports[`SendTransfer should send a single transfer 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -8951,7 +8951,7 @@ exports[`SendTransfer should send a single transfer 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV block"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax block"
                     data-testid="SendTransfer__button--back-to-wallet"
                     type="button"
                   >
@@ -9077,7 +9077,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -9116,7 +9116,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -9146,7 +9146,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -9579,7 +9579,7 @@ exports[`SendTransfer should send a single transfer and show unconfirmed transac
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV block"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax block"
                     data-testid="SendTransfer__button--back-to-wallet"
                     type="button"
                   >
@@ -9705,7 +9705,7 @@ exports[`SendTransfer should send a single transfer with a high fee by confirmin
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -9744,7 +9744,7 @@ exports[`SendTransfer should send a single transfer with a high fee by confirmin
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -9774,7 +9774,7 @@ exports[`SendTransfer should send a single transfer with a high fee by confirmin
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -10207,7 +10207,7 @@ exports[`SendTransfer should send a single transfer with a high fee by confirmin
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV block"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax block"
                     data-testid="SendTransfer__button--back-to-wallet"
                     type="button"
                   >
@@ -10333,7 +10333,7 @@ exports[`SendTransfer should send a single transfer with a low fee by confirming
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -10372,7 +10372,7 @@ exports[`SendTransfer should send a single transfer with a low fee by confirming
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -10402,7 +10402,7 @@ exports[`SendTransfer should send a single transfer with a low fee by confirming
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -10835,7 +10835,7 @@ exports[`SendTransfer should send a single transfer with a low fee by confirming
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV block"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax block"
                     data-testid="SendTransfer__button--back-to-wallet"
                     type="button"
                   >
@@ -10961,7 +10961,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -11000,7 +11000,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -11030,7 +11030,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -11194,7 +11194,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -11205,7 +11205,7 @@ exports[`SendTransfer should show error step and go back 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -148,7 +148,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -178,7 +178,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -638,7 +638,7 @@ exports[`SendVote should send a unvote transaction 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendVote__button--back-to-wallet"
                     type="button"
                   >
@@ -762,7 +762,7 @@ exports[`SendVote should send a vote transaction 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -801,7 +801,7 @@ exports[`SendVote should send a vote transaction 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -831,7 +831,7 @@ exports[`SendVote should send a vote transaction 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1291,7 +1291,7 @@ exports[`SendVote should send a vote transaction 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendVote__button--back-to-wallet"
                     type="button"
                   >
@@ -1415,7 +1415,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1454,7 +1454,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1484,7 +1484,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1713,7 +1713,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                   class="flex justify-end mt-10 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="SendVote__button--back"
                     type="button"
                   >
@@ -1724,7 +1724,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     data-testid="SendVote__button--submit"
                     disabled=""
                     type="submit"
@@ -1860,7 +1860,7 @@ exports[`SendVote should show error step and go back 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1899,7 +1899,7 @@ exports[`SendVote should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1929,7 +1929,7 @@ exports[`SendVote should show error step and go back 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2093,7 +2093,7 @@ exports[`SendVote should show error step and go back 1`] = `
                       class="flex justify-end space-x-3"
                     >
                       <button
-                        class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                         data-testid="ErrorStep__wallet-button"
                         type="button"
                       >
@@ -2104,7 +2104,7 @@ exports[`SendVote should show error step and go back 1`] = `
                         </div>
                       </button>
                       <button
-                        class="Button__StyledButton-mdtvtf-0 ePkfgQ space-x-2"
+                        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc space-x-2"
                         data-testid="ErrorStep__repeat-button"
                         type="button"
                       >

--- a/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRow.test.tsx.snap
+++ b/src/domains/vote/components/AddressTable/AddressRow/__snapshots__/AddressRow.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`AddressRow should emit action on select button 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -316,7 +316,7 @@ exports[`AddressRow should render 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -496,7 +496,7 @@ exports[`AddressRow should render for a multisignature wallet 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -719,7 +719,7 @@ exports[`AddressRow should render when the maximum votes is greater than 1 1`] =
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -933,7 +933,7 @@ exports[`AddressRow should render when the wallet has many votes 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -1100,7 +1100,7 @@ exports[`AddressRow should render when wallet hasn't voted 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -1196,7 +1196,7 @@ exports[`AddressRow should render when wallet hasn't voted 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-1"
               type="button"
             >
@@ -1363,7 +1363,7 @@ exports[`AddressRow should render when wallet not found for votes 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -1459,7 +1459,7 @@ exports[`AddressRow should render when wallet not found for votes 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-1"
               type="button"
             >
@@ -1626,7 +1626,7 @@ exports[`AddressRow should set dark shadow color on mouse events 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >
@@ -1793,7 +1793,7 @@ exports[`AddressRow should set light shadow color on mouse events 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="AddressRow__select-0"
               type="button"
             >

--- a/src/domains/vote/components/AddressTable/__snapshots__/AddressTable.test.tsx.snap
+++ b/src/domains/vote/components/AddressTable/__snapshots__/AddressTable.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`AddressTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="AddressRow__select-0"
                   type="button"
                 >
@@ -618,7 +618,7 @@ exports[`AddressTable should render when the maximum votes is greater than 1 1`]
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="AddressRow__select-0"
                   type="button"
                 >

--- a/src/domains/vote/components/DelegateTable/DelegateRow/__snapshots__/DelegateRow.test.tsx.snap
+++ b/src/domains/vote/components/DelegateTable/DelegateRow/__snapshots__/DelegateRow.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`DelegateRow should emit action on select button 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               color="primary"
               data-testid="DelegateRow__toggle-0"
               type="button"
@@ -153,7 +153,7 @@ exports[`DelegateRow should render 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               color="primary"
               data-testid="DelegateRow__toggle-0"
               type="button"
@@ -239,7 +239,7 @@ exports[`DelegateRow should render the selected delegate 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               color="success"
               data-testid="DelegateRow__toggle-0"
               type="button"
@@ -335,7 +335,7 @@ exports[`DelegateRow should render the selected vote 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               color="primary"
               data-testid="DelegateRow__toggle-0"
               type="button"
@@ -412,7 +412,7 @@ exports[`DelegateRow should render the selected vote 1`] = `
             class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               color="primary"
               data-testid="DelegateRow__toggle-1"
               type="button"
@@ -490,7 +490,7 @@ exports[`DelegateRow should render the selected vote 1`] = `
           >
             <span>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 color="primary"
                 data-testid="DelegateRow__toggle-2"
                 disabled=""

--- a/src/domains/vote/components/DelegateTable/__snapshots__/DelegateTable.test.tsx.snap
+++ b/src/domains/vote/components/DelegateTable/__snapshots__/DelegateTable.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`DelegateTable should emit action on continue button to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-danger-50 dark:bg-theme-danger-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="danger"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -296,7 +296,7 @@ exports[`DelegateTable should emit action on continue button to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -373,7 +373,7 @@ exports[`DelegateTable should emit action on continue button to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -563,7 +563,7 @@ exports[`DelegateTable should emit action on continue button to unvote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -790,7 +790,7 @@ exports[`DelegateTable should emit action on continue button to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -867,7 +867,7 @@ exports[`DelegateTable should emit action on continue button to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -944,7 +944,7 @@ exports[`DelegateTable should emit action on continue button to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -1134,7 +1134,7 @@ exports[`DelegateTable should emit action on continue button to vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -1361,7 +1361,7 @@ exports[`DelegateTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -1438,7 +1438,7 @@ exports[`DelegateTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -1515,7 +1515,7 @@ exports[`DelegateTable should render 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -1705,7 +1705,7 @@ exports[`DelegateTable should render 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -3070,7 +3070,7 @@ exports[`DelegateTable should render loading state 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -3298,7 +3298,7 @@ exports[`DelegateTable should render pagination 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -3342,7 +3342,7 @@ exports[`DelegateTable should render pagination 1`] = `
           </div>
         </div>
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Pagination__next"
           type="button"
         >
@@ -3533,7 +3533,7 @@ exports[`DelegateTable should render pagination 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -3761,7 +3761,7 @@ exports[`DelegateTable should render with a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -3838,7 +3838,7 @@ exports[`DelegateTable should render with a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -3915,7 +3915,7 @@ exports[`DelegateTable should render with a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -4105,7 +4105,7 @@ exports[`DelegateTable should render with a delegate to unvote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -4342,7 +4342,7 @@ exports[`DelegateTable should render with a delegate to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-danger-50 dark:bg-theme-danger-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="danger"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -4419,7 +4419,7 @@ exports[`DelegateTable should render with a delegate to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -4497,7 +4497,7 @@ exports[`DelegateTable should render with a delegate to unvote/vote 1`] = `
               >
                 <span>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     color="primary"
                     data-testid="DelegateRow__toggle-2"
                     disabled=""
@@ -4689,7 +4689,7 @@ exports[`DelegateTable should render with a delegate to unvote/vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -4916,7 +4916,7 @@ exports[`DelegateTable should render with a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -4993,7 +4993,7 @@ exports[`DelegateTable should render with a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -5070,7 +5070,7 @@ exports[`DelegateTable should render with a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -5260,7 +5260,7 @@ exports[`DelegateTable should render with a delegate to vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -5526,7 +5526,7 @@ exports[`DelegateTable should select a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -5603,7 +5603,7 @@ exports[`DelegateTable should select a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -5680,7 +5680,7 @@ exports[`DelegateTable should select a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -5870,7 +5870,7 @@ exports[`DelegateTable should select a delegate to unvote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -6108,7 +6108,7 @@ exports[`DelegateTable should select a delegate to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-danger-50 dark:bg-theme-danger-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="danger"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -6185,7 +6185,7 @@ exports[`DelegateTable should select a delegate to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -6263,7 +6263,7 @@ exports[`DelegateTable should select a delegate to unvote/vote 1`] = `
               >
                 <span>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                     color="primary"
                     data-testid="DelegateRow__toggle-2"
                     disabled=""
@@ -6455,7 +6455,7 @@ exports[`DelegateTable should select a delegate to unvote/vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -6682,7 +6682,7 @@ exports[`DelegateTable should select a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -6759,7 +6759,7 @@ exports[`DelegateTable should select a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -6836,7 +6836,7 @@ exports[`DelegateTable should select a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -7026,7 +7026,7 @@ exports[`DelegateTable should select a delegate to vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -7264,7 +7264,7 @@ exports[`DelegateTable should select multiple delegates to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-danger-50 dark:bg-theme-danger-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="danger"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -7341,7 +7341,7 @@ exports[`DelegateTable should select multiple delegates to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -7418,7 +7418,7 @@ exports[`DelegateTable should select multiple delegates to unvote/vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-success-50 dark:bg-theme-success-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="success"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -7608,7 +7608,7 @@ exports[`DelegateTable should select multiple delegates to unvote/vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
               data-testid="DelegateTable__continue-button"
               type="button"
             >
@@ -7845,7 +7845,7 @@ exports[`DelegateTable should unselect a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -7922,7 +7922,7 @@ exports[`DelegateTable should unselect a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -7999,7 +7999,7 @@ exports[`DelegateTable should unselect a delegate to unvote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -8189,7 +8189,7 @@ exports[`DelegateTable should unselect a delegate to unvote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"
@@ -8427,7 +8427,7 @@ exports[`DelegateTable should unselect a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-0"
                   type="button"
@@ -8504,7 +8504,7 @@ exports[`DelegateTable should unselect a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-1"
                   type="button"
@@ -8581,7 +8581,7 @@ exports[`DelegateTable should unselect a delegate to vote 1`] = `
                 class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   color="primary"
                   data-testid="DelegateRow__toggle-2"
                   type="button"
@@ -8771,7 +8771,7 @@ exports[`DelegateTable should unselect a delegate to vote 1`] = `
           </div>
           <span>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
               data-testid="DelegateTable__continue-button"
               disabled=""
               type="button"

--- a/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
+++ b/src/domains/vote/pages/Votes/__snapshots__/Votes.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`Votes should filter current delegates 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -146,7 +146,7 @@ exports[`Votes should filter current delegates 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -176,7 +176,7 @@ exports[`Votes should filter current delegates 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -655,7 +655,7 @@ exports[`Votes should filter current delegates 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-0"
                           type="button"
@@ -845,7 +845,7 @@ exports[`Votes should filter current delegates 1`] = `
                   </div>
                   <span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="DelegateTable__continue-button"
                       disabled=""
                       type="button"
@@ -971,7 +971,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1010,7 +1010,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1040,7 +1040,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1453,7 +1453,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-0"
                           type="button"
@@ -1530,7 +1530,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-1"
                           type="button"
@@ -1607,7 +1607,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-2"
                           type="button"
@@ -1684,7 +1684,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-3"
                           type="button"
@@ -1761,7 +1761,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-4"
                           type="button"
@@ -1951,7 +1951,7 @@ exports[`Votes should hide testnet wallet if disabled from profile setting 1`] =
                   </div>
                   <span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="DelegateTable__continue-button"
                       disabled=""
                       type="button"
@@ -2081,7 +2081,7 @@ exports[`Votes should render 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2120,7 +2120,7 @@ exports[`Votes should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2150,7 +2150,7 @@ exports[`Votes should render 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2575,7 +2575,7 @@ exports[`Votes should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-primary-50 dark:bg-theme-primary-900"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-0"
                           type="button"
@@ -2652,7 +2652,7 @@ exports[`Votes should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-1"
                           type="button"
@@ -2729,7 +2729,7 @@ exports[`Votes should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-2"
                           type="button"
@@ -2806,7 +2806,7 @@ exports[`Votes should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-3"
                           type="button"
@@ -2883,7 +2883,7 @@ exports[`Votes should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-4"
                           type="button"
@@ -3073,7 +3073,7 @@ exports[`Votes should render 1`] = `
                   </div>
                   <span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="DelegateTable__continue-button"
                       disabled=""
                       type="button"
@@ -3199,7 +3199,7 @@ exports[`Votes should render with no wallets 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3231,7 +3231,7 @@ exports[`Votes should render with no wallets 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -3262,7 +3262,7 @@ exports[`Votes should render with no wallets 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -3484,7 +3484,7 @@ exports[`Votes should render with no wallets 1`] = `
                   class="flex -m-3 space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     type="button"
                   >
                     <div
@@ -3509,7 +3509,7 @@ exports[`Votes should render with no wallets 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     type="button"
                   >
                     <div
@@ -3647,7 +3647,7 @@ exports[`Votes should select a delegate 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3686,7 +3686,7 @@ exports[`Votes should select a delegate 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3716,7 +3716,7 @@ exports[`Votes should select a delegate 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -4141,7 +4141,7 @@ exports[`Votes should select a delegate 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end bg-theme-danger-50 dark:bg-theme-danger-900"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="danger"
                           data-testid="DelegateRow__toggle-0"
                           type="button"
@@ -4218,7 +4218,7 @@ exports[`Votes should select a delegate 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-1"
                           type="button"
@@ -4295,7 +4295,7 @@ exports[`Votes should select a delegate 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-2"
                           type="button"
@@ -4372,7 +4372,7 @@ exports[`Votes should select a delegate 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-3"
                           type="button"
@@ -4449,7 +4449,7 @@ exports[`Votes should select a delegate 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-4"
                           type="button"
@@ -4639,7 +4639,7 @@ exports[`Votes should select a delegate 1`] = `
                   </div>
                   <span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="DelegateTable__continue-button"
                       type="button"
                     >
@@ -4766,7 +4766,7 @@ exports[`Votes should select an address without vote 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -4805,7 +4805,7 @@ exports[`Votes should select an address without vote 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -4835,7 +4835,7 @@ exports[`Votes should select an address without vote 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -5250,7 +5250,7 @@ exports[`Votes should select an address without vote 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-0"
                           type="button"
@@ -5327,7 +5327,7 @@ exports[`Votes should select an address without vote 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-1"
                           type="button"
@@ -5404,7 +5404,7 @@ exports[`Votes should select an address without vote 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-2"
                           type="button"
@@ -5481,7 +5481,7 @@ exports[`Votes should select an address without vote 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-3"
                           type="button"
@@ -5558,7 +5558,7 @@ exports[`Votes should select an address without vote 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end "
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           color="primary"
                           data-testid="DelegateRow__toggle-4"
                           type="button"
@@ -5748,7 +5748,7 @@ exports[`Votes should select an address without vote 1`] = `
                   </div>
                   <span>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="DelegateTable__continue-button"
                       disabled=""
                       type="button"
@@ -5874,7 +5874,7 @@ exports[`Votes should select favorites option in the wallets display type 1`] = 
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5913,7 +5913,7 @@ exports[`Votes should select favorites option in the wallets display type 1`] = 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -5943,7 +5943,7 @@ exports[`Votes should select favorites option in the wallets display type 1`] = 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -6389,7 +6389,7 @@ exports[`Votes should select ledger option in the wallets display type 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -6428,7 +6428,7 @@ exports[`Votes should select ledger option in the wallets display type 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -6458,7 +6458,7 @@ exports[`Votes should select ledger option in the wallets display type 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -6904,7 +6904,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -6943,7 +6943,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -6973,7 +6973,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -7613,7 +7613,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="AddressRow__select-0"
                           type="button"
                         >
@@ -7720,7 +7720,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="AddressRow__select-1"
                           type="button"
                         >
@@ -7816,7 +7816,7 @@ exports[`Votes should toggle network selection from network filters 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="AddressRow__select-2"
                           type="button"
                         >

--- a/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
+++ b/src/domains/wallet/components/DeleteWallet/__snapshots__/DeleteWallet.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`DeleteWallet should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -63,7 +63,7 @@ exports[`DeleteWallet should render a modal 1`] = `
             class="flex justify-end mt-8 space-x-3"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
               data-testid="DeleteResource__cancel-button"
               type="button"
             >
@@ -74,7 +74,7 @@ exports[`DeleteWallet should render a modal 1`] = `
               </div>
             </button>
             <button
-              class="Button__StyledButton-mdtvtf-0 hrpPWq"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hLYMjm"
               data-testid="DeleteResource__submit-button"
               type="submit"
             >

--- a/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
+++ b/src/domains/wallet/components/ReceiveFunds/__snapshots__/ReceiveFunds.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`ReceiveFunds should not render qrcode without an address 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -135,7 +135,7 @@ exports[`ReceiveFunds should not render qrcode without an address 1`] = `
           </div>
           <div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-8 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-8 w-full"
               data-testid="ReceiveFunds__toggle"
               type="button"
             >
@@ -173,7 +173,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -321,7 +321,7 @@ exports[`ReceiveFunds should render with a wallet name 1`] = `
           </div>
           <div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-8 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-8 w-full"
               data-testid="ReceiveFunds__toggle"
               type="button"
             >
@@ -366,7 +366,7 @@ exports[`ReceiveFunds should render without a wallet name 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -491,7 +491,7 @@ exports[`ReceiveFunds should render without a wallet name 1`] = `
           </div>
           <div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-8 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-8 w-full"
               data-testid="ReceiveFunds__toggle"
               type="button"
             >

--- a/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
+++ b/src/domains/wallet/components/SearchWallet/__snapshots__/SearchWallet.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`SearchWallet uses fiat value = false should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -260,7 +260,7 @@ exports[`SearchWallet uses fiat value = false should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-0"
                           type="button"
                         >
@@ -354,7 +354,7 @@ exports[`SearchWallet uses fiat value = false should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-1"
                           type="button"
                         >
@@ -395,7 +395,7 @@ exports[`SearchWallet uses fiat value = false should render with the default exc
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -638,7 +638,7 @@ exports[`SearchWallet uses fiat value = false should render with the default exc
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-0"
                           type="button"
                         >
@@ -732,7 +732,7 @@ exports[`SearchWallet uses fiat value = false should render with the default exc
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-1"
                           type="button"
                         >
@@ -773,7 +773,7 @@ exports[`SearchWallet uses fiat value = true should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1057,7 +1057,7 @@ exports[`SearchWallet uses fiat value = true should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-0"
                           type="button"
                         >
@@ -1162,7 +1162,7 @@ exports[`SearchWallet uses fiat value = true should render 1`] = `
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-1"
                           type="button"
                         >
@@ -1203,7 +1203,7 @@ exports[`SearchWallet uses fiat value = true should render with the default exch
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -1487,7 +1487,7 @@ exports[`SearchWallet uses fiat value = true should render with the default exch
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-0"
                           type="button"
                         >
@@ -1592,7 +1592,7 @@ exports[`SearchWallet uses fiat value = true should render with the default exch
                         class="TableCell__TableCellInnerWrapper-sc-1mn4l8o-0 kjTmcB justify-end"
                       >
                         <button
-                          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                           data-testid="SearchWalletListItem__select-1"
                           type="button"
                         >

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`SignMessage should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -207,7 +207,7 @@ exports[`SignMessage should render 1`] = `
                 class="flex justify-end mt-8 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="SignMessage__cancel-button"
                   type="button"
                 >
@@ -218,7 +218,7 @@ exports[`SignMessage should render 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="SignMessage__submit-button"
                   disabled=""
                   type="submit"
@@ -256,7 +256,7 @@ exports[`SignMessage should render for ledger wallets 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -394,7 +394,7 @@ exports[`SignMessage should render for ledger wallets 1`] = `
                 class="flex justify-end mt-8 space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="SignMessage__cancel-button"
                   type="button"
                 >
@@ -405,7 +405,7 @@ exports[`SignMessage should render for ledger wallets 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="SignMessage__submit-button"
                   disabled=""
                   type="submit"

--- a/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
+++ b/src/domains/wallet/components/UpdateWalletName/__snapshots__/UpdateWalletName.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`UpdateWalletName should render a modal 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -90,7 +90,7 @@ exports[`UpdateWalletName should render a modal 1`] = `
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -101,7 +101,7 @@ exports[`UpdateWalletName should render a modal 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 data-testid="UpdateWalletName__submit"
                 type="button"
               >
@@ -137,7 +137,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -226,7 +226,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -237,7 +237,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 1`] = 
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"
@@ -274,7 +274,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -363,7 +363,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -374,7 +374,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 2`] = 
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"
@@ -411,7 +411,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -500,7 +500,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -511,7 +511,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 3`] = 
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"
@@ -548,7 +548,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -637,7 +637,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -648,7 +648,7 @@ exports[`UpdateWalletName should show an error message for duplicate name 4`] = 
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"
@@ -685,7 +685,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -774,7 +774,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -785,7 +785,7 @@ exports[`UpdateWalletName should show error message when name consists only of w
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"
@@ -822,7 +822,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -911,7 +911,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
               class="flex justify-end mt-8 space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                 data-testid="UpdateWalletName__cancel"
                 type="button"
               >
@@ -922,7 +922,7 @@ exports[`UpdateWalletName should show error message when name exceeds 42 charact
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                 data-testid="UpdateWalletName__submit"
                 disabled=""
                 type="button"

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`VerifyMessage should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -192,7 +192,7 @@ exports[`VerifyMessage should render 1`] = `
                 class="flex justify-end space-x-3"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                   data-testid="VerifyMessage__cancel"
                   type="button"
                 >
@@ -203,7 +203,7 @@ exports[`VerifyMessage should render 1`] = `
                   </div>
                 </button>
                 <button
-                  class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                   data-testid="VerifyMessage__submit"
                   disabled=""
                   type="submit"

--- a/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessageStatus/__snapshots__/VerifyMessageStatus.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`VerifyMessageStatus should render verify message error 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -81,7 +81,7 @@ exports[`VerifyMessageStatus should render verify message success 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >

--- a/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
+++ b/src/domains/wallet/components/WalletUpdate/__snapshots__/WalletUpdate.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`WalletUpdate should render 1`] = `
         class="absolute top-0 right-0 z-50 mt-5 mr-5 rounded transition-all duration-100 ease-linear bg-theme-primary-100 hover:bg-theme-primary-300 dark:bg-theme-secondary-800 dark:text-theme-secondary-600 dark:hover:bg-theme-secondary-700 dark:hover:text-theme-secondary-400"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11"
           data-testid="modal__close-btn"
           type="button"
         >
@@ -76,7 +76,7 @@ exports[`WalletUpdate should render 1`] = `
               class="flex flex-col justify-center space-x-0 sm:flex-row sm:space-x-3"
             >
               <button
-                class="Button__StyledButton-mdtvtf-0 iUSBMV mt-2 sm:mt-0"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-2 sm:mt-0"
                 data-testid="WalletUpdate__cancel-button"
                 type="button"
               >
@@ -87,7 +87,7 @@ exports[`WalletUpdate should render 1`] = `
                 </div>
               </button>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                 data-testid="WalletUpdate__update-button"
                 type="button"
               >

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/CreateWallet.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`CreateWallet should create a wallet with alias 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`CreateWallet should create a wallet with alias 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -173,7 +173,7 @@ exports[`CreateWallet should create a wallet with alias 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -494,7 +494,7 @@ exports[`CreateWallet should create a wallet with alias 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -505,7 +505,7 @@ exports[`CreateWallet should create a wallet with alias 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="CreateWallet__continue-button"
                       disabled=""
                       type="button"
@@ -631,7 +631,7 @@ exports[`CreateWallet should create a wallet with alias 2`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -670,7 +670,7 @@ exports[`CreateWallet should create a wallet with alias 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -700,7 +700,7 @@ exports[`CreateWallet should create a wallet with alias 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -978,7 +978,7 @@ exports[`CreateWallet should create a wallet with alias 2`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -989,7 +989,7 @@ exports[`CreateWallet should create a wallet with alias 2`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="CreateWallet__save-button"
                       type="submit"
                     >
@@ -1114,7 +1114,7 @@ exports[`CreateWallet should create a wallet without alias 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1153,7 +1153,7 @@ exports[`CreateWallet should create a wallet without alias 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -1184,7 +1184,7 @@ exports[`CreateWallet should create a wallet without alias 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -1505,7 +1505,7 @@ exports[`CreateWallet should create a wallet without alias 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -1516,7 +1516,7 @@ exports[`CreateWallet should create a wallet without alias 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="CreateWallet__continue-button"
                       disabled=""
                       type="button"
@@ -1642,7 +1642,7 @@ exports[`CreateWallet should create a wallet without alias 2`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1681,7 +1681,7 @@ exports[`CreateWallet should create a wallet without alias 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1711,7 +1711,7 @@ exports[`CreateWallet should create a wallet without alias 2`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1989,7 +1989,7 @@ exports[`CreateWallet should create a wallet without alias 2`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -2000,7 +2000,7 @@ exports[`CreateWallet should create a wallet without alias 2`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="CreateWallet__save-button"
                       type="submit"
                     >
@@ -2127,7 +2127,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2166,7 +2166,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -2197,7 +2197,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -2518,7 +2518,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -2529,7 +2529,7 @@ exports[`CreateWallet should remove pending wallet if not submitted 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="CreateWallet__continue-button"
                       disabled=""
                       type="button"
@@ -2657,7 +2657,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2696,7 +2696,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2726,7 +2726,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3046,7 +3046,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -3057,7 +3057,7 @@ exports[`CreateWallet should show an error message for duplicate name 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="CreateWallet__continue-button"
                       disabled=""
                       type="button"
@@ -3183,7 +3183,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3222,7 +3222,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -3253,7 +3253,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -3622,7 +3622,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="CreateWallet__back-button"
                       type="button"
                     >
@@ -3633,7 +3633,7 @@ exports[`CreateWallet should show an error message if wallet generation failed 1
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                       data-testid="CreateWallet__continue-button"
                       type="button"
                     >

--- a/src/domains/wallet/pages/CreateWallet/__snapshots__/WalletOverviewStep.test.tsx.snap
+++ b/src/domains/wallet/pages/CreateWallet/__snapshots__/WalletOverviewStep.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`WalletOverviewStep Render step should render 1`] = `
         data-testid="clipboard__wrapper"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="CreateWallet__copy"
           type="button"
         >
@@ -146,7 +146,7 @@ exports[`WalletOverviewStep Render step should render 1`] = `
       class="flex justify-end w-full"
     >
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV flex items-center space-x-2"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax flex items-center space-x-2"
         data-testid="CreateWallet__download"
         type="button"
       >

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerImportStep.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`LedgerImportStep should render with multiple import 1`] = `
             </div>
           </div>
           <button
-            class="Button__StyledButton-mdtvtf-0 iUSBMV"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
             data-testid="LedgerImportStep__edit-alias"
             type="button"
           >
@@ -199,7 +199,7 @@ exports[`LedgerImportStep should render with multiple import 1`] = `
             </div>
           </div>
           <button
-            class="Button__StyledButton-mdtvtf-0 iUSBMV"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
             data-testid="LedgerImportStep__edit-alias"
             type="button"
           >
@@ -678,7 +678,7 @@ exports[`LedgerImportStep should show an error message for duplicate name in the
             </div>
           </div>
           <button
-            class="Button__StyledButton-mdtvtf-0 iUSBMV"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
             data-testid="LedgerImportStep__edit-alias"
             type="button"
           >
@@ -751,7 +751,7 @@ exports[`LedgerImportStep should show an error message for duplicate name in the
             </div>
           </div>
           <button
-            class="Button__StyledButton-mdtvtf-0 iUSBMV"
+            class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
             data-testid="LedgerImportStep__edit-alias"
             type="button"
           >

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerScanStep.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerScanStep.test.tsx.snap
@@ -577,7 +577,7 @@ exports[`LedgerScanStep should render 1`] = `
     </div>
     <div>
       <button
-        class="Button__StyledButton-mdtvtf-0 iUSBMV w-full"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax w-full"
         data-testid="LedgerScanStep__view-more"
         type="button"
       >

--- a/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/Ledger/__snapshots__/LedgerTabs.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`LedgerTabs should render connection step 1`] = `
         class="flex space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Paginator__back-button"
           type="button"
         >
@@ -224,7 +224,7 @@ exports[`LedgerTabs should render connection step 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="Paginator__continue-button"
           disabled=""
           type="button"
@@ -626,7 +626,7 @@ exports[`LedgerTabs should render scan step with failing fetch 1`] = `
           </div>
           <div>
             <button
-              class="Button__StyledButton-mdtvtf-0 kwcZQn w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr w-full"
               data-testid="LedgerScanStep__view-more"
               disabled=""
               type="button"
@@ -646,7 +646,7 @@ exports[`LedgerTabs should render scan step with failing fetch 1`] = `
     >
       <div>
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Paginator__retry-button"
           type="button"
         >
@@ -672,7 +672,7 @@ exports[`LedgerTabs should render scan step with failing fetch 1`] = `
         class="flex space-x-3"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 iUSBMV"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
           data-testid="Paginator__back-button"
           type="button"
         >
@@ -683,7 +683,7 @@ exports[`LedgerTabs should render scan step with failing fetch 1`] = `
           </div>
         </button>
         <button
-          class="Button__StyledButton-mdtvtf-0 kwcZQn"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
           data-testid="Paginator__continue-button"
           disabled=""
           type="button"

--- a/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
+++ b/src/domains/wallet/pages/ImportWallet/__snapshots__/ImportWallet.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`ImportWallet should empty all wallets and import by address 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`ImportWallet should empty all wallets and import by address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -173,7 +173,7 @@ exports[`ImportWallet should empty all wallets and import by address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -492,7 +492,7 @@ exports[`ImportWallet should empty all wallets and import by address 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -503,7 +503,7 @@ exports[`ImportWallet should empty all wallets and import by address 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -629,7 +629,7 @@ exports[`ImportWallet should fail to import by encrypted WIF 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -668,7 +668,7 @@ exports[`ImportWallet should fail to import by encrypted WIF 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -698,7 +698,7 @@ exports[`ImportWallet should fail to import by encrypted WIF 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1016,7 +1016,7 @@ exports[`ImportWallet should fail to import by encrypted WIF 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -1027,7 +1027,7 @@ exports[`ImportWallet should fail to import by encrypted WIF 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -1153,7 +1153,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1192,7 +1192,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1222,7 +1222,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1540,7 +1540,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -1551,7 +1551,7 @@ exports[`ImportWallet should go to previous step 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -1677,7 +1677,7 @@ exports[`ImportWallet should import by address 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1716,7 +1716,7 @@ exports[`ImportWallet should import by address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1746,7 +1746,7 @@ exports[`ImportWallet should import by address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2064,7 +2064,7 @@ exports[`ImportWallet should import by address 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -2075,7 +2075,7 @@ exports[`ImportWallet should import by address 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -2201,7 +2201,7 @@ exports[`ImportWallet should import by address and fill a wallet name 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2240,7 +2240,7 @@ exports[`ImportWallet should import by address and fill a wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2270,7 +2270,7 @@ exports[`ImportWallet should import by address and fill a wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2535,7 +2535,7 @@ exports[`ImportWallet should import by address and fill a wallet name 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -2546,7 +2546,7 @@ exports[`ImportWallet should import by address and fill a wallet name 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -2672,7 +2672,7 @@ exports[`ImportWallet should import by encrypted WIF 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2711,7 +2711,7 @@ exports[`ImportWallet should import by encrypted WIF 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2741,7 +2741,7 @@ exports[`ImportWallet should import by encrypted WIF 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3059,7 +3059,7 @@ exports[`ImportWallet should import by encrypted WIF 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -3070,7 +3070,7 @@ exports[`ImportWallet should import by encrypted WIF 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -3196,7 +3196,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3235,7 +3235,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3265,7 +3265,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3583,7 +3583,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -3594,7 +3594,7 @@ exports[`ImportWallet should import by mnemonic 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -3720,7 +3720,7 @@ exports[`ImportWallet should import by mnemonic and use encryption password 1`] 
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3759,7 +3759,7 @@ exports[`ImportWallet should import by mnemonic and use encryption password 1`] 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3789,7 +3789,7 @@ exports[`ImportWallet should import by mnemonic and use encryption password 1`] 
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -4107,7 +4107,7 @@ exports[`ImportWallet should import by mnemonic and use encryption password 1`] 
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -4118,7 +4118,7 @@ exports[`ImportWallet should import by mnemonic and use encryption password 1`] 
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -4244,7 +4244,7 @@ exports[`ImportWallet should import by private key 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -4283,7 +4283,7 @@ exports[`ImportWallet should import by private key 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -4313,7 +4313,7 @@ exports[`ImportWallet should import by private key 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -4631,7 +4631,7 @@ exports[`ImportWallet should import by private key 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -4642,7 +4642,7 @@ exports[`ImportWallet should import by private key 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -5417,7 +5417,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5456,7 +5456,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--send"
                   disabled=""
                   type="button"
@@ -5487,7 +5487,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 jJjuyu"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 jNneja"
                   data-testid="navbar__buttons--receive"
                   disabled=""
                   type="button"
@@ -5808,7 +5808,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                   class="flex space-x-3"
                 >
                   <button
-                    class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                     data-testid="Paginator__back-button"
                     type="button"
                   >
@@ -5819,7 +5819,7 @@ exports[`ImportWallet should render as ledger import 1`] = `
                     </div>
                   </button>
                   <button
-                    class="Button__StyledButton-mdtvtf-0 ePkfgQ"
+                    class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc"
                     data-testid="Paginator__continue-button"
                     type="button"
                   >
@@ -5943,7 +5943,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5982,7 +5982,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -6012,7 +6012,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -6330,7 +6330,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -6341,7 +6341,7 @@ exports[`ImportWallet should show an error message for duplicate address 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -6467,7 +6467,7 @@ exports[`ImportWallet should show an error message for duplicate name 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -6506,7 +6506,7 @@ exports[`ImportWallet should show an error message for duplicate name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -6536,7 +6536,7 @@ exports[`ImportWallet should show an error message for duplicate name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -6854,7 +6854,7 @@ exports[`ImportWallet should show an error message for duplicate name 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -6865,7 +6865,7 @@ exports[`ImportWallet should show an error message for duplicate name 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"
@@ -6991,7 +6991,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -7030,7 +7030,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -7060,7 +7060,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -7378,7 +7378,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                     class="flex justify-end space-x-3"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 iUSBMV"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax"
                       data-testid="ImportWallet__back-button"
                       type="button"
                     >
@@ -7389,7 +7389,7 @@ exports[`ImportWallet should show an error message for invalid address 1`] = `
                       </div>
                     </button>
                     <button
-                      class="Button__StyledButton-mdtvtf-0 kwcZQn"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr"
                       data-testid="ImportWallet__continue-button"
                       disabled=""
                       type="button"

--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -142,7 +142,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -172,7 +172,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -401,7 +401,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -425,7 +425,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
                 data-testid="WalletHeader__send-button"
                 type="button"
               >
@@ -446,7 +446,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -547,7 +547,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -975,7 +975,7 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >
@@ -1096,7 +1096,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -1135,7 +1135,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -1165,7 +1165,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -1394,7 +1394,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -1418,7 +1418,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
                 data-testid="WalletHeader__send-button"
                 type="button"
               >
@@ -1439,7 +1439,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -1544,7 +1544,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -1972,7 +1972,7 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >
@@ -2093,7 +2093,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -2132,7 +2132,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -2162,7 +2162,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -2391,7 +2391,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -2415,7 +2415,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
                 data-testid="WalletHeader__send-button"
                 type="button"
               >
@@ -2436,7 +2436,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -2541,7 +2541,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -2969,7 +2969,7 @@ exports[`WalletDetails should remove wallet name 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >
@@ -3090,7 +3090,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -3129,7 +3129,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -3159,7 +3159,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -3388,7 +3388,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -3412,7 +3412,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 kwcZQn my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 blpaPr my-auto"
                 data-testid="WalletHeader__send-button"
                 disabled=""
                 type="button"
@@ -3434,7 +3434,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -3535,7 +3535,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -3963,7 +3963,7 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >
@@ -4084,7 +4084,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -4123,7 +4123,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -4153,7 +4153,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -4382,7 +4382,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -4406,7 +4406,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
                 data-testid="WalletHeader__send-button"
                 type="button"
               >
@@ -4427,7 +4427,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -4532,7 +4532,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -4960,7 +4960,7 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >
@@ -5081,7 +5081,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                     class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                       data-testid="navbar__buttons--notifications"
                       type="button"
                     >
@@ -5120,7 +5120,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--send"
                   type="button"
                 >
@@ -5150,7 +5150,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                 class="NavigationBar__NavigationButtonWrapper-sc-1qsoskw-1 eUPnft"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh"
                   data-testid="navbar__buttons--receive"
                   type="button"
                 >
@@ -5385,7 +5385,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                 class="my-auto"
               >
                 <button
-                  class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+                  class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
                   data-testid="WalletHeader__star-button"
                   type="button"
                 >
@@ -5409,7 +5409,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                 </button>
               </div>
               <button
-                class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+                class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
                 data-testid="WalletHeader__send-button"
                 type="button"
               >
@@ -5430,7 +5430,7 @@ exports[`WalletDetails should update wallet name 1`] = `
                     data-testid="dropdown__toggle"
                   >
                     <button
-                      class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+                      class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
                       type="button"
                     >
                       <div
@@ -5535,7 +5535,7 @@ exports[`WalletDetails should update wallet name 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
               data-testid="WalletVote__button"
               type="button"
             >
@@ -5963,7 +5963,7 @@ exports[`WalletDetails should update wallet name 1`] = `
               </div>
             </div>
             <button
-              class="Button__StyledButton-mdtvtf-0 iUSBMV mt-10 mb-5 w-full"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax mt-10 mb-5 w-full"
               data-testid="transactions__fetch-more-button"
               type="button"
             >

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`WalletHeader should render 1`] = `
         class="my-auto"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
           data-testid="WalletHeader__star-button"
           type="button"
         >
@@ -156,7 +156,7 @@ exports[`WalletHeader should render 1`] = `
         </button>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
         data-testid="WalletHeader__send-button"
         type="button"
       >
@@ -177,7 +177,7 @@ exports[`WalletHeader should render 1`] = `
             data-testid="dropdown__toggle"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
               type="button"
             >
               <div
@@ -352,7 +352,7 @@ exports[`WalletHeader should show currency delta (-5%) 1`] = `
         class="my-auto"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
           data-testid="WalletHeader__star-button"
           type="button"
         >
@@ -376,7 +376,7 @@ exports[`WalletHeader should show currency delta (-5%) 1`] = `
         </button>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
         data-testid="WalletHeader__send-button"
         type="button"
       >
@@ -397,7 +397,7 @@ exports[`WalletHeader should show currency delta (-5%) 1`] = `
             data-testid="dropdown__toggle"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
               type="button"
             >
               <div
@@ -572,7 +572,7 @@ exports[`WalletHeader should show currency delta (5%) 1`] = `
         class="my-auto"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
           data-testid="WalletHeader__star-button"
           type="button"
         >
@@ -596,7 +596,7 @@ exports[`WalletHeader should show currency delta (5%) 1`] = `
         </button>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
         data-testid="WalletHeader__send-button"
         type="button"
       >
@@ -617,7 +617,7 @@ exports[`WalletHeader should show currency delta (5%) 1`] = `
             data-testid="dropdown__toggle"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
               type="button"
             >
               <div
@@ -801,7 +801,7 @@ exports[`WalletHeader should show modifiers 1`] = `
         class="my-auto"
       >
         <button
-          class="Button__StyledButton-mdtvtf-0 fHYGyx w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
+          class="OriginalButton__StyledButton-sc-1y2wptt-0 fmvKKh w-11 h-11 text-theme-secondary-text hover:text-theme-secondary-500"
           data-testid="WalletHeader__star-button"
           type="button"
         >
@@ -825,7 +825,7 @@ exports[`WalletHeader should show modifiers 1`] = `
         </button>
       </div>
       <button
-        class="Button__StyledButton-mdtvtf-0 ePkfgQ my-auto"
+        class="OriginalButton__StyledButton-sc-1y2wptt-0 cEUmKc my-auto"
         data-testid="WalletHeader__send-button"
         type="button"
       >
@@ -846,7 +846,7 @@ exports[`WalletHeader should show modifiers 1`] = `
             data-testid="dropdown__toggle"
           >
             <button
-              class="Button__StyledButton-mdtvtf-0 OTOjy text-left"
+              class="OriginalButton__StyledButton-sc-1y2wptt-0 koEywu text-left"
               type="button"
             >
               <div

--- a/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletVote/__snapshots__/WalletVote.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`WalletVote multi vote networks should render a vote for multiple active
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -187,7 +187,7 @@ exports[`WalletVote multi vote networks should render a vote for multiple active
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -296,7 +296,7 @@ exports[`WalletVote multi vote networks should render a vote for multiple active
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -398,7 +398,7 @@ exports[`WalletVote should render 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -570,7 +570,7 @@ exports[`WalletVote should render the maximum votes 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -668,7 +668,7 @@ exports[`WalletVote should render without votes 1`] = `
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -770,7 +770,7 @@ exports[`WalletVote single vote networks should render a vote for a delegate wit
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -872,7 +872,7 @@ exports[`WalletVote single vote networks should render a vote for a standby dele
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >
@@ -963,7 +963,7 @@ exports[`WalletVote single vote networks should render a vote for an active dele
       </div>
     </div>
     <button
-      class="Button__StyledButton-mdtvtf-0 iUSBMV space-x-2"
+      class="OriginalButton__StyledButton-sc-1y2wptt-0 hsoUax space-x-2"
       data-testid="WalletVote__button"
       type="button"
     >

--- a/src/plugins/core/plugin-controller-repository.ts
+++ b/src/plugins/core/plugin-controller-repository.ts
@@ -2,7 +2,7 @@ import { Profile } from "@arkecosystem/platform-sdk-profiles";
 import { Checkbox } from "app/components/Checkbox";
 import { Clipboard } from "app/components/Clipboard";
 import { Input, InputCurrency } from "app/components/Input";
-// import { Modal } from "app/components/Modal";
+import { Modal } from "app/components/Modal";
 import { Spinner } from "app/components/Spinner";
 import { TabPanel, Tabs } from "app/components/Tabs";
 import { runUnknownCode } from "plugins/loader/vm";
@@ -96,8 +96,7 @@ export class PluginControllerRepository {
 			try {
 				const callback = runUnknownCode(entry.source, entry.sourcePath, {
 					ark: {
-						// @TODO: register Modal causes a circular dependency which causes the PluginManager to be undefined when imported
-						Components: { Box, Tabs, TabPanel, Spinner, Clipboard, Input, InputCurrency, Checkbox },
+						Components: { Box, Tabs, TabPanel, Spinner, Clipboard, Input, InputCurrency, Checkbox, Modal },
 					},
 				});
 				const plugin = new PluginController(


### PR DESCRIPTION
## Summary

Adjust Modal component to not use Button wrapped by plugins to avoid circular dependency.

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
