### PR TITLE
fix: always persist through env context

### DIFF
--- a/src/app/contexts/Environment/Environment.tsx
+++ b/src/app/contexts/Environment/Environment.tsx
@@ -1,5 +1,6 @@
 import { Environment } from "@arkecosystem/platform-sdk-profiles";
 import React from "react";
+import { isE2E } from "utils/test-helpers";
 
 type Context = { env: Environment; state?: Record<string, unknown>; persist: () => Promise<void> };
 
@@ -11,11 +12,10 @@ type Props = {
 export const EnvironmentContext = React.createContext<any>(undefined);
 
 export const EnvironmentProvider = ({ children, env }: Props) => {
-	const __E2E__ = process.env.REACT_APP_IS_E2E;
 	const [state, setState] = React.useState<any>(undefined);
 
 	const persist = React.useCallback(async () => {
-		if (__E2E__) {
+		if (isE2E()) {
 			// prevent from persisting when in e2e mode. Tests failing
 			setState({});
 			return;
@@ -25,7 +25,7 @@ export const EnvironmentProvider = ({ children, env }: Props) => {
 
 		// Force update
 		setState({});
-	}, [env, __E2E__]);
+	}, [env]);
 
 	return (
 		<EnvironmentContext.Provider value={{ env, state, persist } as Context}>{children}</EnvironmentContext.Provider>

--- a/src/app/hooks/use-notifications.ts
+++ b/src/app/hooks/use-notifications.ts
@@ -167,5 +167,5 @@ export const useNotifications = () => {
 				deleteNotificationsByVersion: deleteNotificationsByVersion(env),
 			},
 		};
-	}, [profiles, env, t]);
+	}, [profiles, env, persist, t]);
 };

--- a/src/app/hooks/use-notifications.ts
+++ b/src/app/hooks/use-notifications.ts
@@ -141,7 +141,7 @@ const sortTransactionNotificationsDesc = (notifications: any[]) =>
 
 export const useNotifications = () => {
 	const { t } = useTranslation();
-	const { env } = useEnvironmentContext();
+	const { env, persist } = useEnvironmentContext();
 
 	const profiles = env.profiles();
 
@@ -153,7 +153,7 @@ export const useNotifications = () => {
 					.map((profile: ProfileContracts.IProfile) => notifyReceivedTransactions({ ...params, profile })),
 			);
 
-			await env.persist();
+			await persist();
 			return savedNotifications.flat();
 		};
 

--- a/src/app/hooks/use-profile-synchronizer.test.tsx
+++ b/src/app/hooks/use-profile-synchronizer.test.tsx
@@ -431,34 +431,6 @@ describe("useProfileRestore", () => {
 		mockProfileFromUrl.mockRestore();
 	});
 
