### PR TITLE
fix: show correct layout as active on first render

### DIFF
--- a/src/domains/dashboard/components/WalletsControls/WalletsControls.tsx
+++ b/src/domains/dashboard/components/WalletsControls/WalletsControls.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from "app/components/Dropdown";
 import { LayoutControls } from "app/components/LayoutControls";
 import { Tooltip } from "app/components/Tooltip";
 import { FilterWallets, FilterWalletsHookProps } from "domains/dashboard/components/FilterWallets";
-import React, { memo, useState } from "react";
+import React, { memo, useLayoutEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 type WalletsControlsProps = {
@@ -29,6 +29,8 @@ export const WalletsControls = memo(
 		onFilterChange,
 	}: WalletsControlsProps) => {
 		const [walletsViewType, setWalletsViewType] = useState(filterProperties.viewType);
+
+		useLayoutEffect(() => setWalletsViewType(filterProperties.viewType), [filterProperties.viewType]);
 
 		const { t } = useTranslation();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/kdc50y

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
