### PR TITLE
fix: explicitly mark personal settings dropdowns as dirty upon change

### DIFF
--- a/src/domains/setting/pages/General/General.test.tsx
+++ b/src/domains/setting/pages/General/General.test.tsx
@@ -84,6 +84,7 @@ describe("General Settings", () => {
 		);
 
 		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
 	});
@@ -101,6 +102,7 @@ describe("General Settings", () => {
 		);
 
 		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		expect(screen.getByTestId("General-settings__submit-button")).toBeDisabled();
 		expect(asFragment()).toMatchSnapshot();
 
@@ -445,6 +447,7 @@ describe("General Settings", () => {
 		);
 
 		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		expect(container).toBeTruthy();
 
 		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
@@ -481,6 +484,7 @@ describe("General Settings", () => {
 		);
 
 		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		expect(container).toBeTruthy();
 
 		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
@@ -511,6 +515,7 @@ describe("General Settings", () => {
 		);
 
 		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		expect(container).toBeTruthy();
 
 		fireEvent.click(getByTestId("General-settings__toggle--isDarkMode"));

--- a/src/domains/setting/pages/General/General.test.tsx
+++ b/src/domains/setting/pages/General/General.test.tsx
@@ -73,8 +73,8 @@ describe("General Settings", () => {
 		fireEvent.click(screen.getByTestId("General-settings__cancel-button"));
 	});
 
-	it("should render", () => {
-		const { container, asFragment } = renderWithRouter(
+	it("should render", async () => {
+		const { container, asFragment, getByTestId } = renderWithRouter(
 			<Route path="/profiles/:profileId/settings">
 				<GeneralSettings />
 			</Route>,
@@ -83,6 +83,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		expect(container).toBeTruthy();
 		expect(asFragment()).toMatchSnapshot();
 	});
@@ -90,7 +91,7 @@ describe("General Settings", () => {
 	it("should disable submit button when profile is not restored yet", async () => {
 		const isProfileRestoredMock = jest.spyOn(profile.status(), "isRestored").mockReturnValue(false);
 
-		const { asFragment } = renderWithRouter(
+		const { asFragment, getByTestId } = renderWithRouter(
 			<Route path="/profiles/:profileId/settings">
 				<GeneralSettings />
 			</Route>,
@@ -99,6 +100,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		expect(screen.getByTestId("General-settings__submit-button")).toBeDisabled();
 		expect(asFragment()).toMatchSnapshot();
 
@@ -114,6 +116,8 @@ describe("General Settings", () => {
 				routes: [`/profiles/${profile.id()}/settings`],
 			},
 		);
+
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 
 		expect(getByTestId("SelectProfileImage__avatar")).toBeTruthy();
 
@@ -160,6 +164,8 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
+
 		// Upload avatar image
 		showOpenDialogMock = jest.spyOn(electron.remote.dialog, "showOpenDialog").mockImplementation(() => ({
 			filePaths: ["banner.png"],
@@ -205,6 +211,8 @@ describe("General Settings", () => {
 				routes: [`/profiles/${profile.id()}/settings`],
 			},
 		);
+
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 
 		// Upload avatar image
 		showOpenDialogMock = jest.spyOn(electron.remote.dialog, "showOpenDialog").mockImplementation(() => ({
@@ -290,6 +298,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		fireEvent.input(getByTestId("General-settings__input--name"), {
 			target: { value: "     " },
 		});
@@ -310,6 +319,8 @@ describe("General Settings", () => {
 				routes: [`/profiles/${profile.id()}/settings`],
 			},
 		);
+
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 
 		const otherProfile = env
 			.profiles()
@@ -341,6 +352,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		const otherProfile = env
 			.profiles()
 			.values()
@@ -371,6 +383,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		act(() => {
 			fireEvent.input(getByTestId("General-settings__input--name"), {
 				target: { value: "test profile".repeat(10) },
@@ -396,6 +409,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		const otherProfile = env
 			.profiles()
 			.values()
@@ -430,6 +444,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		expect(container).toBeTruthy();
 
 		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
@@ -465,6 +480,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		expect(container).toBeTruthy();
 
 		expect(() => getByTestId("modal__inner")).toThrow(/Unable to find an element by/);
@@ -494,6 +510,7 @@ describe("General Settings", () => {
 			},
 		);
 
+		await waitFor(() => expect(getByTestId("General-settings__input--name")).toHaveValue(profile.name()));
 		expect(container).toBeTruthy();
 
 		fireEvent.click(getByTestId("General-settings__toggle--isDarkMode"));

--- a/src/domains/setting/pages/General/General.tsx
+++ b/src/domains/setting/pages/General/General.tsx
@@ -329,6 +329,9 @@ export const GeneralSettings: React.FC = () => {
 											field: t("SETTINGS.GENERAL.PERSONAL.PASSPHRASE_LANGUAGE"),
 										}).toString(),
 									})}
+									onChange={(bip39Locale: any) =>
+										setValue("bip39Locale", bip39Locale.value, { shouldDirty: true })
+									}
 									options={PlatformSdkChoices.passphraseLanguages}
 									defaultValue={getDefaultValues().bip39Locale}
 								/>
@@ -349,6 +352,9 @@ export const GeneralSettings: React.FC = () => {
 									})}
 									options={PlatformSdkChoices.currencies}
 									defaultValue={getDefaultValues().exchangeCurrency}
+									onChange={(exchangeCurrency: any) =>
+										setValue("exchangeCurrency", exchangeCurrency.value, { shouldDirty: true })
+									}
 								/>
 							</FormField>
 						</div>
@@ -368,6 +374,7 @@ export const GeneralSettings: React.FC = () => {
 									})}
 									options={PlatformSdkChoices.languages}
 									defaultValue={getDefaultValues().locale}
+									onChange={(locale: any) => setValue("locale", locale.value, { shouldDirty: true })}
 								/>
 							</FormField>
 
@@ -385,6 +392,9 @@ export const GeneralSettings: React.FC = () => {
 									})}
 									options={PlatformSdkChoices.marketProviders}
 									defaultValue={getDefaultValues().marketProvider}
+									onChange={(marketProvider: any) =>
+										setValue("marketProvider", marketProvider.value, { shouldDirty: true })
+									}
 								/>
 							</FormField>
 
@@ -402,6 +412,9 @@ export const GeneralSettings: React.FC = () => {
 									})}
 									options={PlatformSdkChoices.timeFormats}
 									defaultValue={getDefaultValues().timeFormat}
+									onChange={(timeFormat: any) =>
+										setValue("timeFormat", timeFormat.value, { shouldDirty: true })
+									}
 								/>
 							</FormField>
 						</div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
