### PR TITLE
refactor: move transaction type dropdown into tabs

### DIFF
--- a/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/domains/dashboard/pages/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -793,49 +793,6 @@ exports[`Dashboard should render 1`] = `
             >
               Transaction History
             </div>
-            <div
-              class="mt-6"
-              data-testid="FilterTransactions"
-            >
-              <div
-                class="relative"
-              >
-                <span
-                  data-testid="dropdown__toggle"
-                >
-                  <button
-                    class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-                    data-testid="CollapseToggleButton"
-                  >
-                    <span>
-                      <span
-                        class="text-theme-secondary-500 dark:text-theme-secondary-600"
-                      >
-                        Type: 
-                      </span>
-                      <span
-                        class="text-theme-secondary-700 dark:text-theme-secondary-200"
-                      >
-                        All
-                      </span>
-                    </span>
-                    <span
-                      class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-                    >
-                      <div
-                        class="sc-bdfBwQ kJrqvM"
-                        height="5"
-                        width="8"
-                      >
-                        <svg>
-                          chevron-down.svg
-                        </svg>
-                      </div>
-                    </span>
-                  </button>
-                </span>
-              </div>
-            </div>
           </div>
           <div
             class="mb-8"
@@ -888,6 +845,52 @@ exports[`Dashboard should render 1`] = `
                   Outgoing
                 </span>
               </button>
+              <div
+                class="flex flex-1"
+              />
+              <div
+                class="my-auto mr-6"
+                data-testid="FilterTransactions"
+              >
+                <div
+                  class="relative"
+                >
+                  <span
+                    data-testid="dropdown__toggle"
+                  >
+                    <button
+                      class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+                      data-testid="CollapseToggleButton"
+                    >
+                      <span>
+                        <span
+                          class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                        >
+                          Type: 
+                        </span>
+                        <span
+                          class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                        >
+                          All
+                        </span>
+                      </span>
+                      <span
+                        class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+                      >
+                        <div
+                          class="sc-bdfBwQ kJrqvM"
+                          height="5"
+                          width="8"
+                        >
+                          <svg>
+                            chevron-down.svg
+                          </svg>
+                        </div>
+                      </span>
+                    </button>
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -2492,49 +2495,6 @@ exports[`Dashboard should render loading state when profile is syncing 1`] = `
             >
               Transaction History
             </div>
-            <div
-              class="mt-6"
-              data-testid="FilterTransactions"
-            >
-              <div
-                class="relative"
-              >
-                <span
-                  data-testid="dropdown__toggle"
-                >
-                  <button
-                    class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-                    data-testid="CollapseToggleButton"
-                  >
-                    <span>
-                      <span
-                        class="text-theme-secondary-500 dark:text-theme-secondary-600"
-                      >
-                        Type: 
-                      </span>
-                      <span
-                        class="text-theme-secondary-700 dark:text-theme-secondary-200"
-                      >
-                        All
-                      </span>
-                    </span>
-                    <span
-                      class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-                    >
-                      <div
-                        class="sc-bdfBwQ kJrqvM"
-                        height="5"
-                        width="8"
-                      >
-                        <svg>
-                          chevron-down.svg
-                        </svg>
-                      </div>
-                    </span>
-                  </button>
-                </span>
-              </div>
-            </div>
           </div>
           <div
             class="mb-8"
@@ -2587,6 +2547,52 @@ exports[`Dashboard should render loading state when profile is syncing 1`] = `
                   Outgoing
                 </span>
               </button>
