### PR TITLE
fix: adjust height calculation of news options container

### DIFF
--- a/src/domains/news/components/NewsOptions/NewsOptions.tsx
+++ b/src/domains/news/components/NewsOptions/NewsOptions.tsx
@@ -25,10 +25,10 @@ interface NewsOptionsProps {
 	onSubmit?: (data: object) => void;
 }
 
-//region for scrollable sidebar on small screen
-const HEADER_HEIGHT = 86;
-const VERTICAL_PADDING = 40;
-//endregion
+// region for scrollable sidebar on small screen
+const HEADER_HEIGHT = 84;
+const VERTICAL_PADDING = 20 + 32;
+// endregion
 
 export const NewsOptions = ({ selectedCategories, selectedCoins, onSearch, onSubmit }: NewsOptionsProps) => {
 	const { t } = useTranslation();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/kvbxnd

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
