### PR TITLE
fix: select new item with enter key when item already selected

### DIFF
--- a/src/app/components/SelectDropdown/SelectDropdown.test.tsx
+++ b/src/app/components/SelectDropdown/SelectDropdown.test.tsx
@@ -216,6 +216,31 @@ describe("SelectDropdown", () => {
 		expect(getByTestId("select-list__input")).toHaveValue("1");
 	});
 
+	it("should select new option with enter", () => {
+		const { getByTestId } = render(<Select options={options} />);
+		const selectDropdown = getByTestId("SelectDropdownInput__input");
+
+		act(() => {
+			fireEvent.change(selectDropdown, { target: { value: "Opt" } });
+		});
+
+		act(() => {
+			fireEvent.keyDown(selectDropdown, { key: "Enter", code: 13 });
+		});
+
+		expect(selectDropdown).toHaveValue("Option 1");
+
+		act(() => {
+			fireEvent.keyDown(selectDropdown, { key: "ArrowDown", code: 40 });
+		});
+
+		act(() => {
+			fireEvent.keyDown(selectDropdown, { key: "Enter", code: 13 });
+		});
+
+		expect(selectDropdown).toHaveValue("Option 2");
+	});
+
 	it("should not select non-matching option after key input and tab", () => {
 		const { getByTestId } = render(<Select options={options} />);
 		const selectDropdown = getByTestId("SelectDropdownInput__input");

--- a/src/app/components/SelectDropdown/SelectDropdown.tsx
+++ b/src/app/components/SelectDropdown/SelectDropdown.tsx
@@ -86,6 +86,7 @@ const SelectDropdown = ({
 		highlightedIndex,
 		reset,
 		toggleMenu,
+		selectedItem,
 	} = useCombobox<Option | null>({
 		id,
 		items: options,
@@ -199,7 +200,12 @@ const SelectDropdown = ({
 						},
 						onKeyDown: (event) => {
 							if (event.key === "Tab" || event.key === "Enter") {
-								// Select first match
+								// check if item already was selected
+								if (selectedItem?.label === inputValue) {
+									return;
+								}
+
+								// Select first suggestion
 								const firstMatch = options.find((option) => isMatch(inputValue, option));
 
 								if (inputValue && firstMatch) {

--- a/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
+++ b/src/app/components/SelectDropdown/__snapshots__/SelectDropdown.test.tsx.snap
@@ -436,12 +436,12 @@ exports[`SelectDropdown should render with default value when free text is allow
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-owns="downshift-115-menu"
+        aria-owns="downshift-124-menu"
         role="combobox"
       >
         <label
-          for="downshift-115-input"
-          id="downshift-115-label"
+          for="downshift-124-input"
+          id="downshift-124-label"
         />
         <div
           class="Input__InputWrapperStyled-wu99qs-0 jYUFQr"
@@ -451,12 +451,12 @@ exports[`SelectDropdown should render with default value when free text is allow
           >
             <input
               aria-autocomplete="list"
-              aria-controls="downshift-115-menu"
-              aria-labelledby="downshift-115-label"
+              aria-controls="downshift-124-menu"
+              aria-labelledby="downshift-124-label"
               autocomplete="off"
               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full cursor-default"
               data-testid="SelectDropdownInput__input"
-              id="downshift-115-input"
+              id="downshift-124-input"
               placeholder="Select option"
               value="3"
             />
@@ -485,9 +485,9 @@ exports[`SelectDropdown should render with default value when free text is allow
           </div>
         </div>
         <ul
-          aria-labelledby="downshift-115-label"
+          aria-labelledby="downshift-124-label"
           class="styles__SelectOptionsList-b2falt-0 ghEDCU"
-          id="downshift-115-menu"
+          id="downshift-124-menu"
           role="listbox"
         />
       </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/j990cp

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