+              <div
+                class="flex flex-1"
+              />
+              <div
+                class="my-auto mr-6"
+                data-testid="FilterTransactions"
+              >
+                <div
+                  class="relative"
+                >
+                  <span
+                    data-testid="dropdown__toggle"
+                  >
+                    <button
+                      class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+                      data-testid="CollapseToggleButton"
+                    >
+                      <span>
+                        <span
+                          class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                        >
+                          Type: 
+                        </span>
+                        <span
+                          class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                        >
+                          All
+                        </span>
+                      </span>
+                      <span
+                        class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+                      >
+                        <div
+                          class="sc-bdfBwQ kJrqvM"
+                          height="5"
+                          width="8"
+                        >
+                          <svg>
+                            chevron-down.svg
+                          </svg>
+                        </div>
+                      </span>
+                    </button>
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div
@@ -5244,49 +5250,6 @@ exports[`Dashboard should show warning for errored networks 1`] = `
             >
               Transaction History
             </div>
-            <div
-              class="mt-6"
-              data-testid="FilterTransactions"
-            >
-              <div
-                class="relative"
-              >
-                <span
-                  data-testid="dropdown__toggle"
-                >
-                  <button
-                    class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-                    data-testid="CollapseToggleButton"
-                  >
-                    <span>
-                      <span
-                        class="text-theme-secondary-500 dark:text-theme-secondary-600"
-                      >
-                        Type: 
-                      </span>
-                      <span
-                        class="text-theme-secondary-700 dark:text-theme-secondary-200"
-                      >
-                        All
-                      </span>
-                    </span>
-                    <span
-                      class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-                    >
-                      <div
-                        class="sc-bdfBwQ kJrqvM"
-                        height="5"
-                        width="8"
-                      >
-                        <svg>
-                          chevron-down.svg
-                        </svg>
-                      </div>
-                    </span>
-                  </button>
-                </span>
-              </div>
-            </div>
           </div>
           <div
             class="mb-8"
@@ -5339,6 +5302,52 @@ exports[`Dashboard should show warning for errored networks 1`] = `
                   Outgoing
                 </span>
               </button>
+              <div
+                class="flex flex-1"
+              />
+              <div
+                class="my-auto mr-6"
+                data-testid="FilterTransactions"
+              >
+                <div
+                  class="relative"
+                >
+                  <span
+                    data-testid="dropdown__toggle"
+                  >
+                    <button
+                      class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+                      data-testid="CollapseToggleButton"
+                    >
+                      <span>
+                        <span
+                          class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                        >
+                          Type: 
+                        </span>
+                        <span
+                          class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                        >
+                          All
+                        </span>
+                      </span>
+                      <span
+                        class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+                      >
+                        <div
+                          class="sc-bdfBwQ kJrqvM"
+                          height="5"
+                          width="8"
+                        >
+                          <svg>
+                            chevron-down.svg
+                          </svg>
+                        </div>
+                      </span>
+                    </button>
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
           <div

