### PR TITLE
refactor: remove divider from `SendTransfer` and adjust spacing in `SendVote`

### DIFF
--- a/src/domains/transaction/pages/SendTransfer/FormStep.tsx
+++ b/src/domains/transaction/pages/SendTransfer/FormStep.tsx
@@ -1,6 +1,5 @@
 import { Enums, Networks } from "@arkecosystem/platform-sdk";
 import { Contracts } from "@arkecosystem/platform-sdk-profiles";
-import { Divider } from "app/components/Divider";
 import { FormField, FormLabel } from "app/components/Form";
 import { Header } from "app/components/Header";
 import { InputCounter } from "app/components/Input";
@@ -165,49 +164,41 @@ export const FormStep = ({
 				</FormField>
 
 				{showFeeInput && (
-					<>
-						<FormField name="fee">
-							<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
-							<InputFee
-								min={fees?.min}
-								avg={fees?.avg}
-								max={fees?.max}
-								loading={!fees}
-								value={fee}
-								step={0.01}
-								disabled={network?.feeType() !== "dynamic"}
-								network={network}
-								profile={profile}
-								onChange={(value) => {
-									setValue("fee", value, { shouldDirty: true, shouldValidate: true });
-								}}
-								viewType={inputFeeSettings.viewType}
-								onChangeViewType={(viewType) => {
-									setValue(
-										"inputFeeSettings",
-										{ ...inputFeeSettings, viewType },
-										{ shouldDirty: true, shouldValidate: true },
-									);
-								}}
-								simpleValue={inputFeeSettings.simpleValue}
-								onChangeSimpleValue={(simpleValue) => {
-									setValue(
-										"inputFeeSettings",
-										{ ...inputFeeSettings, simpleValue },
-										{ shouldDirty: true, shouldValidate: true },
-									);
-								}}
-							/>
-						</FormField>
-					</>
+					<FormField name="fee">
+						<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<InputFee
+							min={fees?.min}
+							avg={fees?.avg}
+							max={fees?.max}
+							loading={!fees}
+							value={fee}
+							step={0.01}
+							disabled={network?.feeType() !== "dynamic"}
+							network={network}
+							profile={profile}
+							onChange={(value) => {
+								setValue("fee", value, { shouldDirty: true, shouldValidate: true });
+							}}
+							viewType={inputFeeSettings.viewType}
+							onChangeViewType={(viewType) => {
+								setValue(
+									"inputFeeSettings",
+									{ ...inputFeeSettings, viewType },
+									{ shouldDirty: true, shouldValidate: true },
+								);
+							}}
+							simpleValue={inputFeeSettings.simpleValue}
+							onChangeSimpleValue={(simpleValue) => {
+								setValue(
+									"inputFeeSettings",
+									{ ...inputFeeSettings, simpleValue },
+									{ shouldDirty: true, shouldValidate: true },
+								);
+							}}
+						/>
+					</FormField>
 				)}
 			</div>
-
-			{showFeeInput && (
-				<div className="pt-2">
-					<Divider dashed />
-				</div>
-			)}
 		</section>
 	);
 };

