### PR TITLE
fix: focus styles of password visibility icon

### DIFF
--- a/src/app/components/Input/InputPassword.tsx
+++ b/src/app/components/Input/InputPassword.tsx
@@ -23,7 +23,7 @@ export const InputPassword = React.forwardRef<HTMLInputElement, InputPasswordPro
 						className="relative flex items-center justify-center w-full h-full text-2xl focus:outline-none group"
 					>
 						{/* icon border on focus */}
-						<div className="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2" />
+						<div className="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible" />
 
 						<Icon name={show ? "EyeOff" : "Eye"} />
 					</button>

--- a/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
+++ b/src/app/components/Input/__snapshots__/InputPassword.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`InputPassword should render as a password field 1`] = `
           type="button"
         >
           <div
-            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
           />
           <div
             class="sc-bdfBwQ fPrsah"
@@ -86,7 +86,7 @@ exports[`InputPassword should render as a password isInvalid 1`] = `
           type="button"
         >
           <div
-            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
           />
           <div
             class="sc-bdfBwQ fPrsah"

--- a/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
+++ b/src/domains/profile/components/PasswordModal/__snapshots__/PasswordModal.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`PasswordModal should render with title and description 1`] = `
                       type="button"
                     >
                       <div
-                        class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                        class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                       />
                       <div
                         class="sc-bdfBwQ fPrsah"

--- a/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
+++ b/src/domains/profile/components/SignIn/__snapshots__/SignIn.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`SignIn should render a modal 1`] = `
                       type="button"
                     >
                       <div
-                        class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                        class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                       />
                       <div
                         class="sc-bdfBwQ fPrsah"

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -276,7 +276,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -939,7 +939,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -996,7 +996,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -1659,7 +1659,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -1716,7 +1716,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -2379,7 +2379,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -2436,7 +2436,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -3119,7 +3119,7 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -3176,7 +3176,7 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -3578,7 +3578,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -3635,7 +3635,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -4278,7 +4278,7 @@ exports[`CreateProfile should render 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -4335,7 +4335,7 @@ exports[`CreateProfile should render 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -4757,7 +4757,7 @@ exports[`CreateProfile should store profile 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -4814,7 +4814,7 @@ exports[`CreateProfile should store profile 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -5457,7 +5457,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -5512,7 +5512,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -6161,7 +6161,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -6218,7 +6218,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -6639,7 +6639,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -6696,7 +6696,7 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -7098,7 +7098,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"
@@ -7155,7 +7155,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                           type="button"
                         >
                           <div
-                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                            class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                           />
                           <div
                             class="sc-bdfBwQ fPrsah"

--- a/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
+++ b/src/domains/profile/pages/ImportProfile/__snapshots__/ProfileFormStep.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`Import Profile - Profile Form Step should fail password confirmation 1`
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -251,7 +251,7 @@ exports[`Import Profile - Profile Form Step should fail password confirmation 1`
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -872,7 +872,7 @@ exports[`Import Profile - Profile Form Step should render profile form 1`] = `
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -929,7 +929,7 @@ exports[`Import Profile - Profile Form Step should render profile form 1`] = `
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -1314,7 +1314,7 @@ exports[`Import Profile - Profile Form Step should render profile form with empt
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -1371,7 +1371,7 @@ exports[`Import Profile - Profile Form Step should render profile form with empt
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -1756,7 +1756,7 @@ exports[`Import Profile - Profile Form Step should render profile form with hidd
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -1813,7 +1813,7 @@ exports[`Import Profile - Profile Form Step should render profile form with hidd
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -2212,7 +2212,7 @@ exports[`Import Profile - Profile Form Step should store new profile with passwo
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -2267,7 +2267,7 @@ exports[`Import Profile - Profile Form Step should store new profile with passwo
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -2899,7 +2899,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -2956,7 +2956,7 @@ exports[`Import Profile - Profile Form Step should store profile 1`] = `
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -3574,7 +3574,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -3631,7 +3631,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -3862,7 +3862,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"
@@ -3919,7 +3919,7 @@ exports[`Import Profile - Profile Form Step should update the avatar when removi
                         type="button"
                       >
                         <div
-                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                          class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                         />
                         <div
                           class="sc-bdfBwQ fPrsah"

--- a/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/domains/setting/pages/Settings/__snapshots__/Settings.test.tsx.snap
@@ -4262,7 +4262,7 @@ exports[`Settings should render password settings 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -4317,7 +4317,7 @@ exports[`Settings should render password settings 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -5444,7 +5444,7 @@ exports[`Settings should set a password 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -5499,7 +5499,7 @@ exports[`Settings should set a password 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -5554,7 +5554,7 @@ exports[`Settings should set a password 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6091,7 +6091,7 @@ exports[`Settings should show an error toast if the current password does not ma
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6146,7 +6146,7 @@ exports[`Settings should show an error toast if the current password does not ma
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6201,7 +6201,7 @@ exports[`Settings should show an error toast if the current password does not ma
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6737,7 +6737,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6792,7 +6792,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -6862,7 +6862,7 @@ exports[`Settings should trigger password confirmation mismatch error 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"

--- a/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
+++ b/src/domains/transaction/components/AuthenticationStep/__snapshots__/AuthenticationStep.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`AuthenticationStep should request mnemonic 1`] = `
                 type="button"
               >
                 <div
-                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                 />
                 <div
                   class="sc-bdfBwQ fPrsah"
@@ -159,7 +159,7 @@ exports[`AuthenticationStep should request mnemonic and second mnemonic 1`] = `
                 type="button"
               >
                 <div
-                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                 />
                 <div
                   class="sc-bdfBwQ fPrsah"
@@ -216,7 +216,7 @@ exports[`AuthenticationStep should request mnemonic and second mnemonic 1`] = `
                 type="button"
               >
                 <div
-                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                  class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                 />
                 <div
                   class="sc-bdfBwQ fPrsah"

--- a/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
+++ b/src/domains/transaction/pages/SendDelegateResignation/__snapshots__/SendDelegateResignation.test.tsx.snap
@@ -2087,7 +2087,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -2144,7 +2144,7 @@ exports[`SendDelegateResignation Delegate Resignation should render 3rd step 1`]
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -3389,7 +3389,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"
@@ -3446,7 +3446,7 @@ exports[`SendDelegateResignation Delegate Resignation should show mnemonic authe
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"

--- a/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
+++ b/src/domains/transaction/pages/SendIpfs/__snapshots__/SendIpfs.test.tsx.snap
@@ -399,7 +399,7 @@ exports[`SendIpfs should error if wrong mnemonic 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -1368,7 +1368,7 @@ exports[`SendTransfer should error if wrong mnemonic 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"

--- a/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
+++ b/src/domains/transaction/pages/SendVote/__snapshots__/SendVote.test.tsx.snap
@@ -1755,7 +1755,7 @@ exports[`SendVote should show error if wrong mnemonic 1`] = `
                               type="button"
                             >
                               <div
-                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                                class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                               />
                               <div
                                 class="sc-bdfBwQ fPrsah"

--- a/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
+++ b/src/domains/wallet/components/SignMessage/__snapshots__/SignMessage.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`SignMessage should render 1`] = `
                             type="button"
                           >
                             <div
-                              class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2"
+                              class="absolute inset-0 -m-1 rounded ring-theme-primary-400 group-focus:ring-2 group-focus-visible"
                             />
                             <div
                               class="sc-bdfBwQ fPrsah"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/gx2ex1

add focus-visible

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
