### PR TITLE
fix: adjust style of dropdown icon when disabled

### DIFF
--- a/src/app/components/Dropdown/Dropdown.tsx
+++ b/src/app/components/Dropdown/Dropdown.tsx
@@ -101,7 +101,7 @@ const renderOptions = (options: DropdownOption[] | DropdownOptionGroup[], onSele
 			{(options as DropdownOption[]).map((option: DropdownOption, index: number) => (
 				<DropdownItem
 					aria-disabled={option.disabled}
-					className="group"
+					className={cn({ group: !option.disabled })}
 					disabled={option.disabled}
 					key={index}
 					data-testid={`dropdown__option--${key ? `${key}-` : ""}${index}`}

--- a/src/app/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/app/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -585,7 +585,7 @@ exports[`Dropdown should render with a disabled option 1`] = `
       >
         <li
           aria-disabled="true"
-          class="sc-gsTCUz bboXA-d group"
+          class="sc-gsTCUz bboXA-d"
           data-testid="dropdown__option--0"
           disabled=""
           tabindex="-1"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/jb7w35

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
