### PR TITLE
fix: plugin skeleton out of bounds on smaller screens

### DIFF
--- a/src/domains/plugin/components/PluginCard/PluginCardSkeleton.tsx
+++ b/src/domains/plugin/components/PluginCard/PluginCardSkeleton.tsx
@@ -10,7 +10,7 @@ export const PluginCardSkeleton = () => {
 	return (
 		<div data-testid="PluginCardSkeleton">
 			<Card>
-				<div className="flex items-center space-x-4">
+				<div className="flex items-center space-x-4 overflow-hidden">
 					<div className="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl">
 						<Skeleton width={100} height={100} />
 					</div>

--- a/src/domains/plugin/components/PluginCard/__snapshots__/PluginCardSkeleton.test.tsx.snap
+++ b/src/domains/plugin/components/PluginCard/__snapshots__/PluginCardSkeleton.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`PluginCardSkeleton should render 1`] = `
       data-testid="Card"
     >
       <div
-        class="flex items-center space-x-4"
+        class="flex items-center space-x-4 overflow-hidden"
       >
         <div
           class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"

--- a/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
+++ b/src/domains/plugin/components/PluginGrid/__snapshots__/PluginGrid.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PluginGrid should render custom number of skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"
@@ -117,7 +117,7 @@ exports[`PluginGrid should render custom number of skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"
@@ -218,7 +218,7 @@ exports[`PluginGrid should render custom number of skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"
@@ -788,7 +788,7 @@ exports[`PluginGrid should render skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"
@@ -889,7 +889,7 @@ exports[`PluginGrid should render skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"
@@ -990,7 +990,7 @@ exports[`PluginGrid should render skeletons 1`] = `
           data-testid="Card"
         >
           <div
-            class="flex items-center space-x-4"
+            class="flex items-center space-x-4 overflow-hidden"
           >
             <div
               class="flex-shrink-0 w-25 h-25 overflow-hidden rounded-xl"


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/gx2dx4

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
