### PR TITLE
fix: show button tooltip only on own address

### DIFF
--- a/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/AddParticipant.tsx
+++ b/src/domains/transaction/components/MultiSignatureRegistrationForm/components/AddParticipant/AddParticipant.tsx
@@ -144,7 +144,7 @@ export const AddParticipant = ({ profile, wallet, onChange, defaultParticipants 
 				<RecipientList
 					recipients={participants}
 					assetSymbol={wallet.network().ticker()}
-					buttonTooltip={t("TRANSACTION.MULTISIGNATURE.REMOVE_NOT_ALLOWED")}
+					tooltipDisabled={t("TRANSACTION.MULTISIGNATURE.REMOVE_NOT_ALLOWED")}
 					disableButton={(address: string) => address === wallet.address()}
 					onRemove={removeParticipant}
 					label="TRANSACTION.MULTISIGNATURE.PARTICIPANT_#"

--- a/src/domains/transaction/components/RecipientList/RecipientList.models.ts
+++ b/src/domains/transaction/components/RecipientList/RecipientList.models.ts
@@ -11,7 +11,7 @@ export interface RecipientListItem {
 	variant?: "condensed";
 	walletName?: string;
 	showAmount?: boolean;
-	buttonTooltip?: string;
+	tooltipDisabled?: string;
 	disableButton?: (address: string) => boolean;
 	onRemove?: (index: number) => void;
 }
@@ -24,7 +24,7 @@ export interface RecipientList {
 	showAmount?: boolean;
 	label?: string;
 	variant?: "condensed";
-	buttonTooltip?: string;
+	tooltipDisabled?: string;
 	disableButton?: (address: string) => boolean;
 	onRemove?: (index: number) => void;
 }

--- a/src/domains/transaction/components/RecipientList/RecipientList.tsx
+++ b/src/domains/transaction/components/RecipientList/RecipientList.tsx
@@ -29,7 +29,7 @@ const RecipientListItem = ({
 	variant,
 	walletName,
 	onRemove,
-	buttonTooltip,
+	tooltipDisabled,
 	disableButton,
 	showAmount,
 }: RecipientListItemProps) => {
@@ -95,7 +95,7 @@ const RecipientListItem = ({
 
 			{isEditable && (
 				<td className="py-6 w-20 text-right">
-					<Tooltip content={buttonTooltip}>
+					<Tooltip content={tooltipDisabled} disabled={!isButtonDisabled}>
 						<span className="inline-block">
 							<Button
 								disabled={isButtonDisabled}
@@ -122,7 +122,7 @@ export const RecipientList = ({
 	variant,
 	label,
 	showAmount,
-	buttonTooltip,
+	tooltipDisabled,
 	disableButton,
 	onRemove,
 }: RecipientListProps) => {
@@ -152,7 +152,7 @@ export const RecipientList = ({
 						listIndex={index}
 						variant={variant}
 						walletName={recipient.walletName}
-						buttonTooltip={buttonTooltip}
+						tooltipDisabled={tooltipDisabled}
 						disableButton={disableButton}
 						onRemove={onRemove}
 					/>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

https://app.clickup.com/t/kx5f9v

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
