### PR TITLE
fix: handle null value exceptions in personal settings dropdowns

### DIFF
--- a/src/domains/setting/pages/General/General.tsx
+++ b/src/domains/setting/pages/General/General.tsx
@@ -335,7 +335,7 @@ export const GeneralSettings: React.FC = () => {
 										}).toString(),
 									})}
 									onChange={(bip39Locale: any) =>
-										setValue("bip39Locale", bip39Locale.value, { shouldDirty: true })
+										setValue("bip39Locale", bip39Locale?.value, { shouldDirty: true })
 									}
 									options={PlatformSdkChoices.passphraseLanguages}
 									defaultValue={getDefaultValues().bip39Locale}
@@ -358,7 +358,7 @@ export const GeneralSettings: React.FC = () => {
 									options={PlatformSdkChoices.currencies}
 									defaultValue={getDefaultValues().exchangeCurrency}
 									onChange={(exchangeCurrency: any) =>
-										setValue("exchangeCurrency", exchangeCurrency.value, { shouldDirty: true })
+										setValue("exchangeCurrency", exchangeCurrency?.value, { shouldDirty: true })
 									}
 								/>
 							</FormField>
@@ -379,7 +379,7 @@ export const GeneralSettings: React.FC = () => {
 									})}
 									options={PlatformSdkChoices.languages}
 									defaultValue={getDefaultValues().locale}
-									onChange={(locale: any) => setValue("locale", locale.value, { shouldDirty: true })}
+									onChange={(locale: any) => setValue("locale", locale?.value, { shouldDirty: true })}
 								/>
 							</FormField>
 
@@ -398,7 +398,7 @@ export const GeneralSettings: React.FC = () => {
 									options={PlatformSdkChoices.marketProviders}
 									defaultValue={getDefaultValues().marketProvider}
 									onChange={(marketProvider: any) =>
-										setValue("marketProvider", marketProvider.value, { shouldDirty: true })
+										setValue("marketProvider", marketProvider?.value, { shouldDirty: true })
 									}
 								/>
 							</FormField>
@@ -418,7 +418,7 @@ export const GeneralSettings: React.FC = () => {
 									options={PlatformSdkChoices.timeFormats}
 									defaultValue={getDefaultValues().timeFormat}
 									onChange={(timeFormat: any) =>
-										setValue("timeFormat", timeFormat.value, { shouldDirty: true })
+										setValue("timeFormat", timeFormat?.value, { shouldDirty: true })
 									}
 								/>
 							</FormField>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Prevent from throwing null value exceptions when user types in personal settings dropdown inputs.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

-   [x] My changes look good in both light AND dark mode
-   [x] The change is not hardcoded to a single network, but has multi-asset in mind
-   [x] I checked my changes for obvious issues, debug statements and commented code
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