-	it("should restore in e2e", async () => {
-		process.env.TEST_PROFILES_RESTORE_STATUS = undefined;
-		process.env.REACT_APP_IS_E2E = "1";
-
-		const profile = env.profiles().findById(getDefaultProfileId());
-		profile.wallets().flush();
-
-		const wrapper = ({ children }: any) => (
-			<EnvironmentProvider env={env}>
-				<ConfigurationProvider>{children}</ConfigurationProvider>
-			</EnvironmentProvider>
-		);
-
-		const {
-			result: { current },
-		} = renderHook(() => useProfileRestore(), { wrapper });
-
-		let isRestored;
-
-		await act(async () => {
-			isRestored = await current.restoreProfile(profile);
-		});
-
-		expect(isRestored).toEqual(true);
-
-		process.env.TEST_PROFILES_RESTORE_STATUS = "restored";
-	});
-
 	it("should restore only once", async () => {
 		process.env.TEST_PROFILES_RESTORE_STATUS = undefined;
 		process.env.REACT_APP_IS_E2E = undefined;

--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -137,21 +137,6 @@ export const useProfileRestore = () => {
 
 		setStatus("restoring");
 
-		// When in e2e mode, profiles are migrated passwordless and
-		// password needs to be set again. The restore should happen
-		// without password and then reset the password.
-		const __E2E__ = ["true", "1"].includes(process.env.REACT_APP_IS_E2E?.toLowerCase() as string);
-		if (__E2E__) {
-			await env.profiles().restore(profile, password);
-
-			await profile.sync();
-
-			await persist();
-
-			markAsRestored(profile.id());
-			return true;
-		}
-
 		// Reset profile normally (passwordless or not)
 		await env.profiles().restore(profile, password);
 		markAsRestored(profile.id());
@@ -177,7 +162,6 @@ type ProfileSynchronizerProps = {
 };
 
 export const useProfileSynchronizer = ({ onProfileRestoreError }: ProfileSynchronizerProps = {}) => {
-	const __E2E__ = process.env.REACT_APP_IS_E2E;
 	const { persist } = useEnvironmentContext();
 	const { setConfiguration, profileIsSyncing } = useConfiguration();
 	const { restoreProfile } = useProfileRestore();
@@ -262,7 +246,6 @@ export const useProfileSynchronizer = ({ onProfileRestoreError }: ProfileSynchro
 		status,
 		onProfileRestoreError,
 		stop,
-		__E2E__,
 	]);
 
 	return { profile, profileIsSyncing };

--- a/src/domains/profile/e2e/common.ts
+++ b/src/domains/profile/e2e/common.ts
@@ -9,5 +9,5 @@ export const goToProfile = async (t: any) => {
 	await t.click(Selector("span").withText("John Doe"));
 	await t.expect(Selector("div").withText(translations.COMMON.WALLETS).exists).ok();
 	const transactionsCount = Selector('[data-testid="TableRow"]').count;
-	await t.expect(transactionsCount).gte(10, { timeout: 300000 });
+	await t.expect(transactionsCount).gte(10);
 };

--- a/src/domains/setting/pages/Settings/available-settings/Password.tsx
+++ b/src/domains/setting/pages/Settings/available-settings/Password.tsx
@@ -11,7 +11,7 @@ import { SettingsProps } from "../Settings.models";
 
 export const PasswordSettings = ({ formConfig, onSuccess, onError }: SettingsProps) => {
 	const activeProfile = useActiveProfile();
-	const { env } = useEnvironmentContext();
+	const { persist } = useEnvironmentContext();
 
 	const usesPassword = activeProfile.usesPassword();
 	const { password: passwordValidation } = useValidation();
@@ -35,7 +35,7 @@ export const PasswordSettings = ({ formConfig, onSuccess, onError }: SettingsPro
 		reset();
 
 		// the profile has already been saved by the changePassword / setPassword methods above
-		await env.persist();
+		await persist();
 
 		onSuccess(t("SETTINGS.PASSWORD.SUCCESS"));
 	};

--- a/src/domains/transaction/pages/SendDelegateResignation/SendDelegateResignation.tsx
+++ b/src/domains/transaction/pages/SendDelegateResignation/SendDelegateResignation.tsx
@@ -38,7 +38,7 @@ export const SendDelegateResignation = ({ formDefaultData }: SendResignationProp
 
 	const [transaction, setTransaction] = useState((null as unknown) as Contracts.SignedTransactionData);
 
-	const { env } = useEnvironmentContext();
+	const { persist } = useEnvironmentContext();
 
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
@@ -95,7 +95,7 @@ export const SendDelegateResignation = ({ formDefaultData }: SendResignationProp
 
 			await activeWallet.transaction().broadcast(signedTransactionId);
 
-			await env.persist();
+			await persist();
 
 			setTransaction(activeWallet.transaction().transaction(signedTransactionId));
 

--- a/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
+++ b/src/domains/transaction/pages/SendIpfs/SendIpfs.tsx
@@ -26,7 +26,7 @@ export const SendIpfs = () => {
 	const [activeTab, setActiveTab] = useState(1);
 	const [transaction, setTransaction] = useState((null as unknown) as Contracts.SignedTransactionData);
 
-	const { env } = useEnvironmentContext();
+	const { env, persist } = useEnvironmentContext();
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
 	const networks = useMemo(() => env.availableNetworks(), [env]);
@@ -94,7 +94,7 @@ export const SendIpfs = () => {
 			const { uuid, transaction } = await transactionBuilder.build("ipfs", transactionInput, { abortSignal });
 			await transactionBuilder.broadcast(uuid, transactionInput);
 
-			await env.persist();
+			await persist();
 
 			setTransaction(transaction);
 			setActiveTab(4);

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -49,7 +49,7 @@ export const SendTransfer = () => {
 	const [isConfirming, setIsConfirming] = useState(false);
 	const [transaction, setTransaction] = useState((null as unknown) as Contracts.SignedTransactionData);
 
-	const { env, persist } = useEnvironmentContext();
+	const { persist } = useEnvironmentContext();
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
 

--- a/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
+++ b/src/domains/transaction/pages/SendTransfer/SendTransfer.tsx
@@ -49,7 +49,7 @@ export const SendTransfer = () => {
 	const [isConfirming, setIsConfirming] = useState(false);
 	const [transaction, setTransaction] = useState((null as unknown) as Contracts.SignedTransactionData);
 
-	const { env } = useEnvironmentContext();
+	const { env, persist } = useEnvironmentContext();
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
 
@@ -238,7 +238,7 @@ export const SendTransfer = () => {
 
 			await transactionBuilder.broadcast(uuid, transactionInput);
 
-			await env.persist();
+			await persist();
 
 			setTransaction(transaction);
 			setActiveTab(4);

--- a/src/domains/transaction/pages/SendVote/SendVote.tsx
+++ b/src/domains/transaction/pages/SendVote/SendVote.tsx
@@ -21,7 +21,7 @@ import { VoteLedgerReview } from "./LedgerReview";
 
 export const SendVote = () => {
 	const { t } = useTranslation();
-	const { env } = useEnvironmentContext();
+	const { env, persist } = useEnvironmentContext();
 	const history = useHistory();
 	const activeProfile = useActiveProfile();
 	const activeWallet = useActiveWallet();
@@ -216,7 +216,7 @@ export const SendVote = () => {
 
 					await transactionBuilder.broadcast(unvoteResult.uuid, voteTransactionInput);
 
-					await env.persist();
+					await persist();
 
 					await confirmSendVote("unvote");
 
@@ -233,7 +233,7 @@ export const SendVote = () => {
 
 					await transactionBuilder.broadcast(voteResult.uuid, voteTransactionInput);
 
-					await env.persist();
+					await persist();
 
 					setTransaction(voteResult.transaction);
 
@@ -257,7 +257,7 @@ export const SendVote = () => {
 
 					await transactionBuilder.broadcast(uuid, voteTransactionInput);
 
-					await env.persist();
+					await persist();
 
 					setTransaction(transaction);
 
@@ -286,7 +286,7 @@ export const SendVote = () => {
 
 				await transactionBuilder.broadcast(uuid, voteTransactionInput);
 
-				await env.persist();
+				await persist();
 
 				setTransaction(transaction);
 

--- a/src/domains/wallet/e2e/common.ts
+++ b/src/domains/wallet/e2e/common.ts
@@ -8,7 +8,7 @@ export const goToWalletAndWaitTransactions = async (t: any, wallet = "D8rr7B1d6T
 	await t.click(Selector(`[data-testid=WalletCard__${wallet}]`));
 	await t.expect(Selector("[data-testid=WalletHeader]").exists).ok();
 	const transactionsCount = Selector('[data-testid="TableRow"]').count;
-	await t.expect(transactionsCount).gte(12, { timeout: 600000 });
+	await t.expect(transactionsCount).gte(12);
 };
 
 export const goToWallet = async (t: any, wallet = "D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD") => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
-   [x] Ensure persist is called through environment context, and not directly. 
-   [x] Fix failing e2e tests (timeouts)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