--- a/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/PendingTransactionsTable.tsx
+++ b/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/PendingTransactionsTable.tsx
@@ -61,7 +61,7 @@ export const PendingTransactions = ({
 
 	return (
 		<div data-testid="PendingTransactions" className="relative">
-			<h2 className="mb-6 font-bold">{t("WALLETS.PAGE_WALLET_DETAILS.PENDING_TRANSACTIONS")}</h2>
+			<h2 className="mb-6">{t("WALLETS.PAGE_WALLET_DETAILS.PENDING_TRANSACTIONS")}</h2>
 
 			<Table columns={columns} data={[...transfers, ...signed]}>
 				{(transaction: DTO.ExtendedTransactionData | DTO.ExtendedSignedTransactionData) => {

--- a/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
+++ b/src/domains/transaction/components/TransactionTable/PendingTransactionsTable/__snapshots__/PendingTransactionsTable.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Signed Transaction Table should render pending transfers 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -312,7 +312,7 @@ exports[`Signed Transaction Table should render signed transactions 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -1340,7 +1340,7 @@ exports[`Signed Transaction Table should show as awaiting confirmations 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -1679,7 +1679,7 @@ exports[`Signed Transaction Table should show as awaiting other wallets signatur
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -2018,7 +2018,7 @@ exports[`Signed Transaction Table should show as awaiting the wallet signature 1
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -2357,7 +2357,7 @@ exports[`Signed Transaction Table should show as final signature 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -2696,7 +2696,7 @@ exports[`Signed Transaction Table should show as unvote 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -3031,7 +3031,7 @@ exports[`Signed Transaction Table should show as vote 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>
@@ -3366,7 +3366,7 @@ exports[`Signed Transaction Table should show the sign button 1`] = `
     data-testid="PendingTransactions"
   >
     <h2
-      class="mb-6 font-bold"
+      class="mb-6"
     >
       Pending Transactions
     </h2>

--- a/src/domains/transaction/components/Transactions/Transactions.tsx
+++ b/src/domains/transaction/components/Transactions/Transactions.tsx
@@ -95,19 +95,6 @@ export const Transactions = memo(
 					{!title && (
 						<div className="mb-8 text-4xl font-bold">{t("DASHBOARD.TRANSACTION_HISTORY.TITLE")}</div>
 					)}
-
-					<FilterTransactions
-						wallets={wallets}
-						onSelect={(option, type) => {
-							setActiveTransactionTypeLabel(option.label);
-							updateFilters({
-								activeMode,
-								activeTransactionType: type,
-							});
-						}}
-						isDisabled={wallets.length === 0}
-						className="mt-6"
-					/>
 				</div>
 
 				<Tabs
@@ -132,6 +119,21 @@ export const Transactions = memo(
 						<Tab tabId="all">{t("TRANSACTION.ALL")}</Tab>
 						<Tab tabId="received">{t("TRANSACTION.INCOMING")}</Tab>
 						<Tab tabId="sent">{t("TRANSACTION.OUTGOING")}</Tab>
+
+						<div className="flex flex-1" />
+
+						<FilterTransactions
+							className="my-auto mr-6"
+							wallets={wallets}
+							onSelect={(option, type) => {
+								setActiveTransactionTypeLabel(option.label);
+								updateFilters({
+									activeMode,
+									activeTransactionType: type,
+								});
+							}}
+							isDisabled={wallets.length === 0}
+						/>
 					</TabList>
 				</Tabs>
 

--- a/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
+++ b/src/domains/transaction/components/Transactions/__snapshots__/Transactions.test.tsx.snap
@@ -10,49 +10,6 @@ exports[`Transactions should fetch more transactions 1`] = `
     >
       Transaction History
     </div>
-    <div
-      class="mt-6"
-      data-testid="FilterTransactions"
-    >
-      <div
-        class="relative"
-      >
-        <span
-          data-testid="dropdown__toggle"
-        >
-          <button
-            class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-            data-testid="CollapseToggleButton"
-          >
-            <span>
-              <span
-                class="text-theme-secondary-500 dark:text-theme-secondary-600"
-              >
-                Type: 
-              </span>
-              <span
-                class="text-theme-secondary-700 dark:text-theme-secondary-200"
-              >
-                All
-              </span>
-            </span>
-            <span
-              class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-            >
-              <div
-                class="sc-bdfBwQ kJrqvM"
-                height="5"
-                width="8"
-              >
-                <svg>
-                  chevron-down.svg
-                </svg>
-              </div>
-            </span>
-          </button>
-        </span>
-      </div>
-    </div>
   </div>
   <div
     class="mb-8"
@@ -105,6 +62,52 @@ exports[`Transactions should fetch more transactions 1`] = `
           Outgoing
         </span>
       </button>
+      <div
+        class="flex flex-1"
+      />
+      <div
+        class="my-auto mr-6"
+        data-testid="FilterTransactions"
+      >
+        <div
+          class="relative"
+        >
+          <span
+            data-testid="dropdown__toggle"
+          >
+            <button
+              class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+              data-testid="CollapseToggleButton"
+            >
+              <span>
+                <span
+                  class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                >
+                  Type: 
+                </span>
+                <span
+                  class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  All
+                </span>
+              </span>
+              <span
+                class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+              >
+                <div
+                  class="sc-bdfBwQ kJrqvM"
+                  height="5"
+                  width="8"
+                >
+                  <svg>
+                    chevron-down.svg
+                  </svg>
+                </div>
+              </span>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -924,49 +927,6 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
     >
       Transaction History
     </div>
-    <div
-      class="mt-6"
-      data-testid="FilterTransactions"
-    >
-      <div
-        class="relative"
-      >
-        <span
-          data-testid="dropdown__toggle"
-        >
-          <button
-            class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-            data-testid="CollapseToggleButton"
-          >
-            <span>
-              <span
-                class="text-theme-secondary-500 dark:text-theme-secondary-600"
-              >
-                Type: 
-              </span>
-              <span
-                class="text-theme-secondary-700 dark:text-theme-secondary-200"
-              >
-                All
-              </span>
-            </span>
-            <span
-              class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-            >
-              <div
-                class="sc-bdfBwQ kJrqvM"
-                height="5"
-                width="8"
-              >
-                <svg>
-                  chevron-down.svg
-                </svg>
-              </div>
-            </span>
-          </button>
-        </span>
-      </div>
-    </div>
   </div>
   <div
     class="mb-8"
@@ -1019,6 +979,52 @@ exports[`Transactions should open detail modal on transaction row click 1`] = `
           Outgoing
         </span>
       </button>
+      <div
+        class="flex flex-1"
+      />
+      <div
+        class="my-auto mr-6"
+        data-testid="FilterTransactions"
+      >
+        <div
+          class="relative"
+        >
+          <span
+            data-testid="dropdown__toggle"
+          >
+            <button
+              class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+              data-testid="CollapseToggleButton"
+            >
+              <span>
+                <span
+                  class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                >
+                  Type: 
+                </span>
+                <span
+                  class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  All
+                </span>
+              </span>
+              <span
+                class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+              >
+                <div
+                  class="sc-bdfBwQ kJrqvM"
+                  height="5"
+                  width="8"
+                >
+                  <svg>
+                    chevron-down.svg
+                  </svg>
+                </div>
+              </span>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -1849,49 +1855,6 @@ exports[`Transactions should render 1`] = `
     >
       Transaction History
     </div>
-    <div
-      class="mt-6"
-      data-testid="FilterTransactions"
-    >
-      <div
-        class="relative"
-      >
-        <span
-          data-testid="dropdown__toggle"
-        >
-          <button
-            class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-            data-testid="CollapseToggleButton"
-          >
-            <span>
-              <span
-                class="text-theme-secondary-500 dark:text-theme-secondary-600"
-              >
-                Type: 
-              </span>
-              <span
-                class="text-theme-secondary-700 dark:text-theme-secondary-200"
-              >
-                All
-              </span>
-            </span>
-            <span
-              class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-            >
-              <div
-                class="sc-bdfBwQ kJrqvM"
-                height="5"
-                width="8"
-              >
-                <svg>
-                  chevron-down.svg
-                </svg>
-              </div>
-            </span>
-          </button>
-        </span>
-      </div>
-    </div>
   </div>
   <div
     class="mb-8"
@@ -1944,6 +1907,52 @@ exports[`Transactions should render 1`] = `
           Outgoing
         </span>
       </button>
+      <div
+        class="flex flex-1"
+      />
+      <div
+        class="my-auto mr-6"
+        data-testid="FilterTransactions"
+      >
+        <div
+          class="relative"
+        >
+          <span
+            data-testid="dropdown__toggle"
+          >
+            <button
+              class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+              data-testid="CollapseToggleButton"
+            >
+              <span>
+                <span
+                  class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                >
+                  Type: 
+                </span>
+                <span
+                  class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  All
+                </span>
+              </span>
+              <span
+                class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+              >
+                <div
+                  class="sc-bdfBwQ kJrqvM"
+                  height="5"
+                  width="8"
+                >
+                  <svg>
+                    chevron-down.svg
+                  </svg>
+                </div>
+              </span>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -2774,49 +2783,6 @@ exports[`Transactions should render with custom title 1`] = `
     <h1>
       Test
     </h1>
-    <div
-      class="mt-6"
-      data-testid="FilterTransactions"
-    >
-      <div
-        class="relative"
-      >
-        <span
-          data-testid="dropdown__toggle"
-        >
-          <button
-            class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
-            data-testid="CollapseToggleButton"
-          >
-            <span>
-              <span
-                class="text-theme-secondary-500 dark:text-theme-secondary-600"
-              >
-                Type: 
-              </span>
-              <span
-                class="text-theme-secondary-700 dark:text-theme-secondary-200"
-              >
-                All
-              </span>
-            </span>
-            <span
-              class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
-            >
-              <div
-                class="sc-bdfBwQ kJrqvM"
-                height="5"
-                width="8"
-              >
-                <svg>
-                  chevron-down.svg
-                </svg>
-              </div>
-            </span>
-          </button>
-        </span>
-      </div>
-    </div>
   </div>
   <div
     class="mb-8"
@@ -2869,6 +2835,52 @@ exports[`Transactions should render with custom title 1`] = `
           Outgoing
         </span>
       </button>
+      <div
+        class="flex flex-1"
+      />
+      <div
+        class="my-auto mr-6"
+        data-testid="FilterTransactions"
+      >
+        <div
+          class="relative"
+        >
+          <span
+            data-testid="dropdown__toggle"
+          >
+            <button
+              class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-500"
+              data-testid="CollapseToggleButton"
+            >
+              <span>
+                <span
+                  class="text-theme-secondary-500 dark:text-theme-secondary-600"
+                >
+                  Type: 
+                </span>
+                <span
+                  class="text-theme-secondary-700 dark:text-theme-secondary-200"
+                >
+                  All
+                </span>
+              </span>
+              <span
+                class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 jmsVky"
+              >
+                <div
+                  class="sc-bdfBwQ kJrqvM"
+                  height="5"
+                  width="8"
+                >
+                  <svg>
+                    chevron-down.svg
+                  </svg>
+                </div>
+              </span>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -3699,50 +3711,6 @@ exports[`Transactions should update wallet filters 1`] = `
     >
       Transaction History
     </div>
-    <div
-      class="mt-6"
-      data-testid="FilterTransactions"
-    >
-      <div
-        class="relative"
-      >
-        <span
-          data-testid="dropdown__toggle"
-        >
-          <button
-            class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-400 dark:text-theme-secondary-800 cursor-not-allowed"
-            data-testid="CollapseToggleButton"
-            disabled=""
-          >
-            <span>
-              <span
-                class=""
-              >
-                Type: 
-              </span>
-              <span
-                class=""
-              >
-                All
-              </span>
-            </span>
-            <span
-              class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 hdzQGX"
-            >
-              <div
-                class="sc-bdfBwQ kJrqvM"
-                height="5"
-                width="8"
-              >
-                <svg>
-                  chevron-down.svg
-                </svg>
-              </div>
-            </span>
-          </button>
-        </span>
-      </div>
-    </div>
   </div>
   <div
     class="mb-8"
@@ -3795,6 +3763,53 @@ exports[`Transactions should update wallet filters 1`] = `
           Outgoing
         </span>
       </button>
+      <div
+        class="flex flex-1"
+      />
+      <div
+        class="my-auto mr-6"
+        data-testid="FilterTransactions"
+      >
+        <div
+          class="relative"
+        >
+          <span
+            data-testid="dropdown__toggle"
+          >
+            <button
+              class="flex items-center py-2 font-semibold rounded focus:outline-none space-x-2 text-theme-secondary-400 dark:text-theme-secondary-800 cursor-not-allowed"
+              data-testid="CollapseToggleButton"
+              disabled=""
+            >
+              <span>
+                <span
+                  class=""
+                >
+                  Type: 
+                </span>
+                <span
+                  class=""
+                >
+                  All
+                </span>
+              </span>
+              <span
+                class="CollapseToggleButton__ToggleIcon-sc-1f6f05f-0 hdzQGX"
+              >
+                <div
+                  class="sc-bdfBwQ kJrqvM"
+                  height="5"
+                  width="8"
+                >
+                  <svg>
+                    chevron-down.svg
+                  </svg>
+                </div>
+              </span>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/src/domains/wallet/pages/WalletDetails/WalletDetails.tsx
+++ b/src/domains/wallet/pages/WalletDetails/WalletDetails.tsx
@@ -100,7 +100,7 @@ export const WalletDetails = () => {
 
 				<Section className="flex-1">
 					{[...pendingSigned, ...pendingTransfers].length > 0 && (
-						<div className="mb-16">
+						<div className="mb-8">
 							<PendingTransactions
 								transfers={pendingTransfers}
 								signed={pendingSigned}
@@ -112,11 +112,7 @@ export const WalletDetails = () => {
 					)}
 
 					<Transactions
-						title={
-							<h2 className="mb-8 font-bold">
-								{t("WALLETS.PAGE_WALLET_DETAILS.TRANSACTION_HISTORY.TITLE")}
-							</h2>
-						}
+						title={<h2 className="mb-6">{t("WALLETS.PAGE_WALLET_DETAILS.TRANSACTION_HISTORY.TITLE")}</h2>}
 						showUnconfirmed={false}
 						profile={activeProfile}
 						wallets={[activeWallet]}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/mvd46m
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
