### PR TITLE
fix: update wallet import method after manual encryption

### DIFF
--- a/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
+++ b/src/domains/wallet/pages/ImportWallet/ImportWallet.tsx
@@ -121,6 +121,8 @@ export const ImportWallet = () => {
 	const encryptMnemonic = async () => {
 		await walletData!.wif().set(walletGenerationInput!, getValues("encryptionPassword"));
 
+		walletData?.data().set(Contracts.WalletData.ImportMethod, Contracts.WalletImportMethod.BIP39.MNEMONIC_WITH_ENCRYPTION);
+
 		await persist();
 	};
 


### PR DESCRIPTION
Because DW doesn't make proper use of https://github.com/ArkEcosystem/platform-sdk/blob/master/packages/platform-sdk-profiles/source/wallet.factory.ts#L66-L70 this has to be manually set for now. Ideally DW would make proper use of that method and not generate the wallet until it gathered the mnemonic and password.