### PR TITLE
fix: make memo input reactive in `SendTransfer`

### DIFF
--- a/src/domains/transaction/pages/SendTransfer/FormStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/FormStep.tsx
@@ -84,7 +84,7 @@ export const FormStep = ({
 							type="text"
 							placeholder=" "
 							maxLengthLabel="255"
-							defaultValue={memo}
+							value={memo || ""}
 							onChange={(event: ChangeEvent<HTMLInputElement>) =>
 								setValue("memo", event.target.value, { shouldDirty: true, shouldValidate: true })
 							}

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -3659,7 +3659,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
                         >
-                          …
+                          ARK…
                         </div>
                         <div
                           class="Input__InputWrapperStyled-wu99qs-0 jYUFQr"
@@ -3673,7 +3673,7 @@ exports[`SendTransfer should render form and use location state 1`] = `
                               name="memo"
                               placeholder=" "
                               type="text"
-                              value=""
+                              value="ARK"
                             />
                           </div>
                           <div
@@ -8441,6 +8441,7 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
                         >
+                          
                           …
                         </div>
                         <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
