### PR TITLE
refactor: use `displayName` method in `use-wallet-alias` hook

### DIFF
--- a/src/app/hooks/use-wallet-alias.test.tsx
+++ b/src/app/hooks/use-wallet-alias.test.tsx
@@ -17,29 +17,19 @@ describe("UseWalletAlias", () => {
 		jest.clearAllMocks();
 	});
 
-	it("should return undefined with an address not found", () => {
+	it("should return undefined when no wallet or contact was found", () => {
 		const { result } = renderHook(() => useWalletAlias({ address: "wrong-address", profile }));
 		expect(result.current).toBe(undefined);
 	});
 
-	it("should return if none alias found", () => {
-		const isKnownSpy = jest.spyOn(wallet, "isKnown").mockReturnValue(false);
-		const aliasSpy = jest.spyOn(wallet, "alias").mockReturnValue(undefined);
-		const usernameSpy = jest.spyOn(wallet, "username").mockReturnValue(undefined);
+	it("should return undefined if wallet has no display name", () => {
+		const displayNameSpy = jest.spyOn(wallet, "displayName").mockReturnValue(undefined);
 		const { result } = renderHook(() => useWalletAlias({ address: wallet.address(), profile }));
 		expect(result.current).toBe(undefined);
-		aliasSpy.mockRestore();
-		isKnownSpy.mockRestore();
-		usernameSpy.mockRestore();
-	});
-
-	it("should return alias", () => {
-		const { result } = renderHook(() => useWalletAlias({ address: wallet.address(), profile }));
-		expect(result.current).toBe("ARK Wallet 1");
+		displayNameSpy.mockRestore();
 	});
 
 	it("should return contact name", async () => {
-		jest.spyOn(wallet, "alias").mockReturnValueOnce(undefined);
 		const contact = profile.contacts().create("Test");
 		await contact.setAddresses([
 			{ name: "my contact name", address: wallet.address(), coin: wallet.coinId(), network: wallet.networkId() },
@@ -51,21 +41,8 @@ describe("UseWalletAlias", () => {
 		profile.contacts().forget(contact.id());
 	});
 
-	it("should return known name", () => {
-		jest.spyOn(wallet, "alias").mockReturnValue(undefined);
-		jest.spyOn(wallet, "isKnown").mockReturnValueOnce(true);
-		jest.spyOn(wallet, "knownName").mockImplementation(() => "known alias");
-
+	it("should return displayName", () => {
 		const { result } = renderHook(() => useWalletAlias({ address: wallet.address(), profile }));
-		expect(result.current).toBe("known alias");
-	});
-
-	it("should return username", () => {
-		jest.spyOn(wallet, "alias").mockReturnValue(undefined);
-		jest.spyOn(wallet, "hasSyncedWithNetwork").mockReturnValue(true);
-		jest.spyOn(wallet, "username").mockImplementation(() => "my username");
-
-		const { result } = renderHook(() => useWalletAlias({ address: wallet.address(), profile }));
-		expect(result.current).toBe("my username");
+		expect(result.current).toBe("ARK Wallet 1");
 	});
 });

--- a/src/app/hooks/use-wallet-alias.tsx
+++ b/src/app/hooks/use-wallet-alias.tsx
@@ -13,20 +13,14 @@ export const useWalletAlias = ({ address, profile }: Props) => {
 		return;
 	}
 
-	if (wallet?.alias()) {
-		return wallet?.alias();
-	}
-
 	if (contact) {
-		const contactWallet = contact.addresses().findByAddress(address)[0];
-		return contactWallet.name();
+		return contact.addresses().findByAddress(address)[0].name();
 	}
 
-	if (wallet?.isKnown()) {
-		return wallet?.knownName();
-	}
-
-	if (wallet?.hasSyncedWithNetwork() && wallet?.username()) {
-		return wallet?.username();
+	try {
+		const displayName = wallet!.displayName();
+		return displayName;
+	} catch {
+		//
 	}
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://app.clickup.com/t/jvbz3g

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
