### PR TITLE
refactor: add switch component

### DIFF
--- a/src/app/components/Switch/Switch.test.tsx
+++ b/src/app/components/Switch/Switch.test.tsx
@@ -1,0 +1,69 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import React, { useState } from "react";
+
+import { Switch, SwitchOptions } from "./Switch";
+
+describe("Switch", () => {
+	const onChange = jest.fn();
+
+	const options: SwitchOptions = [
+		{ value: "a", label: "Option A" },
+		{ value: "b", label: "Option B" },
+	];
+
+	const Wrapper = () => {
+		const [value, setValue] = useState("a");
+
+		const change = (val: string) => {
+			onChange(val);
+			setValue(val);
+		};
+
+		return <Switch value={value} onChange={change} options={options} />;
+	};
+
+	it("should render", () => {
+		const { asFragment, getByRole, getByText } = render(<Wrapper />);
+
+		expect(getByRole("checkbox")).toBeTruthy();
+		expect(getByText("Option A")).toBeTruthy();
+		expect(getByText("Option B")).toBeTruthy();
+		expect(asFragment()).toMatchSnapshot();
+	});
+
+	it("should allow changing the selected option by clicking the handle", () => {
+		const { getByRole } = render(<Wrapper />);
+
+		act(() => {
+			fireEvent.click(getByRole("checkbox"));
+		});
+
+		expect(onChange).toBeCalledWith("b");
+		expect(getByRole("checkbox")).toBeChecked();
+
+		act(() => {
+			fireEvent.click(getByRole("checkbox"));
+		});
+
+		expect(onChange).toBeCalledWith("a");
+		expect(getByRole("checkbox")).not.toBeChecked();
+	});
+
+	it("should allow changing the selected option by clicking the option text", () => {
+		const { getByRole, getByText } = render(<Wrapper />);
+
+		act(() => {
+			fireEvent.click(getByText("Option B"));
+		});
+
+		expect(onChange).toBeCalledWith("b");
+		expect(getByRole("checkbox")).toBeChecked();
+
+		act(() => {
+			fireEvent.click(getByText("Option A"));
+		});
+
+		expect(onChange).toBeCalledWith("a");
+		expect(getByRole("checkbox")).not.toBeChecked();
+	});
+});

--- a/src/app/components/Switch/Switch.test.tsx
+++ b/src/app/components/Switch/Switch.test.tsx
@@ -1,15 +1,13 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import React, { useState } from "react";
 
