### PR TITLE
fix: reset dashboard filters for newly created profiles

### DIFF
--- a/src/app/hooks/use-profile-synchronizer.ts
+++ b/src/app/hooks/use-profile-synchronizer.ts
@@ -233,6 +233,7 @@ export const useProfileRestore = () => {
 
 	return {
 		restoreProfile,
+		restoreProfileConfig,
 	};
 };
 

--- a/src/domains/profile/pages/CreateProfile/CreateProfile.tsx
+++ b/src/domains/profile/pages/CreateProfile/CreateProfile.tsx
@@ -10,7 +10,7 @@ import { Select } from "app/components/SelectDropdown";
 import { SelectProfileImage } from "app/components/SelectProfileImage";
 import { Toggle } from "app/components/Toggle";
 import { useEnvironmentContext } from "app/contexts";
-import { useTheme, useValidation } from "app/hooks";
+import { useProfileRestore,useTheme, useValidation } from "app/hooks";
 import { PlatformSdkChoices } from "data";
 import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -23,6 +23,7 @@ export const CreateProfile = () => {
 	const form = useForm({ mode: "onChange" });
 	const history = useHistory();
 	const { t } = useTranslation();
+	const { restoreProfileConfig } = useProfileRestore();
 
 	const { watch, register, formState, setValue, trigger } = form;
 	const { name, confirmPassword, isDarkMode } = watch(["name", "confirmPassword", "isDarkMode"], { name: "" });
@@ -80,6 +81,7 @@ export const CreateProfile = () => {
 			profile.auth().setPassword(password);
 		}
 
+		restoreProfileConfig(profile);
 		await persist();
 
 		history.push("/");

--- a/src/domains/profile/pages/CreateProfile/CreateProfile.tsx
+++ b/src/domains/profile/pages/CreateProfile/CreateProfile.tsx
@@ -10,7 +10,7 @@ import { Select } from "app/components/SelectDropdown";
 import { SelectProfileImage } from "app/components/SelectProfileImage";
 import { Toggle } from "app/components/Toggle";
 import { useEnvironmentContext } from "app/contexts";
-import { useProfileRestore,useTheme, useValidation } from "app/hooks";
+import { useProfileRestore, useTheme, useValidation } from "app/hooks";
 import { PlatformSdkChoices } from "data";
 import React, { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";

--- a/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
+++ b/src/domains/profile/pages/CreateProfile/__snapshots__/CreateProfile.test.tsx.snap
@@ -327,12 +327,12 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-70-menu"
+                        aria-owns="downshift-73-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-70-input"
-                          id="downshift-70-label"
+                          for="downshift-73-input"
+                          id="downshift-73-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -346,14 +346,14 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-70-item-0"
+                              aria-activedescendant="downshift-73-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-70-menu"
-                              aria-labelledby="downshift-70-label"
+                              aria-controls="downshift-73-menu"
+                              aria-labelledby="downshift-73-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-70-input"
+                              id="downshift-73-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -393,16 +393,16 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-70-label"
+                          aria-labelledby="downshift-73-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-70-menu"
+                          id="downshift-73-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-70-item-0"
+                            id="downshift-73-item-0"
                             role="option"
                           >
                             <div
@@ -415,7 +415,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-70-item-1"
+                            id="downshift-73-item-1"
                             role="option"
                           >
                             <div
@@ -428,7 +428,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-70-item-2"
+                            id="downshift-73-item-2"
                             role="option"
                           >
                             <div
@@ -441,7 +441,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-70-item-3"
+                            id="downshift-73-item-3"
                             role="option"
                           >
                             <div
@@ -454,7 +454,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-70-item-4"
+                            id="downshift-73-item-4"
                             role="option"
                           >
                             <div
@@ -467,7 +467,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-70-item-5"
+                            id="downshift-73-item-5"
                             role="option"
                           >
                             <div
@@ -480,7 +480,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-70-item-6"
+                            id="downshift-73-item-6"
                             role="option"
                           >
                             <div
@@ -493,7 +493,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-70-item-7"
+                            id="downshift-73-item-7"
                             role="option"
                           >
                             <div
@@ -506,7 +506,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-70-item-8"
+                            id="downshift-73-item-8"
                             role="option"
                           >
                             <div
@@ -519,7 +519,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-70-item-9"
+                            id="downshift-73-item-9"
                             role="option"
                           >
                             <div
@@ -532,7 +532,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-70-item-10"
+                            id="downshift-73-item-10"
                             role="option"
                           >
                             <div
@@ -545,7 +545,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-70-item-11"
+                            id="downshift-73-item-11"
                             role="option"
                           >
                             <div
@@ -558,7 +558,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-70-item-12"
+                            id="downshift-73-item-12"
                             role="option"
                           >
                             <div
@@ -571,7 +571,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-70-item-13"
+                            id="downshift-73-item-13"
                             role="option"
                           >
                             <div
@@ -584,7 +584,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-70-item-14"
+                            id="downshift-73-item-14"
                             role="option"
                           >
                             <div
@@ -597,7 +597,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-70-item-15"
+                            id="downshift-73-item-15"
                             role="option"
                           >
                             <div
@@ -610,7 +610,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-70-item-16"
+                            id="downshift-73-item-16"
                             role="option"
                           >
                             <div
@@ -623,7 +623,7 @@ exports[`CreateProfile should fail password confirmation 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-70-item-17"
+                            id="downshift-73-item-17"
                             role="option"
                           >
                             <div
@@ -1071,12 +1071,12 @@ exports[`CreateProfile should not be able to create new profile if name already 
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-23-menu"
+                        aria-owns="downshift-25-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-23-input"
-                          id="downshift-23-label"
+                          for="downshift-25-input"
+                          id="downshift-25-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -1090,14 +1090,14 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-23-item-0"
+                              aria-activedescendant="downshift-25-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-23-menu"
-                              aria-labelledby="downshift-23-label"
+                              aria-controls="downshift-25-menu"
+                              aria-labelledby="downshift-25-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-23-input"
+                              id="downshift-25-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -1137,16 +1137,16 @@ exports[`CreateProfile should not be able to create new profile if name already 
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-23-label"
+                          aria-labelledby="downshift-25-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-23-menu"
+                          id="downshift-25-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-23-item-0"
+                            id="downshift-25-item-0"
                             role="option"
                           >
                             <div
@@ -1159,7 +1159,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-23-item-1"
+                            id="downshift-25-item-1"
                             role="option"
                           >
                             <div
@@ -1172,7 +1172,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-23-item-2"
+                            id="downshift-25-item-2"
                             role="option"
                           >
                             <div
@@ -1185,7 +1185,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-23-item-3"
+                            id="downshift-25-item-3"
                             role="option"
                           >
                             <div
@@ -1198,7 +1198,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-23-item-4"
+                            id="downshift-25-item-4"
                             role="option"
                           >
                             <div
@@ -1211,7 +1211,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-23-item-5"
+                            id="downshift-25-item-5"
                             role="option"
                           >
                             <div
@@ -1224,7 +1224,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-23-item-6"
+                            id="downshift-25-item-6"
                             role="option"
                           >
                             <div
@@ -1237,7 +1237,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-23-item-7"
+                            id="downshift-25-item-7"
                             role="option"
                           >
                             <div
@@ -1250,7 +1250,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-23-item-8"
+                            id="downshift-25-item-8"
                             role="option"
                           >
                             <div
@@ -1263,7 +1263,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-23-item-9"
+                            id="downshift-25-item-9"
                             role="option"
                           >
                             <div
@@ -1276,7 +1276,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-23-item-10"
+                            id="downshift-25-item-10"
                             role="option"
                           >
                             <div
@@ -1289,7 +1289,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-23-item-11"
+                            id="downshift-25-item-11"
                             role="option"
                           >
                             <div
@@ -1302,7 +1302,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-23-item-12"
+                            id="downshift-25-item-12"
                             role="option"
                           >
                             <div
@@ -1315,7 +1315,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-23-item-13"
+                            id="downshift-25-item-13"
                             role="option"
                           >
                             <div
@@ -1328,7 +1328,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-23-item-14"
+                            id="downshift-25-item-14"
                             role="option"
                           >
                             <div
@@ -1341,7 +1341,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-23-item-15"
+                            id="downshift-25-item-15"
                             role="option"
                           >
                             <div
@@ -1354,7 +1354,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-23-item-16"
+                            id="downshift-25-item-16"
                             role="option"
                           >
                             <div
@@ -1367,7 +1367,7 @@ exports[`CreateProfile should not be able to create new profile if name already 
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-23-item-17"
+                            id="downshift-25-item-17"
                             role="option"
                           >
                             <div
@@ -1815,12 +1815,12 @@ exports[`CreateProfile should not be able to create new profile if name consists
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-34-menu"
+                        aria-owns="downshift-36-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-34-input"
-                          id="downshift-34-label"
+                          for="downshift-36-input"
+                          id="downshift-36-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -1834,14 +1834,14 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-34-item-0"
+                              aria-activedescendant="downshift-36-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-34-menu"
-                              aria-labelledby="downshift-34-label"
+                              aria-controls="downshift-36-menu"
+                              aria-labelledby="downshift-36-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-34-input"
+                              id="downshift-36-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -1881,16 +1881,16 @@ exports[`CreateProfile should not be able to create new profile if name consists
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-34-label"
+                          aria-labelledby="downshift-36-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-34-menu"
+                          id="downshift-36-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-34-item-0"
+                            id="downshift-36-item-0"
                             role="option"
                           >
                             <div
@@ -1903,7 +1903,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-34-item-1"
+                            id="downshift-36-item-1"
                             role="option"
                           >
                             <div
@@ -1916,7 +1916,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-34-item-2"
+                            id="downshift-36-item-2"
                             role="option"
                           >
                             <div
@@ -1929,7 +1929,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-34-item-3"
+                            id="downshift-36-item-3"
                             role="option"
                           >
                             <div
@@ -1942,7 +1942,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-34-item-4"
+                            id="downshift-36-item-4"
                             role="option"
                           >
                             <div
@@ -1955,7 +1955,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-34-item-5"
+                            id="downshift-36-item-5"
                             role="option"
                           >
                             <div
@@ -1968,7 +1968,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-34-item-6"
+                            id="downshift-36-item-6"
                             role="option"
                           >
                             <div
@@ -1981,7 +1981,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-34-item-7"
+                            id="downshift-36-item-7"
                             role="option"
                           >
                             <div
@@ -1994,7 +1994,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-34-item-8"
+                            id="downshift-36-item-8"
                             role="option"
                           >
                             <div
@@ -2007,7 +2007,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-34-item-9"
+                            id="downshift-36-item-9"
                             role="option"
                           >
                             <div
@@ -2020,7 +2020,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-34-item-10"
+                            id="downshift-36-item-10"
                             role="option"
                           >
                             <div
@@ -2033,7 +2033,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-34-item-11"
+                            id="downshift-36-item-11"
                             role="option"
                           >
                             <div
@@ -2046,7 +2046,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-34-item-12"
+                            id="downshift-36-item-12"
                             role="option"
                           >
                             <div
@@ -2059,7 +2059,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-34-item-13"
+                            id="downshift-36-item-13"
                             role="option"
                           >
                             <div
@@ -2072,7 +2072,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-34-item-14"
+                            id="downshift-36-item-14"
                             role="option"
                           >
                             <div
@@ -2085,7 +2085,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-34-item-15"
+                            id="downshift-36-item-15"
                             role="option"
                           >
                             <div
@@ -2098,7 +2098,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-34-item-16"
+                            id="downshift-36-item-16"
                             role="option"
                           >
                             <div
@@ -2111,7 +2111,7 @@ exports[`CreateProfile should not be able to create new profile if name consists
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-34-item-17"
+                            id="downshift-36-item-17"
                             role="option"
                           >
                             <div
@@ -2559,12 +2559,12 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-45-menu"
+                        aria-owns="downshift-47-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-45-input"
-                          id="downshift-45-label"
+                          for="downshift-47-input"
+                          id="downshift-47-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -2578,14 +2578,14 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-45-item-0"
+                              aria-activedescendant="downshift-47-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-45-menu"
-                              aria-labelledby="downshift-45-label"
+                              aria-controls="downshift-47-menu"
+                              aria-labelledby="downshift-47-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-45-input"
+                              id="downshift-47-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -2625,16 +2625,16 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-45-label"
+                          aria-labelledby="downshift-47-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-45-menu"
+                          id="downshift-47-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-45-item-0"
+                            id="downshift-47-item-0"
                             role="option"
                           >
                             <div
@@ -2647,7 +2647,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-45-item-1"
+                            id="downshift-47-item-1"
                             role="option"
                           >
                             <div
@@ -2660,7 +2660,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-45-item-2"
+                            id="downshift-47-item-2"
                             role="option"
                           >
                             <div
@@ -2673,7 +2673,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-45-item-3"
+                            id="downshift-47-item-3"
                             role="option"
                           >
                             <div
@@ -2686,7 +2686,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-45-item-4"
+                            id="downshift-47-item-4"
                             role="option"
                           >
                             <div
@@ -2699,7 +2699,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-45-item-5"
+                            id="downshift-47-item-5"
                             role="option"
                           >
                             <div
@@ -2712,7 +2712,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-45-item-6"
+                            id="downshift-47-item-6"
                             role="option"
                           >
                             <div
@@ -2725,7 +2725,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-45-item-7"
+                            id="downshift-47-item-7"
                             role="option"
                           >
                             <div
@@ -2738,7 +2738,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-45-item-8"
+                            id="downshift-47-item-8"
                             role="option"
                           >
                             <div
@@ -2751,7 +2751,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-45-item-9"
+                            id="downshift-47-item-9"
                             role="option"
                           >
                             <div
@@ -2764,7 +2764,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-45-item-10"
+                            id="downshift-47-item-10"
                             role="option"
                           >
                             <div
@@ -2777,7 +2777,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-45-item-11"
+                            id="downshift-47-item-11"
                             role="option"
                           >
                             <div
@@ -2790,7 +2790,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-45-item-12"
+                            id="downshift-47-item-12"
                             role="option"
                           >
                             <div
@@ -2803,7 +2803,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-45-item-13"
+                            id="downshift-47-item-13"
                             role="option"
                           >
                             <div
@@ -2816,7 +2816,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-45-item-14"
+                            id="downshift-47-item-14"
                             role="option"
                           >
                             <div
@@ -2829,7 +2829,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-45-item-15"
+                            id="downshift-47-item-15"
                             role="option"
                           >
                             <div
@@ -2842,7 +2842,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-45-item-16"
+                            id="downshift-47-item-16"
                             role="option"
                           >
                             <div
@@ -2855,7 +2855,7 @@ exports[`CreateProfile should not be able to create new profile if name is too l
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-45-item-17"
+                            id="downshift-47-item-17"
                             role="option"
                           >
                             <div
@@ -3324,12 +3324,12 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-95-menu"
+                        aria-owns="downshift-98-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-95-input"
-                          id="downshift-95-label"
+                          for="downshift-98-input"
+                          id="downshift-98-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -3344,12 +3344,12 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                           >
                             <input
                               aria-autocomplete="list"
-                              aria-controls="downshift-95-menu"
-                              aria-labelledby="downshift-95-label"
+                              aria-controls="downshift-98-menu"
+                              aria-labelledby="downshift-98-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full cursor-default"
                               data-testid="SelectDropdown__input"
-                              id="downshift-95-input"
+                              id="downshift-98-input"
                               name="currency"
                               placeholder="Select Currency"
                               value=""
@@ -3379,9 +3379,9 @@ exports[`CreateProfile should not update the uploaded avatar when removing focus
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-95-label"
+                          aria-labelledby="downshift-98-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR"
-                          id="downshift-95-menu"
+                          id="downshift-98-menu"
                           role="listbox"
                         />
                       </div>
@@ -3803,12 +3803,12 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-116-menu"
+                        aria-owns="downshift-120-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-116-input"
-                          id="downshift-116-label"
+                          for="downshift-120-input"
+                          id="downshift-120-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -3822,14 +3822,14 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-116-item-0"
+                              aria-activedescendant="downshift-120-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-116-menu"
-                              aria-labelledby="downshift-116-label"
+                              aria-controls="downshift-120-menu"
+                              aria-labelledby="downshift-120-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-116-input"
+                              id="downshift-120-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -3869,16 +3869,16 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-116-label"
+                          aria-labelledby="downshift-120-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-116-menu"
+                          id="downshift-120-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-116-item-0"
+                            id="downshift-120-item-0"
                             role="option"
                           >
                             <div
@@ -3891,7 +3891,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-116-item-1"
+                            id="downshift-120-item-1"
                             role="option"
                           >
                             <div
@@ -3904,7 +3904,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-116-item-2"
+                            id="downshift-120-item-2"
                             role="option"
                           >
                             <div
@@ -3917,7 +3917,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-116-item-3"
+                            id="downshift-120-item-3"
                             role="option"
                           >
                             <div
@@ -3930,7 +3930,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-116-item-4"
+                            id="downshift-120-item-4"
                             role="option"
                           >
                             <div
@@ -3943,7 +3943,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-116-item-5"
+                            id="downshift-120-item-5"
                             role="option"
                           >
                             <div
@@ -3956,7 +3956,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-116-item-6"
+                            id="downshift-120-item-6"
                             role="option"
                           >
                             <div
@@ -3969,7 +3969,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-116-item-7"
+                            id="downshift-120-item-7"
                             role="option"
                           >
                             <div
@@ -3982,7 +3982,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-116-item-8"
+                            id="downshift-120-item-8"
                             role="option"
                           >
                             <div
@@ -3995,7 +3995,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-116-item-9"
+                            id="downshift-120-item-9"
                             role="option"
                           >
                             <div
@@ -4008,7 +4008,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-116-item-10"
+                            id="downshift-120-item-10"
                             role="option"
                           >
                             <div
@@ -4021,7 +4021,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-116-item-11"
+                            id="downshift-120-item-11"
                             role="option"
                           >
                             <div
@@ -4034,7 +4034,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-116-item-12"
+                            id="downshift-120-item-12"
                             role="option"
                           >
                             <div
@@ -4047,7 +4047,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-116-item-13"
+                            id="downshift-120-item-13"
                             role="option"
                           >
                             <div
@@ -4060,7 +4060,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-116-item-14"
+                            id="downshift-120-item-14"
                             role="option"
                           >
                             <div
@@ -4073,7 +4073,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-116-item-15"
+                            id="downshift-120-item-15"
                             role="option"
                           >
                             <div
@@ -4086,7 +4086,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-116-item-16"
+                            id="downshift-120-item-16"
                             role="option"
                           >
                             <div
@@ -4099,7 +4099,7 @@ exports[`CreateProfile should not upload avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-116-item-17"
+                            id="downshift-120-item-17"
                             role="option"
                           >
                             <div
@@ -5745,12 +5745,12 @@ exports[`CreateProfile should store profile with password 1`] = `
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-56-menu"
+                        aria-owns="downshift-58-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-56-input"
-                          id="downshift-56-label"
+                          for="downshift-58-input"
+                          id="downshift-58-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -5764,14 +5764,14 @@ exports[`CreateProfile should store profile with password 1`] = `
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-56-item-0"
+                              aria-activedescendant="downshift-58-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-56-menu"
-                              aria-labelledby="downshift-56-label"
+                              aria-controls="downshift-58-menu"
+                              aria-labelledby="downshift-58-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-56-input"
+                              id="downshift-58-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -5811,16 +5811,16 @@ exports[`CreateProfile should store profile with password 1`] = `
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-56-label"
+                          aria-labelledby="downshift-58-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-56-menu"
+                          id="downshift-58-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-56-item-0"
+                            id="downshift-58-item-0"
                             role="option"
                           >
                             <div
@@ -5833,7 +5833,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-56-item-1"
+                            id="downshift-58-item-1"
                             role="option"
                           >
                             <div
@@ -5846,7 +5846,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-56-item-2"
+                            id="downshift-58-item-2"
                             role="option"
                           >
                             <div
@@ -5859,7 +5859,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-56-item-3"
+                            id="downshift-58-item-3"
                             role="option"
                           >
                             <div
@@ -5872,7 +5872,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-56-item-4"
+                            id="downshift-58-item-4"
                             role="option"
                           >
                             <div
@@ -5885,7 +5885,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-56-item-5"
+                            id="downshift-58-item-5"
                             role="option"
                           >
                             <div
@@ -5898,7 +5898,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-56-item-6"
+                            id="downshift-58-item-6"
                             role="option"
                           >
                             <div
@@ -5911,7 +5911,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-56-item-7"
+                            id="downshift-58-item-7"
                             role="option"
                           >
                             <div
@@ -5924,7 +5924,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-56-item-8"
+                            id="downshift-58-item-8"
                             role="option"
                           >
                             <div
@@ -5937,7 +5937,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-56-item-9"
+                            id="downshift-58-item-9"
                             role="option"
                           >
                             <div
@@ -5950,7 +5950,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-56-item-10"
+                            id="downshift-58-item-10"
                             role="option"
                           >
                             <div
@@ -5963,7 +5963,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-56-item-11"
+                            id="downshift-58-item-11"
                             role="option"
                           >
                             <div
@@ -5976,7 +5976,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-56-item-12"
+                            id="downshift-58-item-12"
                             role="option"
                           >
                             <div
@@ -5989,7 +5989,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-56-item-13"
+                            id="downshift-58-item-13"
                             role="option"
                           >
                             <div
@@ -6002,7 +6002,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-56-item-14"
+                            id="downshift-58-item-14"
                             role="option"
                           >
                             <div
@@ -6015,7 +6015,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-56-item-15"
+                            id="downshift-58-item-15"
                             role="option"
                           >
                             <div
@@ -6028,7 +6028,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-56-item-16"
+                            id="downshift-58-item-16"
                             role="option"
                           >
                             <div
@@ -6041,7 +6041,7 @@ exports[`CreateProfile should store profile with password 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-56-item-17"
+                            id="downshift-58-item-17"
                             role="option"
                           >
                             <div
@@ -6476,12 +6476,12 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-85-menu"
+                        aria-owns="downshift-88-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-85-input"
-                          id="downshift-85-label"
+                          for="downshift-88-input"
+                          id="downshift-88-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -6496,12 +6496,12 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           >
                             <input
                               aria-autocomplete="list"
-                              aria-controls="downshift-85-menu"
-                              aria-labelledby="downshift-85-label"
+                              aria-controls="downshift-88-menu"
+                              aria-labelledby="downshift-88-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full cursor-default"
                               data-testid="SelectDropdown__input"
-                              id="downshift-85-input"
+                              id="downshift-88-input"
                               name="currency"
                               placeholder="Select Currency"
                               value=""
@@ -6531,9 +6531,9 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-85-label"
+                          aria-labelledby="downshift-88-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR"
-                          id="downshift-85-menu"
+                          id="downshift-88-menu"
                           role="listbox"
                         />
                       </div>
@@ -6974,12 +6974,12 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-85-menu"
+                        aria-owns="downshift-88-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-85-input"
-                          id="downshift-85-label"
+                          for="downshift-88-input"
+                          id="downshift-88-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -6994,12 +6994,12 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           >
                             <input
                               aria-autocomplete="list"
-                              aria-controls="downshift-85-menu"
-                              aria-labelledby="downshift-85-label"
+                              aria-controls="downshift-88-menu"
+                              aria-labelledby="downshift-88-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full cursor-default"
                               data-testid="SelectDropdown__input"
-                              id="downshift-85-input"
+                              id="downshift-88-input"
                               name="currency"
                               placeholder="Select Currency"
                               value=""
@@ -7029,9 +7029,9 @@ exports[`CreateProfile should update the avatar when removing focus from name in
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-85-label"
+                          aria-labelledby="downshift-88-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR"
-                          id="downshift-85-menu"
+                          id="downshift-88-menu"
                           role="listbox"
                         />
                       </div>
@@ -7453,12 +7453,12 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                       <div
                         aria-expanded="true"
                         aria-haspopup="listbox"
-                        aria-owns="downshift-101-menu"
+                        aria-owns="downshift-104-menu"
                         role="combobox"
                       >
                         <label
-                          for="downshift-101-input"
-                          id="downshift-101-label"
+                          for="downshift-104-input"
+                          id="downshift-104-label"
                         />
                         <div
                           class="fixed invisible w-auto whitespace-nowrap"
@@ -7472,14 +7472,14 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             class="relative flex flex-1 h-full"
                           >
                             <input
-                              aria-activedescendant="downshift-101-item-0"
+                              aria-activedescendant="downshift-104-item-0"
                               aria-autocomplete="list"
-                              aria-controls="downshift-101-menu"
-                              aria-labelledby="downshift-101-label"
+                              aria-controls="downshift-104-menu"
+                              aria-labelledby="downshift-104-label"
                               autocomplete="off"
                               class="Input__InputStyled-wu99qs-1 ioFtLo p-0 border-none bg-transparent focus:ring-0 no-ligatures w-full"
                               data-testid="SelectDropdown__input"
-                              id="downshift-101-input"
+                              id="downshift-104-input"
                               name="currency"
                               placeholder="Select Currency"
                               value="BTC (Ƀ)"
@@ -7519,16 +7519,16 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                           </div>
                         </div>
                         <ul
-                          aria-labelledby="downshift-101-label"
+                          aria-labelledby="downshift-104-label"
                           class="styles__SelectOptionsList-b2falt-0 dyOwRR is-open"
-                          id="downshift-101-menu"
+                          id="downshift-104-menu"
                           role="listbox"
                         >
                           <li
                             aria-selected="true"
                             class="select-list-option is-highlighted is-selected"
                             data-testid="SelectDropdown__option--0"
-                            id="downshift-101-item-0"
+                            id="downshift-104-item-0"
                             role="option"
                           >
                             <div
@@ -7541,7 +7541,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--1"
-                            id="downshift-101-item-1"
+                            id="downshift-104-item-1"
                             role="option"
                           >
                             <div
@@ -7554,7 +7554,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--2"
-                            id="downshift-101-item-2"
+                            id="downshift-104-item-2"
                             role="option"
                           >
                             <div
@@ -7567,7 +7567,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--3"
-                            id="downshift-101-item-3"
+                            id="downshift-104-item-3"
                             role="option"
                           >
                             <div
@@ -7580,7 +7580,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--4"
-                            id="downshift-101-item-4"
+                            id="downshift-104-item-4"
                             role="option"
                           >
                             <div
@@ -7593,7 +7593,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--5"
-                            id="downshift-101-item-5"
+                            id="downshift-104-item-5"
                             role="option"
                           >
                             <div
@@ -7606,7 +7606,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--6"
-                            id="downshift-101-item-6"
+                            id="downshift-104-item-6"
                             role="option"
                           >
                             <div
@@ -7619,7 +7619,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--7"
-                            id="downshift-101-item-7"
+                            id="downshift-104-item-7"
                             role="option"
                           >
                             <div
@@ -7632,7 +7632,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--8"
-                            id="downshift-101-item-8"
+                            id="downshift-104-item-8"
                             role="option"
                           >
                             <div
@@ -7645,7 +7645,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--9"
-                            id="downshift-101-item-9"
+                            id="downshift-104-item-9"
                             role="option"
                           >
                             <div
@@ -7658,7 +7658,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--10"
-                            id="downshift-101-item-10"
+                            id="downshift-104-item-10"
                             role="option"
                           >
                             <div
@@ -7671,7 +7671,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--11"
-                            id="downshift-101-item-11"
+                            id="downshift-104-item-11"
                             role="option"
                           >
                             <div
@@ -7684,7 +7684,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--12"
-                            id="downshift-101-item-12"
+                            id="downshift-104-item-12"
                             role="option"
                           >
                             <div
@@ -7697,7 +7697,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--13"
-                            id="downshift-101-item-13"
+                            id="downshift-104-item-13"
                             role="option"
                           >
                             <div
@@ -7710,7 +7710,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--14"
-                            id="downshift-101-item-14"
+                            id="downshift-104-item-14"
                             role="option"
                           >
                             <div
@@ -7723,7 +7723,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--15"
-                            id="downshift-101-item-15"
+                            id="downshift-104-item-15"
                             role="option"
                           >
                             <div
@@ -7736,7 +7736,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--16"
-                            id="downshift-101-item-16"
+                            id="downshift-104-item-16"
                             role="option"
                           >
                             <div
@@ -7749,7 +7749,7 @@ exports[`CreateProfile should upload and remove avatar image 1`] = `
                             aria-selected="false"
                             class="select-list-option"
                             data-testid="SelectDropdown__option--17"
-                            id="downshift-101-item-17"
+                            id="downshift-104-item-17"
                             role="option"
                           >
                             <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
