### PR TITLE
refactor: hide converted balance if wallet belongs to test network

### DIFF
--- a/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/__snapshots__/WalletDetails.test.tsx.snap
@@ -383,12 +383,6 @@ exports[`WalletDetails should not fail if the votes have not yet been synchroniz
                   <span>
                     Balance:
                   </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
-                  </span>
                 </div>
                 <span
                   class="text-lg font-semibold text-white"
@@ -1375,12 +1369,6 @@ exports[`WalletDetails should open detail modal on transaction row click 1`] = `
                 >
                   <span>
                     Balance:
-                  </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
                   </span>
                 </div>
                 <span
@@ -2373,12 +2361,6 @@ exports[`WalletDetails should remove wallet name 1`] = `
                   <span>
                     Balance:
                   </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
-                  </span>
                 </div>
                 <span
                   class="text-lg font-semibold text-white"
@@ -3370,12 +3352,6 @@ exports[`WalletDetails should render when wallet not found for votes 1`] = `
                   <span>
                     Balance:
                   </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
-                  </span>
                 </div>
                 <span
                   class="text-lg font-semibold text-white"
@@ -4363,12 +4339,6 @@ exports[`WalletDetails should star and unstar a wallet 1`] = `
                 >
                   <span>
                     Balance:
-                  </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
                   </span>
                 </div>
                 <span
@@ -5366,12 +5336,6 @@ exports[`WalletDetails should update wallet name 1`] = `
                 >
                   <span>
                     Balance:
-                  </span>
-                  <span
-                    class="ml-1"
-                    data-testid="WalletHeader__currency-balance"
-                  >
-                    0 BTC
                   </span>
                 </div>
                 <span

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.test.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.test.tsx
@@ -78,6 +78,16 @@ describe("WalletHeader", () => {
 		multisigSpy.mockRestore();
 	});
 
+	it("should hide converted balance if wallet belongs to test network", () => {
+		const networkSpy = jest.spyOn(wallet.network(), "isTest").mockReturnValue(true);
+
+		const { getByTestId, asFragment } = render(<WalletHeader profile={profile} wallet={wallet} />);
+
+		expect(() => getByTestId("WalletHeader__currency-balance")).toThrowError(/Unable to find/);
+
+		networkSpy.mockRestore();
+	});
+
 	it.each([-5, 5])("should show currency delta (%s%)", (delta) => {
 		const { getByTestId, getByText, asFragment } = render(
 			<WalletHeader profile={profile} wallet={wallet} currencyDelta={delta} />,

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/WalletHeader.tsx
@@ -272,7 +272,7 @@ export const WalletHeader = ({ profile, wallet, currencyDelta, onSend }: WalletH
 						<div className="flex items-center text-sm font-semibold text-theme-secondary-text">
 							<span>{t("COMMON.BALANCE")}:</span>
 
-							{wallet.convertedBalance() && (
+							{!wallet.network().isTest() && (
 								<Amount
 									value={wallet.convertedBalance()}
 									ticker={profile.settings().get<string>(ProfileSetting.ExchangeCurrency)!}

--- a/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
+++ b/src/domains/wallet/pages/WalletDetails/components/WalletHeader/__snapshots__/WalletHeader.test.tsx.snap
@@ -114,12 +114,6 @@ exports[`WalletHeader should render 1`] = `
           <span>
             Balance:
           </span>
-          <span
-            class="ml-1"
-            data-testid="WalletHeader__currency-balance"
-          >
-            0 BTC
-          </span>
         </div>
         <span
           class="text-lg font-semibold text-white"
@@ -315,12 +309,6 @@ exports[`WalletHeader should show currency delta (-5%) 1`] = `
         >
           <span>
             Balance:
-          </span>
-          <span
-            class="ml-1"
-            data-testid="WalletHeader__currency-balance"
-          >
-            0 BTC
           </span>
           <span
             class="inline-flex items-center ml-2 text-theme-danger-500"
@@ -535,12 +523,6 @@ exports[`WalletHeader should show currency delta (5%) 1`] = `
         >
           <span>
             Balance:
-          </span>
-          <span
-            class="ml-1"
-            data-testid="WalletHeader__currency-balance"
-          >
-            0 BTC
           </span>
           <span
             class="inline-flex items-center ml-2 text-theme-success-600"
@@ -782,12 +764,6 @@ exports[`WalletHeader should show modifiers 1`] = `
         >
           <span>
             Balance:
-          </span>
-          <span
-            class="ml-1"
-            data-testid="WalletHeader__currency-balance"
-          >
-            0 BTC
           </span>
         </div>
         <span


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/fx05ac

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