-import { Switch, SwitchOptions } from "./Switch";
+import { Switch, SwitchOption } from "./Switch";
 
 describe("Switch", () => {
 	const onChange = jest.fn();
 
-	const options: SwitchOptions = [
-		{ value: "a", label: "Option A" },
-		{ value: "b", label: "Option B" },
-	];
+	const leftOption: SwitchOption = { value: "a", label: "Option A" };
+	const rightOption: SwitchOption = { value: "b", label: "Option B" };
 
 	const Wrapper = () => {
 		const [value, setValue] = useState("a");
@@ -19,7 +17,7 @@ describe("Switch", () => {
 			setValue(val);
 		};
 
-		return <Switch value={value} onChange={change} options={options} />;
+		return <Switch value={value} onChange={change} leftOption={leftOption} rightOption={rightOption} />;
 	};
 
 	it("should render", () => {

--- a/src/app/components/Switch/Switch.tsx
+++ b/src/app/components/Switch/Switch.tsx
@@ -4,23 +4,26 @@ import React from "react";
 import { Toggle } from "../Toggle";
 import { SwitchText } from "./SwitchText";
 
-interface SwitchOption<TValue> {
+export interface SwitchOption<TValue = string> {
 	label: string;
 	value: TValue;
 }
 
-export type SwitchOptions<TValue = string> = [SwitchOption<TValue>, SwitchOption<TValue>];
-
 interface Props<TOptionValue = string> {
 	value: TOptionValue;
 	onChange: (value: TOptionValue) => void;
-	options: SwitchOptions<TOptionValue>;
+	leftOption: SwitchOption<TOptionValue>;
+	rightOption: SwitchOption<TOptionValue>;
 	className?: string;
 }
 
-export function Switch<TOptionValue = string>({ value, onChange, options, className }: Props<TOptionValue>) {
-	const [left, right] = options;
-
+export function Switch<TOptionValue = string>({
+	value,
+	onChange,
+	leftOption,
+	rightOption,
+	className,
+}: Props<TOptionValue>) {
 	const renderOption = (option: SwitchOption<TOptionValue>) => (
 		<SwitchText role="button" selected={option.value === value} onClick={() => onChange(option.value)}>
 			{option.label}
@@ -29,17 +32,17 @@ export function Switch<TOptionValue = string>({ value, onChange, options, classN
 
 	return (
 		<div className={cn("flex items-center", className)}>
-			{renderOption(left)}
+			{renderOption(leftOption)}
 
 			<div className="mx-4">
 				<Toggle
 					alwaysOn
-					checked={right.value === value}
-					onChange={() => onChange(right.value === value ? left.value : right.value)}
+					checked={rightOption.value === value}
+					onChange={() => onChange(rightOption.value === value ? leftOption.value : rightOption.value)}
 				/>
 			</div>
 
-			{renderOption(right)}
+			{renderOption(rightOption)}
 		</div>
 	);
 }

--- a/src/app/components/Switch/Switch.tsx
+++ b/src/app/components/Switch/Switch.tsx
@@ -1,0 +1,45 @@
+import cn from "classnames";
+import React from "react";
+
+import { Toggle } from "../Toggle";
+import { SwitchText } from "./SwitchText";
+
+interface SwitchOption<TValue> {
+	label: string;
+	value: TValue;
+}
+
+export type SwitchOptions<TValue = string> = [SwitchOption<TValue>, SwitchOption<TValue>];
+
+interface Props<TOptionValue = string> {
+	value: TOptionValue;
+	onChange: (value: TOptionValue) => void;
+	options: SwitchOptions<TOptionValue>;
+	className?: string;
+}
+
+export function Switch<TOptionValue = string>({ value, onChange, options, className }: Props<TOptionValue>) {
+	const [left, right] = options;
+
+	const renderOption = (option: SwitchOption<TOptionValue>) => (
+		<SwitchText role="button" selected={option.value === value} onClick={() => onChange(option.value)}>
+			{option.label}
+		</SwitchText>
+	);
+
+	return (
+		<div className={cn("flex items-center", className)}>
+			{renderOption(left)}
+
+			<div className="mx-4">
+				<Toggle
+					alwaysOn
+					checked={right.value === value}
+					onChange={() => onChange(right.value === value ? left.value : right.value)}
+				/>
+			</div>
+
+			{renderOption(right)}
+		</div>
+	);
+}

--- a/src/app/components/Switch/SwitchText.tsx
+++ b/src/app/components/Switch/SwitchText.tsx
@@ -1,0 +1,12 @@
+import { PropsWithChildren } from "react";
+import tw, { styled } from "twin.macro";
+
+interface Props {
+	selected?: boolean;
+}
+
+export const SwitchText = styled.span<PropsWithChildren<Props>>`
+	${tw`text-lg font-semibold text-theme-secondary-500 dark:text-theme-secondary-700`}
+
+	${({ selected }) => selected && tw`text-theme-secondary-700 dark:text-theme-secondary-200`}
+`;

--- a/src/app/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/src/app/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Switch should render 1`] = `
+<DocumentFragment>
+  <div
+    class="flex items-center"
+  >
+    <span
+      class="SwitchText-sc-1l99vi2-0 jdBPCe"
+      role="button"
+    >
+      Option A
+    </span>
+    <div
+      class="mx-4"
+    >
+      <label
+        class="flex"
+      >
+        <input
+          class="Toggle__Input-qyyifx-0 WGuGL"
+          type="checkbox"
+        />
+        <div
+          class="Toggle__Handle-qyyifx-1 geejDn"
+        >
+          <span
+            class="Toggle__HandleInner-qyyifx-2 eSIhju"
+          />
+        </div>
+      </label>
+    </div>
+    <span
+      class="SwitchText-sc-1l99vi2-0 hkRGPv"
+      role="button"
+    >
+      Option B
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/src/app/components/Switch/index.ts
+++ b/src/app/components/Switch/index.ts
@@ -1,0 +1,1 @@
+export * from "./Switch";

--- a/src/domains/wallet/components/VerifyMessage/VerifyMessage.test.tsx
+++ b/src/domains/wallet/components/VerifyMessage/VerifyMessage.test.tsx
@@ -54,7 +54,7 @@ describe("VerifyMessage", () => {
 	it("should switch between manual and json input", async () => {
 		await renderComponent({});
 
-		const toggle = screen.getByTestId("VerifyMessage__toggle");
+		const toggle = screen.getByRole("checkbox");
 
 		expect(screen.getByTestId("VerifyMessage__manual")).toBeTruthy();
 
@@ -144,7 +144,7 @@ describe("VerifyMessage", () => {
 
 		await renderComponent({ onSubmit });
 
-		const toggle = screen.getByTestId("VerifyMessage__toggle");
+		const toggle = screen.getByRole("checkbox");
 
 		act(() => {
 			fireEvent.click(toggle);

--- a/src/domains/wallet/components/VerifyMessage/VerifyMessage.tsx
+++ b/src/domains/wallet/components/VerifyMessage/VerifyMessage.tsx
@@ -1,17 +1,20 @@
-// UI Elements
 import { Button } from "app/components/Button";
 import { Form, FormField, FormLabel } from "app/components/Form";
 import { InputDefault } from "app/components/Input";
 import { Modal } from "app/components/Modal";
+import { Switch, SwitchOptions } from "app/components/Switch";
 import { TextArea } from "app/components/TextArea";
-import { Toggle } from "app/components/Toggle";
 import { useEnvironmentContext } from "app/contexts";
 import { useValidation } from "app/hooks";
-import cn from "classnames";
 import { VerifyMessageStatus } from "domains/wallet/components/VerifyMessageStatus";
 import React, { ChangeEvent, useEffect, useState } from "react";
 import { useForm, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+
+enum VerificationMethod {
+	Manual,
+	Json,
+}
 
 interface Props {
 	isOpen: boolean;
@@ -116,11 +119,22 @@ export const VerifyMessage = ({ profileId, walletId, onSubmit, onCancel, isOpen,
 	const { getValues, formState } = form;
 	const { isValid } = formState;
 
-	const [verificationMethod, setVerificationMethod] = useState("manual");
+	const [verificationMethod, setVerificationMethod] = useState<VerificationMethod>(VerificationMethod.Manual);
 	const [isMessageVerified, setIsMessageVerified] = useState(false);
 	const [isSubmitted, setIsSubmitted] = useState(false);
 
-	const isJson = verificationMethod === "json";
+	const isJson = verificationMethod === VerificationMethod.Json;
+
+	const verificationMethods: SwitchOptions<VerificationMethod> = [
+		{
+			label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.JSON"),
+			value: VerificationMethod.Json,
+		},
+		{
+			label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.MANUAL"),
+			value: VerificationMethod.Manual,
+		},
+	];
 
 	const handleSubmit = async () => {
 		const profile = env?.profiles().findById(profileId);
@@ -175,30 +189,12 @@ export const VerifyMessage = ({ profileId, walletId, onSubmit, onCancel, isOpen,
 					{t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.DESCRIPTION")}
 				</span>
 
-				<div className="flex items-center mt-6 space-x-4 text-theme-secondary-500 dark:text-theme-secondary-700">
-					<div
-						className={cn("text-lg font-semibold", {
-							"text-theme-secondary-700 dark:text-theme-secondary-200": isJson,
-						})}
-					>
-						{t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.JSON")}
-					</div>
-
-					<Toggle
-						data-testid="VerifyMessage__toggle"
-						checked={!isJson}
-						onChange={(event) => setVerificationMethod(event.target.checked ? "manual" : "json")}
-						alwaysOn
-					/>
-
-					<div
-						className={cn("text-lg font-semibold", {
-							"text-theme-secondary-700 dark:text-theme-secondary-200": !isJson,
-						})}
-					>
-						{t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.MANUAL")}
-					</div>
-				</div>
+				<Switch
+					className="mt-6 space-x-4"
+					value={verificationMethod}
+					onChange={setVerificationMethod}
+					options={verificationMethods}
+				/>
 
 				<Form id="VerifyMessage__form" context={form} onSubmit={handleSubmit}>
 					{isJson ? <JsonForm /> : <ManualForm />}

--- a/src/domains/wallet/components/VerifyMessage/VerifyMessage.tsx
+++ b/src/domains/wallet/components/VerifyMessage/VerifyMessage.tsx
@@ -2,7 +2,7 @@ import { Button } from "app/components/Button";
 import { Form, FormField, FormLabel } from "app/components/Form";
 import { InputDefault } from "app/components/Input";
 import { Modal } from "app/components/Modal";
-import { Switch, SwitchOptions } from "app/components/Switch";
+import { Switch } from "app/components/Switch";
 import { TextArea } from "app/components/TextArea";
 import { useEnvironmentContext } from "app/contexts";
 import { useValidation } from "app/hooks";
@@ -125,17 +125,6 @@ export const VerifyMessage = ({ profileId, walletId, onSubmit, onCancel, isOpen,
 
 	const isJson = verificationMethod === VerificationMethod.Json;
 
-	const verificationMethods: SwitchOptions<VerificationMethod> = [
-		{
-			label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.JSON"),
-			value: VerificationMethod.Json,
-		},
-		{
-			label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.MANUAL"),
-			value: VerificationMethod.Manual,
-		},
-	];
-
 	const handleSubmit = async () => {
 		const profile = env?.profiles().findById(profileId);
 		const wallet = profile?.wallets().findById(walletId);
@@ -193,7 +182,14 @@ export const VerifyMessage = ({ profileId, walletId, onSubmit, onCancel, isOpen,
 					className="mt-6 space-x-4"
 					value={verificationMethod}
 					onChange={setVerificationMethod}
-					options={verificationMethods}
+					leftOption={{
+						label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.JSON"),
+						value: VerificationMethod.Json,
+					}}
+					rightOption={{
+						label: t("WALLETS.MODAL_VERIFY_MESSAGE.VERIFICATION_METHOD.MANUAL"),
+						value: VerificationMethod.Manual,
+					}}
 				/>
 
 				<Form id="VerifyMessage__form" context={form} onSubmit={handleSubmit}>

--- a/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
+++ b/src/domains/wallet/components/VerifyMessage/__snapshots__/VerifyMessage.test.tsx.snap
@@ -67,35 +67,40 @@ exports[`VerifyMessage should render 1`] = `
                 Input fields manually or provide a JSON string.
               </span>
               <div
-                class="flex items-center mt-6 space-x-4 text-theme-secondary-500 dark:text-theme-secondary-700"
+                class="flex items-center mt-6 space-x-4"
               >
-                <div
-                  class="text-lg font-semibold"
+                <span
+                  class="SwitchText-sc-1l99vi2-0 hkRGPv"
+                  role="button"
                 >
                   JSON
-                </div>
-                <label
-                  class="flex"
-                >
-                  <input
-                    checked=""
-                    class="Toggle__Input-qyyifx-0 WGuGL"
-                    data-testid="VerifyMessage__toggle"
-                    type="checkbox"
-                  />
-                  <div
-                    class="Toggle__Handle-qyyifx-1 geejDn"
-                  >
-                    <span
-                      class="Toggle__HandleInner-qyyifx-2 eSIhju"
-                    />
-                  </div>
-                </label>
+                </span>
                 <div
-                  class="text-lg font-semibold text-theme-secondary-700 dark:text-theme-secondary-200"
+                  class="mx-4"
+                >
+                  <label
+                    class="flex"
+                  >
+                    <input
+                      checked=""
+                      class="Toggle__Input-qyyifx-0 WGuGL"
+                      type="checkbox"
+                    />
+                    <div
+                      class="Toggle__Handle-qyyifx-1 geejDn"
+                    >
+                      <span
+                        class="Toggle__HandleInner-qyyifx-2 eSIhju"
+                      />
+                    </div>
+                  </label>
+                </div>
+                <span
+                  class="SwitchText-sc-1l99vi2-0 jdBPCe"
+                  role="button"
                 >
                   Manual
-                </div>
+                </span>
               </div>
               <form
                 class="space-y-8"

--- a/src/domains/wallet/e2e/verify-message-action.e2e.ts
+++ b/src/domains/wallet/e2e/verify-message-action.e2e.ts
@@ -64,7 +64,7 @@ test("Should fail verification", async (t) => {
 		message: "Wrong message",
 	};
 
-	await t.click(Selector("[data-testid=VerifyMessage__toggle]").sibling(-1));
+	await t.click(Selector("input[type=checkbox]").parent());
 
 	await t.typeText(Selector("[data-testid=VerifyMessage__json-jsonString]"), JSON.stringify(mockFailingMessage));
 
@@ -95,7 +95,7 @@ test("Should successfully verify message", async (t) => {
 		message: "Hello World",
 	};
 
-	await t.click(Selector("[data-testid=VerifyMessage__toggle]").sibling(-1));
+	await t.click(Selector("input[type=checkbox]").parent());
 
 	await t.typeText(Selector("[data-testid=VerifyMessage__json-jsonString]"), JSON.stringify(mockSuccessMessage));
 


### PR DESCRIPTION
## Summary

If applied, this PR will add a Switch component, wrapping a Toggle component with two clickable labels on the sides. Since it shows up in both VerifyMessage and the new InputFee redesign, the idea is to wrap its logic in a reusable component.

Note: additional tweaking will be implemented along with InputFee to allow for slightly different designs (e.g. smaller options text).

## Screenshots

### Dark
![image](https://user-images.githubusercontent.com/18616324/121136021-719f0180-c835-11eb-823c-c2faaf288aa8.png)

### Light
![image](https://user-images.githubusercontent.com/18616324/121136106-8e3b3980-c835-11eb-8f29-7275525ff0e6.png)

## Checklist

-   [x] My changes look good in both light AND dark mode
-   [x] Tests
-   [x] Ready to be merged
