### PR TITLE
fix: restore profile only once

### DIFF
--- a/src/domains/profile/pages/Welcome/Welcome.tsx
+++ b/src/domains/profile/pages/Welcome/Welcome.tsx
@@ -6,7 +6,6 @@ import { Image } from "app/components/Image";
 import { Page, Section } from "app/components/Layout";
 import { Link } from "app/components/Link";
 import { useEnvironmentContext } from "app/contexts";
-import { useProfileRestore } from "app/hooks";
 import { DeleteProfile } from "domains/profile/components/DeleteProfile/DeleteProfile";
 import { ProfileCard } from "domains/profile/components/ProfileCard";
 import { SignIn } from "domains/profile/components/SignIn/SignIn";
@@ -17,7 +16,6 @@ import { setScreenshotProtection } from "utils/electron-utils";
 
 export const Welcome = () => {
 	const context = useEnvironmentContext();
-	const { restoreProfile } = useProfileRestore();
 	const history = useHistory();
 
 	const { t } = useTranslation();
@@ -53,7 +51,6 @@ export const Welcome = () => {
 			setSelectedProfile(profile);
 			setRequestedAction({ label: "Homepage", value: "home" });
 		} else {
-			restoreProfile(profile);
 			navigateToProfile(profile);
 		}
 	};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Prevent from calling profile restore in welcome screen when clicking profile card to enter. Profile restoration is called only once from profile synchronizer

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