--- a/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
+++ b/src/domains/transaction/pages/SendTransfer/__snapshots__/SendTransfer.test.tsx.snap
@@ -1875,14 +1875,6 @@ exports[`SendTransfer should render 1st step with custom deeplink values and use
         </div>
       </fieldset>
     </div>
-    <div
-      class="pt-2"
-    >
-      <div
-        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-        type="horizontal"
-      />
-    </div>
   </section>
 </DocumentFragment>
 `;
@@ -2864,14 +2856,6 @@ exports[`SendTransfer should render form and use location state 1`] = `
                           </div>
                         </div>
                       </fieldset>
-                    </div>
-                    <div
-                      class="pt-2"
-                    >
-                      <div
-                        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-                        type="horizontal"
-                      />
                     </div>
                   </section>
                 </div>
@@ -3879,14 +3863,6 @@ exports[`SendTransfer should render form and use location state without memo 1`]
                         </div>
                       </fieldset>
                     </div>
-                    <div
-                      class="pt-2"
-                    >
-                      <div
-                        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-                        type="horizontal"
-                      />
-                    </div>
                   </section>
                 </div>
                 <div
@@ -4432,14 +4408,6 @@ exports[`SendTransfer should render form step 1`] = `
         </div>
       </fieldset>
     </div>
-    <div
-      class="pt-2"
-    >
-      <div
-        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-        type="horizontal"
-      />
-    </div>
   </section>
 </DocumentFragment>
 `;
@@ -4960,14 +4928,6 @@ exports[`SendTransfer should render form step with deeplink values and use them 
           </div>
         </div>
       </fieldset>
-    </div>
-    <div
-      class="pt-2"
-    >
-      <div
-        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-        type="horizontal"
-      />
     </div>
   </section>
 </DocumentFragment>
@@ -5584,14 +5544,6 @@ exports[`SendTransfer should render form step without test networks 1`] = `
           </div>
         </div>
       </fieldset>
-    </div>
-    <div
-      class="pt-2"
-    >
-      <div
-        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-        type="horizontal"
-      />
     </div>
   </section>
 </DocumentFragment>
@@ -7807,14 +7759,6 @@ exports[`SendTransfer should select a cryptoasset and select sender without wall
                           </div>
                         </div>
                       </fieldset>
-                    </div>
-                    <div
-                      class="pt-2"
-                    >
-                      <div
-                        class="Divider-sc-19q4mlo-0 bKsVMa border-theme-secondary-300 dark:border-theme-secondary-800"
-                        type="horizontal"
-                      />
                     </div>
                   </section>
                 </div>

--- a/src/domains/transaction/pages/SendVote/FormStep.tsx
+++ b/src/domains/transaction/pages/SendVote/FormStep.tsx
@@ -1,3 +1,4 @@
+import { Networks } from "@arkecosystem/platform-sdk";
 import { Contracts as ProfilesContracts } from "@arkecosystem/platform-sdk-profiles";
 import { FormField, FormLabel } from "app/components/Form";
 import { Header } from "app/components/Header";
@@ -10,10 +11,9 @@ import {
 	TransactionSender,
 } from "domains/transaction/components/TransactionDetail";
 import { VoteList } from "domains/vote/components/VoteList";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { TransactionFees } from "types";
 
 export const FormStep = ({
 	unvotes,
@@ -30,40 +30,28 @@ export const FormStep = ({
 	const { t } = useTranslation();
 
 	const { findByType } = useFees(profile);
+
 	const form = useFormContext();
-	const { getValues, setValue, watch, register } = form;
-
-	const [fees, setFees] = useState<TransactionFees>({
-		avg: 0,
-		max: 0,
-		min: 0,
-		static: 5,
-	});
-
-	useEffect(() => {
-		register("fees");
-	}, [register]);
-
-	// getValues does not get the value of `defaultValues` on first render
-	const [defaultFee] = useState(() => watch("fee"));
-	const fee = getValues("fee") || defaultFee;
+	const { setValue, watch } = form;
+	const { fee, fees } = watch();
 
 	const inputFeeSettings = watch("inputFeeSettings") ?? {};
 
 	useEffect(() => {
-		const setVoteFees = async (senderWallet: ProfilesContracts.IReadWriteWallet) => {
-			const voteFees = await findByType(senderWallet.coinId(), senderWallet.networkId(), "vote");
+		const setFees = async (network: Networks.Network) => {
+			const fees = await findByType(network.coin(), network.id(), "vote");
 
-			setFees(voteFees);
-			setValue("fees", voteFees);
+			setValue("fees", fees);
+			setValue("fee", fees?.avg, {
+				shouldDirty: true,
+				shouldValidate: true,
+			});
 		};
 
-		setVoteFees(wallet);
-	}, [env, setFees, wallet, setValue, findByType]);
+		setFees(wallet.network());
+	}, [env, wallet, setValue, findByType]);
 
-	useEffect(() => {
-		setValue("fee", defaultFee ?? fees.avg, { shouldDirty: true, shouldValidate: true });
-	}, [setValue, fees, defaultFee]);
+	const showFeeInput = useMemo(() => !wallet.network().chargesZeroFees(), [wallet]);
 
 	return (
 		<section data-testid="SendVote__form-step">
@@ -92,41 +80,43 @@ export const FormStep = ({
 				</TransactionDetail>
 			)}
 
-			<TransactionDetail>
-				<FormField name="fee">
-					<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
-					<InputFee
-						min={fees?.min}
-						avg={fees?.avg}
-						max={fees?.max}
-						loading={!fees}
-						value={fee}
-						step={0.01}
-						disabled={wallet.network().feeType() !== "dynamic"}
-						network={wallet.network()}
-						profile={profile}
-						onChange={(value) => {
-							setValue("fee", value, { shouldDirty: true, shouldValidate: true });
-						}}
-						viewType={inputFeeSettings.viewType}
-						onChangeViewType={(viewType) => {
-							setValue(
-								"inputFeeSettings",
-								{ ...inputFeeSettings, viewType },
-								{ shouldDirty: true, shouldValidate: true },
-							);
-						}}
-						simpleValue={inputFeeSettings.simpleValue}
-						onChangeSimpleValue={(simpleValue) => {
-							setValue(
-								"inputFeeSettings",
-								{ ...inputFeeSettings, simpleValue },
-								{ shouldDirty: true, shouldValidate: true },
-							);
-						}}
-					/>
-				</FormField>
-			</TransactionDetail>
+			{showFeeInput && (
+				<TransactionDetail paddingPosition="top">
+					<FormField name="fee">
+						<FormLabel label={t("TRANSACTION.TRANSACTION_FEE")} />
+						<InputFee
+							min={fees?.min}
+							avg={fees?.avg}
+							max={fees?.max}
+							loading={!fees}
+							value={fee}
+							step={0.01}
+							disabled={wallet.network().feeType() !== "dynamic"}
+							network={wallet.network()}
+							profile={profile}
+							onChange={(value) => {
+								setValue("fee", value, { shouldDirty: true, shouldValidate: true });
+							}}
+							viewType={inputFeeSettings.viewType}
+							onChangeViewType={(viewType) => {
+								setValue(
+									"inputFeeSettings",
+									{ ...inputFeeSettings, viewType },
+									{ shouldDirty: true, shouldValidate: true },
+								);
+							}}
+							simpleValue={inputFeeSettings.simpleValue}
+							onChangeSimpleValue={(simpleValue) => {
+								setValue(
+									"inputFeeSettings",
+									{ ...inputFeeSettings, simpleValue },
+									{ shouldDirty: true, shouldValidate: true },
+								);
+							}}
+						/>
+					</FormField>
+				</TransactionDetail>
+			)}
 		</section>
 	);
 };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes the divider from the `SendTransfer` form and adjusts the spacing in the `SendVote` form.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [ ] My changes look good in both light AND dark mode
-   [ ] The change is not hardcoded to a single network, but has multi-asset in mind
-   [ ] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
