### PR TITLE
test: add awaits to jest resolves/rejects calls

### DIFF
--- a/src/app/hooks/use-fees.test.tsx
+++ b/src/app/hooks/use-fees.test.tsx
@@ -21,7 +21,7 @@ describe("useFees", () => {
 		} = renderHook(() => useFees({ profile }), { wrapper });
 
 		await env.fees().sync(profile, "ARK", "ark.devnet");
-		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+		await expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
 			static: "5",
 			max: "5",
 			min: "5",
@@ -41,7 +41,7 @@ describe("useFees", () => {
 		} = renderHook(() => useFees({ profile, normalize: false }), { wrapper });
 
 		await env.fees().sync(profile, "ARK", "ark.devnet");
-		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+		await expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
 			static: "500000000",
 			max: "500000000",
 			min: "500000000",
@@ -66,7 +66,7 @@ describe("useFees", () => {
 		} = renderHook(() => useFees({ profile }), { wrapper });
 
 		await env.fees().sync(profile, "ARK", "ark.devnet");
-		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+		await expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
 			static: "5",
 			max: "5",
 			min: "5",
@@ -95,7 +95,7 @@ describe("useFees", () => {
 		} = renderHook(() => useFees({ profile }), { wrapper });
 
 		await env.fees().sync(profile, "ARK", "ark.devnet");
-		expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
+		await expect(current.findByType("ARK", "ark.devnet", "ipfs")).resolves.toEqual({
 			static: "5",
 			max: "5",
 			min: "5",

--- a/src/app/hooks/use-profile-synchronizer.test.tsx
+++ b/src/app/hooks/use-profile-synchronizer.test.tsx
@@ -332,7 +332,7 @@ describe("useProfileRestore", () => {
 			result: { current },
 		} = renderHook(() => useProfileRestore(), { wrapper });
 
-		expect(current.restoreProfile(profile)).resolves.toEqual(false);
+		await expect(current.restoreProfile(profile)).resolves.toEqual(false);
 
 		process.env.TEST_PROFILES_RESTORE_STATUS = undefined;
 	});
@@ -496,7 +496,6 @@ describe("useProfileRestore", () => {
 
 		const historyMock = jest.spyOn(history, "push").mockReturnValue();
 
-		jest.runAllTimers();
 		await waitFor(() => expect(getByTestId("ProfileRestored")).toBeInTheDocument(), { timeout: 4000 });
 
 		await waitFor(() => expect(historyMock).toHaveBeenCalled(), { timeout: 4000 });

--- a/src/domains/transaction/hooks/use-wallet-signatory.test.ts
+++ b/src/domains/transaction/hooks/use-wallet-signatory.test.ts
@@ -17,32 +17,34 @@ describe("useWalletSignatory", () => {
 		await profile.sync();
 	});
 
-	it("should sign with mnemonic", () => {
+	it("should sign with mnemonic", async () => {
 		const mockMnemonic = jest.spyOn(wallet.signatory(), "mnemonic");
 		const { result } = renderHook(() => useWalletSignatory(wallet));
-		expect(result.current.sign({ mnemonic: "mnemonic" })).resolves.toBeTruthy();
+		await expect(result.current.sign({ mnemonic: "mnemonic" })).resolves.toBeTruthy();
 		expect(mockMnemonic).toHaveBeenCalled();
 		mockMnemonic.mockRestore();
 	});
 
-	it("should sign with secondMnemonic", () => {
+	it("should sign with secondMnemonic", async () => {
 		const mockSecondaryMnemonic = jest.spyOn(wallet.signatory(), "secondaryMnemonic");
 		const { result } = renderHook(() => useWalletSignatory(wallet));
-		expect(result.current.sign({ mnemonic: "mnemonic", secondMnemonic: "second mnemonic" })).resolves.toBeTruthy();
+		await expect(
+			result.current.sign({ mnemonic: "mnemonic", secondMnemonic: "second mnemonic" }),
+		).resolves.toBeTruthy();
 		mockSecondaryMnemonic.mockRestore();
 	});
 
-	it("should sign multisignature wallet", () => {
+	it("should sign multisignature wallet", async () => {
 		const mockIsMultiSignature = jest.spyOn(wallet, "isMultiSignature").mockReturnValue(true);
 		const mockSecondaryMnemonic = jest.spyOn(wallet.signatory(), "senderPublicKey");
 		const { result } = renderHook(() => useWalletSignatory(wallet));
-		expect(result.current.sign({})).resolves.toBeTruthy();
+		await expect(result.current.sign({})).resolves.toBeTruthy();
 		mockSecondaryMnemonic.mockRestore();
 		mockIsMultiSignature.mockRestore();
 	});
 
-	it("should throw error if no input is provided", () => {
+	it("should throw error if no input is provided", async () => {
 		const { result } = renderHook(() => useWalletSignatory(wallet));
-		expect(result.current.sign({})).rejects.toBeTruthy();
+		await expect(result.current.sign({})).rejects.toBeTruthy();
 	});
 });

--- a/src/domains/wallet/hooks/use-wallet-import.test.tsx
+++ b/src/domains/wallet/hooks/use-wallet-import.test.tsx
@@ -26,7 +26,7 @@ describe("useWalletImport", () => {
 		});
 
 		await act(async () => {
-			expect(
+			await expect(
 				current.importWalletByType({ network, type: "encryptedWif", value: "password", encryptedWif: "wif" }),
 			).rejects.toBeTruthy();
 		});
@@ -34,7 +34,7 @@ describe("useWalletImport", () => {
 		mockEncryptedWif.mockRestore();
 
 		await act(async () => {
-			expect(
+			await expect(
 				current.importWalletByType({ network, type: "uknown", value: "password", encryptedWif: "wif" }),
 			).resolves.toBeUndefined();
 		});

--- a/src/domains/wallet/hooks/use-wallet-sync.test.tsx
+++ b/src/domains/wallet/hooks/use-wallet-sync.test.tsx
@@ -25,7 +25,7 @@ describe("useWalletSync", () => {
 		const mockAllowVoting = jest.spyOn(network, "allowsVoting").mockReturnValue(false);
 
 		await act(async () => {
-			expect(current.syncAll(wallet)).resolves.toBeTruthy();
+			await expect(current.syncAll(wallet)).resolves.toBeTruthy();
 		});
 
 		mockAllowVoting.mockRestore();


### PR DESCRIPTION
## Summary

If applied, this PR will add `await` where missing in front of expect(something).resolves and rejects calls.

## Checklist

-   [x] Tests
